### PR TITLE
[feature] #2628: Add support for `repr(transparent)` in FFI

### DIFF
--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -33,7 +33,7 @@ use crate::{ParseError, ValidationError};
     TryFromReprC,
     IntoSchema,
 )]
-#[repr(transparent)]
+// FIXME: #[repr(transparent)] (https://github.com/hyperledger/iroha/issues/2645)
 pub struct Name(ConstString);
 
 impl Name {

--- a/ffi/derive/src/convert.rs
+++ b/ffi/derive/src/convert.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream as TokenStream2;
-use proc_macro_error::abort;
+use proc_macro_error::{abort, OptionExt};
 use quote::quote;
 use syn::{parse_quote, DeriveInput, Ident};
 
-use crate::{enum_size, find_attr, is_fieldless_enum, is_opaque};
+use crate::{enum_size, find_attr, is_fieldless_enum, is_opaque, is_repr_attr};
 
 pub fn derive_try_from_repr_c(input: &DeriveInput) -> TokenStream2 {
     if !matches!(input.vis, syn::Visibility::Public(_)) {
@@ -28,7 +28,13 @@ pub fn derive_try_from_repr_c(input: &DeriveInput) -> TokenStream2 {
                 derive_try_from_repr_c_for_item(&input.ident)
             }
         }
-        syn::Data::Struct(_) => derive_try_from_repr_c_for_item(&input.ident),
+        syn::Data::Struct(item) => {
+            if is_transparent(input) {
+                derive_try_from_repr_c_for_transparent_item(&input.ident, &input.generics, item)
+            } else {
+                derive_try_from_repr_c_for_item(&input.ident)
+            }
+        }
         syn::Data::Union(item) => abort!(item.union_token, "Unions are not supported"),
     }
 }
@@ -56,7 +62,13 @@ pub fn derive_into_ffi(input: &DeriveInput) -> TokenStream2 {
                 derive_into_ffi_for_item(&input.ident)
             }
         }
-        syn::Data::Struct(_) => derive_into_ffi_for_item(&input.ident),
+        syn::Data::Struct(item) => {
+            if is_transparent(input) {
+                derive_into_ffi_for_transparent_item(&input.ident, &input.generics, item)
+            } else {
+                derive_into_ffi_for_item(&input.ident)
+            }
+        }
         syn::Data::Union(item) => abort!(item.union_token, "Unions are not supported"),
     }
 }
@@ -85,7 +97,7 @@ fn derive_try_from_repr_c_for_opaque_item_wrapper(input: &DeriveInput) -> TokenS
     let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
     let lifetimes = &[lifetime.clone()];
     let (generic_params, ty_generics, where_clause) =
-        add_bounds_and_split_generics(&mut generics, lifetimes, &[]);
+        add_bounds_and_split_generics(&mut generics, lifetimes, &[], &[]);
 
     let opaque_item_slice_try_from_repr_c_derive =
         derive_try_from_repr_c_for_opaque_item_slice(input);
