### PR TITLE
[fix] #2623: fix doctest for VariantCount

### DIFF
--- a/macro/derive/src/lib.rs
+++ b/macro/derive/src/lib.rs
@@ -215,13 +215,15 @@ fn impl_from_variant(ast: &syn::DeriveInput) -> TokenStream {
 /// [`VariantCount`] derives an associated constant `VARIANT_COUNT: usize` for enums
 /// that is equal to the count of variants in enum. E.g.
 /// ```
+/// use iroha_derive::VariantCount;
+///
 /// #[derive(VariantCount)]
 /// enum MyEnum {
 ///   First,
 ///   Second(i32),
 ///   Third {
-///     some: str,
-///     stuff: usize
+///     a: usize,
+///     b: usize
 ///   }
 /// }
 ///


### PR DESCRIPTION
Signed-off-by: Artemii Gerasimovich <gerasimovich@soramitsu.co.jp>

### Description of the Change

Fix doctest for `VariantCount` derive macro.

### Issue

#2623 


### Benefits

Doctest passes

### Possible Drawbacks

None
