### PR TITLE
[fix] #0: Fix `docker-compose-single.yml`

### DIFF
--- a/docker-compose-single.yml
+++ b/docker-compose-single.yml
@@ -3,10 +3,8 @@ services:
   iroha0:
     build: .
     image: iroha2:dev
-    volumes:
-      - './configs/peer:/config'
-      - './:/root/soramitsu/iroha'
     environment:
+      KURA_BLOCK_STORE_PATH: /storage
       TORII_P2P_ADDR: iroha0:1337
       TORII_API_URL: iroha0:8080
       TORII_TELEMETRY_URL: iroha0:8180
@@ -19,3 +17,6 @@ services:
       - "8180:8180"
     init: true
     command: iroha --submit-genesis
+    volumes:
+      - './configs/peer:/config'
+      - './:/root/soramitsu/iroha'


### PR DESCRIPTION
### Description of the Change

- Fix `KURA_BLOCK_STORE_PATH` in `docker-compose-single.yml`

### Issue

- As of f26263ad, `docker-compose -f docker-compose-single.yml up` does not work

### Benefits

- It works with [this modification](https://github.com/hyperledger/iroha/issues/2640#issuecomment-1225673675)

### Possible Drawbacks

- None