@@ -153,7 +165,7 @@ fn derive_try_from_repr_c_for_opaque_item(input: &DeriveInput) -> TokenStream2 {
     let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
     let lifetimes = &[lifetime.clone()];
     let (generic_params, ty_generics, where_clause) =
-        add_bounds_and_split_generics(&mut generics, lifetimes, &[]);
+        add_bounds_and_split_generics(&mut generics, lifetimes, &[], &[]);
 
     let opaque_item_slice_try_from_repr_c_derive =
         derive_try_from_repr_c_for_opaque_item_slice(input);
@@ -212,7 +224,7 @@ fn derive_try_from_repr_c_for_opaque_item_slice(input: &DeriveInput) -> TokenStr
     let lifetimes = &[lifetime.clone()];
     let trait_bounds = &[syn::parse_quote!(core::clone::Clone)];
     let (generic_params, ty_generics, where_clause) =
-        add_bounds_and_split_generics(&mut generics, lifetimes, trait_bounds);
+        add_bounds_and_split_generics(&mut generics, lifetimes, &[], trait_bounds);
 
     quote! {
         impl<#generic_params> iroha_ffi::slice::TryFromReprCSliceRef<#lifetime> for #name #ty_generics #where_clause {
@@ -241,7 +253,7 @@ fn derive_try_from_repr_c_for_opaque_item_vec(input: &DeriveInput) -> TokenStrea
     let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
     let lifetimes = &[lifetime.clone()];
     let (generic_params, ty_generics, where_clause) =
-        add_bounds_and_split_generics(&mut generics, lifetimes, &[]);
+        add_bounds_and_split_generics(&mut generics, lifetimes, &[], &[]);
 
     quote! {
         impl<#generic_params> iroha_ffi::owned::TryFromReprCVec<#lifetime> for #name #ty_generics #where_clause {
@@ -260,6 +272,136 @@ fn derive_try_from_repr_c_for_opaque_item_vec(input: &DeriveInput) -> TokenStrea
                 }
 
                 Ok(res)
+            }
+        }
+    }
+}
+
+fn derive_try_from_repr_c_for_transparent_item(
+    name: &Ident,
+    generics: &syn::Generics,
+    item: &syn::DataStruct,
+) -> TokenStream2 {
+    let transparent = derive_transparent(name, generics, item);
+    let try_from_repr_c_transparent_slice =
+        derive_try_from_repr_c_transparent_item_slice(name, generics);
+    let try_from_repr_c_transparent_vec =
+        derive_try_from_repr_c_transparent_item_vec(name, generics);
+
+    let mut generics = generics.clone();
+    let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
+    let lifetimes = &[lifetime.clone()];
+    let types = &[syn::parse_quote!(__iroha_ffi_T: iroha_ffi::TryFromReprC<#lifetime>)];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::Transparent<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, lifetimes, types, self_trait_bounds);
+
+    quote! {
+        #transparent
+
+        impl<#generic_params> iroha_ffi::TryFromReprC<#lifetime> for #name #ty_generics #where_clause {
+            type Source = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Source;
+            type Store = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Store;
+
+            unsafe fn try_from_repr_c(
+                source: <Self as iroha_ffi::TryFromReprC<#lifetime>>::Source,
+                store: &#lifetime mut <Self as iroha_ffi::TryFromReprC<#lifetime>>::Store
+            ) -> iroha_ffi::Result<Self> {
+                let inner = unsafe { iroha_ffi::TryFromReprC::try_from_repr_c(source, store)? };
+                Ok(<Self as iroha_ffi::Transparent>::from_inner(inner))
+            }
+        }
+
+        impl<#generic_params> iroha_ffi::TryFromReprC<#lifetime> for &#lifetime #name #ty_generics #where_clause {
+            type Source = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Source;
+            type Store = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Store;
+
+            unsafe fn try_from_repr_c(
+                source: <Self as iroha_ffi::TryFromReprC<#lifetime>>::Source,
+                store: &#lifetime mut <Self as iroha_ffi::TryFromReprC<#lifetime>>::Store
+            ) -> iroha_ffi::Result<Self> {
+                let inner = unsafe { iroha_ffi::TryFromReprC::try_from_repr_c(source, store)? };
+                Ok(<Self as iroha_ffi::Transparent>::from_inner(inner))
+            }
+
+        }
+
+        impl<#generic_params> iroha_ffi::TryFromReprC<#lifetime> for &#lifetime mut #name #ty_generics #where_clause {
+            type Source = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Source;
+            type Store = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::TryFromReprC<#lifetime>>::Store;
+
+            unsafe fn try_from_repr_c(
+                source: <Self as iroha_ffi::TryFromReprC<#lifetime>>::Source,
+                store: &#lifetime mut <Self as iroha_ffi::TryFromReprC<#lifetime>>::Store
+            ) -> iroha_ffi::Result<Self> {
+                let inner = unsafe { iroha_ffi::TryFromReprC::try_from_repr_c(source, store)? };
+                Ok(<Self as iroha_ffi::Transparent>::from_inner(inner))
+            }
+        }
+
+        #try_from_repr_c_transparent_slice
+        #try_from_repr_c_transparent_vec
+    }
+}
+
+fn derive_try_from_repr_c_transparent_item_slice(
+    name: &Ident,
+    generics: &syn::Generics,
+) -> TokenStream2 {
+    let mut generics = generics.clone();
+    let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_slice);
+    let lifetimes = &[lifetime.clone()];
+    let types =
+        &[syn::parse_quote!(__iroha_ffi_T: iroha_ffi::slice::TryFromReprCSliceRef<#lifetime>)];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::TransparentVec<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, lifetimes, types, self_trait_bounds);
+
+    quote! {
+        impl<#generic_params> iroha_ffi::slice::TryFromReprCSliceRef<#lifetime> for #name #ty_generics #where_clause {
+            type Source = <<Self as iroha_ffi::TransparentSlice>::Inner as iroha_ffi::slice::TryFromReprCSliceRef<#lifetime>>::Source;
+            type Store = <<Self as iroha_ffi::TransparentSlice>::Inner as iroha_ffi::slice::TryFromReprCSliceRef<#lifetime>>::Store;
+
+            unsafe fn try_from_repr_c(
+                source: <Self as iroha_ffi::slice::TryFromReprCSliceRef<#lifetime>>::Source,
+                store: &#lifetime mut <Self as iroha_ffi::TryFromReprC<#lifetime>>::Store
+            ) -> iroha_ffi::Result<&#lifetime [Self]> {
+                let inner = unsafe { iroha_ffi::slice::TryFromReprCSliceRef::try_from_repr_c(source, store)? };
+                Ok(<Self as iroha_ffi::TransparentSlice>::from_inner(inner))
+            }
+        }
+    }
+}
+
+fn derive_try_from_repr_c_transparent_item_vec(
+    name: &Ident,
+    generics: &syn::Generics,
+) -> TokenStream2 {
+    let mut generics = generics.clone();
+    let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
+    let lifetimes = &[lifetime.clone()];
+    let types = &[syn::parse_quote!(__iroha_ffi_T: iroha_ffi::owned::TryFromReprCVec<#lifetime>)];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::TransparentVec<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, lifetimes, types, self_trait_bounds);
+
+    quote! {
+        impl<#generic_params> iroha_ffi::owned::TryFromReprCVec<#lifetime> for #name #ty_generics #where_clause {
+            type Source = <<Self as iroha_ffi::TransparentVec>::Inner as iroha_ffi::owned::TryFromReprCVec<#lifetime>>::Source;
+            type Store = <<Self as iroha_ffi::TransparentVec>::Inner as iroha_ffi::owned::TryFromReprCVec<#lifetime>>::Store;
+
+            unsafe fn try_from_repr_c(
+                source: <Self as iroha_ffi::owned::TryFromReprCVec<#lifetime>>::Source,
+                store: &#lifetime mut <Self as iroha_ffi::owned::TryFromReprCVec<#lifetime>>::Store
+            ) -> iroha_ffi::Result<Vec<Self>> {
+                let inner = unsafe { iroha_ffi::owned::TryFromReprCVec::try_from_repr_c(source, store)? };
+                Ok(<Self as iroha_ffi::TransparentVec>::from_inner(inner))
             }
         }
     }
@@ -461,7 +603,7 @@ fn derive_into_ffi_for_opaque_item_slice(input: &DeriveInput) -> TokenStream2 {
     let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_slice);
     let lifetimes = &[lifetime.clone()];
     let (generic_params, ty_generics, where_clause) =
-        add_bounds_and_split_generics(&mut generics, lifetimes, &[]);
+        add_bounds_and_split_generics(&mut generics, lifetimes, &[], &[]);
 
     quote! {
         impl<#generic_params> iroha_ffi::slice::IntoFfiSliceRef<#lifetime> for #name #ty_generics #where_clause {
@@ -484,6 +626,101 @@ fn derive_into_ffi_for_opaque_item_vec(input: &DeriveInput) -> TokenStream2 {
 
             fn into_ffi(source: Vec<Self>) -> Self::Target {
                 source.into_iter().map(IntoFfi::into_ffi).collect()
+            }
+        }
+    }
+}
+
+fn derive_into_ffi_for_transparent_item(
+    name: &Ident,
+    generics: &syn::Generics,
+    _: &syn::DataStruct,
+) -> TokenStream2 {
+    let into_ffi_transparent_slice = derive_into_ffi_transparent_item_slice(name, generics);
+    let into_ffi_transparent_vec = derive_into_ffi_transparent_item_vec(name, generics);
+
+    let mut generics = generics.clone();
+    let types = &[syn::parse_quote!(__iroha_ffi_T: iroha_ffi::IntoFfi)];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::Transparent<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, &[], types, self_trait_bounds);
+
+    quote! {
+        impl<#generic_params> iroha_ffi::IntoFfi for #name #ty_generics #where_clause {
+            type Target = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::IntoFfi>::Target;
+
+            fn into_ffi(self) -> Self::Target {
+                let inner = <Self as iroha_ffi::Transparent>::into_inner(self);
+                iroha_ffi::IntoFfi::into_ffi(inner)
+            }
+        }
+
+        impl<#generic_params> iroha_ffi::IntoFfi for &#name #ty_generics #where_clause {
+            type Target = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::IntoFfi>::Target;
+
+            fn into_ffi(self) -> Self::Target {
+                let inner = <Self as iroha_ffi::Transparent>::into_inner(self);
+                iroha_ffi::IntoFfi::into_ffi(inner)
+            }
+        }
+
+        impl<#generic_params> iroha_ffi::IntoFfi for &mut #name #ty_generics #where_clause {
+            type Target = <<Self as iroha_ffi::Transparent>::Inner as iroha_ffi::IntoFfi>::Target;
+
+            fn into_ffi(self) -> Self::Target {
+                let inner = <Self as iroha_ffi::Transparent>::into_inner(self);
+                iroha_ffi::IntoFfi::into_ffi(inner)
+            }
+        }
+
+        #into_ffi_transparent_slice
+        #into_ffi_transparent_vec
+    }
+}
+
+fn derive_into_ffi_transparent_item_slice(name: &Ident, generics: &syn::Generics) -> TokenStream2 {
+    let mut generics = generics.clone();
+    let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_slice);
+    let lifetimes = &[lifetime.clone()];
+    let types = &[syn::parse_quote!(__iroha_ffi_T: iroha_ffi::slice::IntoFfiSliceRef<#lifetime>)];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::TransparentVec<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, lifetimes, types, self_trait_bounds);
+
+    quote! {
+        impl<#generic_params> iroha_ffi::slice::IntoFfiSliceRef<#lifetime> for #name #ty_generics #where_clause {
+            type Target = <<Self as iroha_ffi::TransparentSlice>::Inner as iroha_ffi::slice::IntoFfiSliceRef<#lifetime>>::Target;
+
+            fn into_ffi(outer: &#lifetime [Self]) -> <Self as iroha_ffi::slice::IntoFfiSliceRef>::Target {
+                let inner = <Self as iroha_ffi::TransparentSlice>::into_inner(outer);
+                iroha_ffi::slice::IntoFfiSliceRef::into_ffi(inner)
+            }
+        }
+    }
+}
+
+fn derive_into_ffi_transparent_item_vec(name: &Ident, generics: &syn::Generics) -> TokenStream2 {
+    let mut generics = generics.clone();
+    let types = &[syn::parse_quote!(
+        __iroha_ffi_T: iroha_ffi::owned::IntoFfiVec
+    )];
+    let self_trait_bounds = &[syn::parse_quote!(
+        iroha_ffi::TransparentVec<Inner = __iroha_ffi_T>
+    )];
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, &[], types, self_trait_bounds);
+
+    quote! {
+        impl<#generic_params> iroha_ffi::owned::IntoFfiVec for #name #ty_generics #where_clause {
+            type Target = <<Self as iroha_ffi::TransparentVec>::Inner as iroha_ffi::owned::IntoFfiVec>::Target;
+
+            fn into_ffi(outer: Vec<Self>) -> <Self as iroha_ffi::owned::IntoFfiVec>::Target {
+                let inner = <Self as iroha_ffi::TransparentVec>::into_inner(outer);
+                iroha_ffi::owned::IntoFfiVec::into_ffi(inner)
             }
         }
     }
@@ -525,22 +762,134 @@ fn derive_into_ffi_for_fieldless_enum(enum_name: &Ident, repr: &[syn::NestedMeta
     }
 }
 
+fn derive_transparent(
+    name: &Ident,
+    generics: &syn::Generics,
+    item: &syn::DataStruct,
+) -> TokenStream2 {
+    let inner = item
+        .fields
+        .iter()
+        .next()
+        .map(|field| &field.ty)
+        .expect_or_abort("transparent struct must have at least one field");
+
+    let lifetime: syn::Lifetime = syn::parse_quote!('__iroha_ffi_itm);
+    let mut generics = generics.clone();
+    let (generic_params, ty_generics, where_clause) =
+        add_bounds_and_split_generics(&mut generics, &[], &[], &[]);
+
+    quote! {
+        // Note: if `#inner` is generic or doesn't have the same layout with `#name` this won't compile
+        // SAFETY: `Self` and `Self::Inner` have the same size because from macro generation `Self::Inner` is the inner field of transparent `Self` with the same size.
+        unsafe impl <#generic_params> iroha_ffi::Transparent for #name #ty_generics #where_clause {
+            type Inner = #inner;
+
+            fn into_inner(outer: Self) -> Self::Inner {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { core::mem::transmute(outer) }
+            }
+
+            fn from_inner(inner: Self::Inner) -> Self {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { core::mem::transmute(inner) }
+            }
+        }
+
+        unsafe impl <#lifetime, #generic_params> iroha_ffi::Transparent for &#lifetime #name #ty_generics #where_clause {
+            type Inner = &#lifetime #inner;
+
+            fn into_inner(outer: Self) -> Self::Inner {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { & *(outer as *const _ as *const _) }
+            }
+
+            fn from_inner(inner: Self::Inner) -> Self {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { & *(inner as *const _ as *const _) }
+            }
+        }
+
+        unsafe impl <#lifetime, #generic_params> iroha_ffi::Transparent for &#lifetime mut #name #ty_generics #where_clause {
+            type Inner = &#lifetime mut #inner;
+
+            fn into_inner(outer: Self) -> Self::Inner {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { &mut *(outer as *mut _ as *mut _) }
+            }
+
+            fn from_inner(inner: Self::Inner) -> Self {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { &mut *(inner as *mut _ as *mut _) }
+            }
+        }
+
+        unsafe impl <#generic_params> iroha_ffi::TransparentSlice for #name #ty_generics #where_clause {
+            type Inner = #inner;
+
+            fn into_inner(outer: &[Self]) -> &[Self::Inner] {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { core::mem::transmute(outer) }
+            }
+
+            fn from_inner(inner: &[Self::Inner]) -> &[Self] {
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe { core::mem::transmute(inner) }
+            }
+        }
+
+        unsafe impl <#generic_params> iroha_ffi::TransparentVec for #name #ty_generics #where_clause {
+            type Inner = #inner;
+
+            fn into_inner(outer: Vec<Self>) -> Vec<Self::Inner> {
+                let mut outer = core::mem::ManuallyDrop::new(outer);
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe {
+                    Vec::from_raw_parts(
+                        outer.as_mut_ptr() as *mut _,
+                        outer.len(),
+                        outer.capacity()
+                    )
+                }
+            }
+
+            fn from_inner(inner: Vec<Self::Inner>) -> Vec<Self> {
+                let mut inner = core::mem::ManuallyDrop::new(inner);
+                // SAFETY: `Self` and `Self::Inner` have the same memory layout
+                unsafe {
+                    Vec::from_raw_parts(
+                        inner.as_mut_ptr() as *mut _,
+                        inner.len(),
+                        inner.capacity()
+                    )
+                }
+            }
+        }
+    }
+}
+
 fn is_opaque_wrapper(input: &DeriveInput) -> bool {
     let opaque_attr = parse_quote! {#[opaque_wrapper]};
     input.attrs.iter().any(|a| *a == opaque_attr)
 }
 
+fn is_transparent(input: &DeriveInput) -> bool {
+    let repr = &find_attr(&input.attrs, "repr");
+    is_repr_attr(repr, "transparent")
+}
+
 fn add_bounds_and_split_generics<'generics>(
     generics: &'generics mut syn::Generics,
     lifetimes: &'generics [syn::Lifetime],
-    trait_bounds: &'generics [syn::TraitBound],
+    types: &'generics [syn::TypeParam],
+    self_trait_bounds: &'generics [syn::TraitBound],
 ) -> (
     syn::punctuated::Punctuated<syn::GenericParam, syn::Token![,]>,
     syn::TypeGenerics<'generics>,
     Option<&'generics syn::WhereClause>,
 ) {
     let where_predicate: syn::WherePredicate =
-        syn::parse_quote!(Self: #(#lifetimes +)* #(#trait_bounds)+*);
+        syn::parse_quote!(Self: #(#lifetimes +)* #(#self_trait_bounds)+*);
     generics
         .make_where_clause()
         .predicates
@@ -548,6 +897,6 @@ fn add_bounds_and_split_generics<'generics>(
     let (_, ty_generics, where_clause) = generics.split_for_impl();
     let params = &generics.params;
     // NOTE: Put lifetimes first
-    let generic_params = syn::parse_quote!(#(#lifetimes,)* #params);
+    let generic_params = syn::parse_quote!(#(#lifetimes,)* #(#types,)* #params);
     (generic_params, ty_generics, where_clause)
 }

--- a/ffi/derive/src/impl_visitor.rs
+++ b/ffi/derive/src/impl_visitor.rs
@@ -221,22 +221,6 @@ impl<'ast> FnVisitor<'ast> {
         ));
     }
 
-    /// Set return type arg name to self type arg name
-    /// in case of function like `fn(self, ...) -> Self`, otherwise leave name unchanged
-    fn set_output_arg_name(&self, mut output_arg: Arg) -> Arg {
-        if let Some(receiver) = &self.receiver {
-            // NOTE: types need to be resolved here in case of `fn(self) -> Type` where `Type == Self`
-            // NOTE: `Self` is first consumed and then returned in the same method
-            if matches!(receiver.src_type(), Type::Path(_))
-                && receiver.src_type_resolved() == output_arg.src_type_resolved()
-            {
-                output_arg.name = receiver.name().clone();
-            }
-        }
-
-        output_arg
-    }
-
     fn add_output_arg(&mut self, src_type: &'ast Type) {
         assert!(self.curr_arg_name.is_none());
         assert!(self.output_arg.is_none());
@@ -247,7 +231,7 @@ impl<'ast> FnVisitor<'ast> {
             src_type.clone(),
         );
 
-        self.output_arg = Some(self.set_output_arg_name(output_arg));
+        self.output_arg = Some(output_arg);
     }
 }
 

--- a/ffi/derive/src/lib.rs
+++ b/ffi/derive/src/lib.rs
@@ -267,7 +267,7 @@ fn is_opaque(input: &syn::DeriveInput) -> bool {
         }
     }
 
-    !is_repr_attr(repr, "C")
+    !is_repr_attr(repr, "C") && !is_repr_attr(repr, "transparent")
 }
 
 fn is_fieldless_enum(name: &syn::Ident, item: &syn::DataEnum, repr: &[NestedMeta]) -> bool {

--- a/ffi/derive/tests/ui_pass/valid.rs
+++ b/ffi/derive/tests/ui_pass/valid.rs
@@ -70,6 +70,7 @@ fn main() {
         FfiStruct__new(name, ffi_struct.as_mut_ptr());
         TryFromReprC::try_from_repr_c(ffi_struct.assume_init(), &mut ()).unwrap()
     };
+    let mut output = MaybeUninit::new(core::ptr::null_mut());
 
     let in_params = vec![(Name("Nomen"), Value("Omen"))];
     let mut param: MaybeUninit<*const Value> = MaybeUninit::uninit();
@@ -85,9 +86,13 @@ fn main() {
         let name = IntoFfi::into_ffi(name.clone());
 
         FfiStruct__with_params(
-            IntoFfi::into_ffi(&mut ffi_struct),
+            IntoFfi::into_ffi(ffi_struct),
             in_params.clone().into_ffi().as_ref(),
+            output.as_mut_ptr(),
         );
+
+        ffi_struct = TryFromReprC::try_from_repr_c(output.assume_init(), &mut ()).expect("valid");
+
         FfiStruct__get_param(IntoFfi::into_ffi(&ffi_struct), name, param.as_mut_ptr());
         FfiStruct__params(IntoFfi::into_ffi(&ffi_struct), out_params);
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -256,6 +256,51 @@ pub struct Opaque {
     __marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
 }
 
+/// Trait for `#[repr(transparent)]` structs to convert between [`Self`] and [`Self::Inner`]
+///
+/// # Safety
+/// `Self` and `Self::Inner` must have the same memory layout.
+pub unsafe trait Transparent: Sized {
+    /// Non-ZST field of transparent struct
+    type Inner;
+
+    /// Convert transparent struct into its non-ZST field
+    fn into_inner(outer: Self) -> Self::Inner;
+
+    /// Recover transparent struct from its non-ZST field
+    fn from_inner(inner: Self::Inner) -> Self;
+}
+
+/// Trait for `#[repr(transparent)]` structs to convert between slice of [`Self`] and slice of [`Self::Inner`]
+///
+/// # Safety
+/// `Self` and `Self::Inner` must have the same memory layout.
+pub unsafe trait TransparentSlice: Sized {
+    /// Non-ZST field of transparent struct
+    type Inner;
+
+    /// Convert transparent struct into its non-ZST field
+    fn into_inner(outer: &[Self]) -> &[Self::Inner];
+
+    /// Recover transparent struct from its non-ZST field
+    fn from_inner(inner: &[Self::Inner]) -> &[Self];
+}
+
+/// Trait for `#[repr(transparent)]` structs to convert between vec of [`Self`] and vec of [`Self::Inner`]
+///
+/// # Safety
+/// `Self` and `Self::Inner` must have the same memory layout.
+pub unsafe trait TransparentVec: Sized {
+    /// Non-ZST field of transparent struct
+    type Inner;
+
+    /// Convert transparent struct into its non-ZST field
+    fn into_inner(outer: Vec<Self>) -> Vec<Self::Inner>;
+
+    /// Recover transparent struct from its non-ZST field
+    fn from_inner(inner: Vec<Self::Inner>) -> Vec<Self>;
+}
+
 macro_rules! impl_tuple {
     ( ($( $ty:ident ),+ $(,)?) -> $ffi_ty:ident ) => {
         /// FFI-compatible tuple with n elements

--- a/ffi/tests/transparent.rs
+++ b/ffi/tests/transparent.rs
@@ -1,0 +1,185 @@
+#![allow(unsafe_code, clippy::restriction, clippy::pedantic)]
+
+use std::{marker::PhantomData, mem::MaybeUninit};
+
+use iroha_ffi::{
+    ffi_export,
+    slice::{OutBoxedSlice, OutSliceRef, SliceRef},
+    AsReprCRef, FfiReturn, IntoFfi, TryFromReprC,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, IntoFfi, TryFromReprC)]
+#[repr(transparent)]
+pub struct GenericTransparentStruct<P>(u64, PhantomData<P>);
+
+impl<P> GenericTransparentStruct<P> {
+    fn new(value: u64) -> Self {
+        Self(value, PhantomData)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, IntoFfi, TryFromReprC)]
+#[repr(transparent)]
+pub struct TransparentStruct {
+    // NOTE: non-ZST enforced to be first field
+    payload: GenericTransparentStruct<()>,
+    _zst1: [u8; 0],
+    _zst2: (),
+    _zst3: PhantomData<String>,
+}
+
+#[ffi_export]
+impl TransparentStruct {
+    pub fn new(payload: GenericTransparentStruct<()>) -> Self {
+        Self {
+            payload,
+            _zst1: [],
+            _zst2: (),
+            _zst3: PhantomData,
+        }
+    }
+
+    pub fn with_payload(mut self, payload: GenericTransparentStruct<()>) -> Self {
+        self.payload = payload;
+        self
+    }
+
+    pub fn payload(&self) -> &GenericTransparentStruct<()> {
+        &self.payload
+    }
+}
+
+#[ffi_export]
+pub fn self_to_self(value: TransparentStruct) -> TransparentStruct {
+    value
+}
+
+#[ffi_export]
+pub fn vec_to_vec(value: Vec<TransparentStruct>) -> Vec<TransparentStruct> {
+    value
+}
+
+#[ffi_export]
+pub fn slice_to_slice(value: &[TransparentStruct]) -> &[TransparentStruct] {
+    value
+}
+
+#[test]
+fn transparent_self_to_self() {
+    let transparent_struct = TransparentStruct::new(GenericTransparentStruct::new(42));
+    // NOTE: recursively traversing transparent structs
+    let mut output: MaybeUninit<u64> = MaybeUninit::new(0);
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::Ok,
+            __self_to_self(transparent_struct.into_ffi().as_ref(), output.as_mut_ptr())
+        );
+        assert_eq!(
+            Ok(transparent_struct),
+            TryFromReprC::try_from_repr_c(output.assume_init(), &mut ())
+        );
+    }
+}
+
+#[test]
+fn transparent_vec_to_vec() {
+    let transparent_struct_vec = vec![
+        TransparentStruct::new(GenericTransparentStruct::new(1)),
+        TransparentStruct::new(GenericTransparentStruct::new(2)),
+        TransparentStruct::new(GenericTransparentStruct::new(3)),
+    ];
+
+    let mut transparent_struct_uninit = vec![
+        MaybeUninit::new(4),
+        MaybeUninit::new(5),
+        MaybeUninit::new(6),
+    ];
+    let mut len = MaybeUninit::new(0);
+    let output =
+        OutBoxedSlice::from_uninit_slice(Some(transparent_struct_uninit.as_mut()), &mut len);
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::Ok,
+            __vec_to_vec(transparent_struct_vec.clone().into_ffi().as_ref(), output,)
+        );
+
+        // NOTE: it's really inconvenient now to receive `Vec` from ffi
+        transparent_struct_uninit.truncate(len.assume_init() as usize);
+
+        for (transparent_struct, output) in transparent_struct_vec
+            .into_iter()
+            .zip(transparent_struct_uninit.into_iter())
+        {
+            assert_eq!(
+                Ok(transparent_struct),
+                TryFromReprC::try_from_repr_c(output.assume_init(), &mut ())
+            );
+        }
+    }
+}
+
+#[test]
+fn transparent_slice_to_slice() {
+    let transparent_struct_slice = [
+        TransparentStruct::new(GenericTransparentStruct::new(1)),
+        TransparentStruct::new(GenericTransparentStruct::new(2)),
+        TransparentStruct::new(GenericTransparentStruct::new(3)),
+    ];
+    let mut data_ptr = core::ptr::null();
+    let mut len = MaybeUninit::new(0);
+    let output = OutSliceRef::from_raw(Some(&mut data_ptr), &mut len);
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::Ok,
+            __slice_to_slice(transparent_struct_slice.as_slice().into_ffi(), output)
+        );
+        let slice_ref = SliceRef::from_raw_parts(data_ptr, len.assume_init());
+        assert_eq!(
+            Ok(transparent_struct_slice.as_slice()),
+            TryFromReprC::try_from_repr_c(slice_ref, &mut ())
+        );
+    }
+}
+
+#[test]
+fn transparent_method_consume() {
+    let mut transparent_struct = TransparentStruct::new(GenericTransparentStruct::new(42));
+    let payload = GenericTransparentStruct::new(24);
+
+    let mut output: MaybeUninit<u64> = MaybeUninit::new(0);
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::Ok,
+            TransparentStruct__with_payload(
+                transparent_struct.into_ffi(),
+                payload.into_ffi(),
+                output.as_mut_ptr()
+            )
+        );
+        transparent_struct =
+            TryFromReprC::try_from_repr_c(output.assume_init(), &mut ()).expect("valid");
+
+        assert_eq!(transparent_struct.payload, payload);
+    }
+}
+
+#[test]
+fn transparent_method_borrow() {
+    let transparent_struct = TransparentStruct::new(GenericTransparentStruct::new(42));
+    let mut output = MaybeUninit::new(core::ptr::null());
+
+    unsafe {
+        assert_eq!(
+            FfiReturn::Ok,
+            TransparentStruct__payload(IntoFfi::into_ffi(&transparent_struct), output.as_mut_ptr())
+        );
+        assert_eq!(
+            Ok(&transparent_struct.payload),
+            TryFromReprC::try_from_repr_c(output.assume_init(), &mut ())
+        );
+    }
+}


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Before transparent structs cross ffi as opaque pointers, now conversion to ffi delegated to inner field;
- Remove special handling of `fn(T) -> T` because this case was created under assumption that every struct passed as opaque pointer (implementation use `read/write/is_null` methods) which not hold in general for transparent and non-opaque structs.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2628.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Reduce number of indirections.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Case `fn(T) -> T` now uses 2 allocations instead of 1 and a bit less convenient to write.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
