### PR TITLE
[fix] #2554: Fix key pair generation with provided seed

### DIFF
--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -69,7 +69,10 @@ impl<T: Write> RunArgs<T> for Args {
 
 mod crypto {
     use color_eyre::eyre::WrapErr as _;
-    use iroha_crypto::{Algorithm, KeyGenConfiguration, KeyPair, PrivateKey};
+    use iroha_crypto::{
+        ursa::sha2::{Digest, Sha256},
+        Algorithm, KeyGenConfiguration, KeyPair, PrivateKey,
+    };
 
     use super::*;
 
@@ -134,10 +137,9 @@ mod crypto {
                     )
                 },
                 |seed| -> color_eyre::Result<_> {
+                    let seed = Sha256::digest(seed.as_bytes()).as_slice().to_owned();
                     KeyPair::generate_with_configuration(
-                        key_gen_configuration
-                            .clone()
-                            .use_seed(seed.as_bytes().into()),
+                        key_gen_configuration.clone().use_seed(seed),
                     )
                     .wrap_err("Failed to generate key pair")
                 },


### PR DESCRIPTION
Signed-off-by: Shanin Roman <shanin1000@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Compute sha256 hash from provided seed string and pass it to ursa. 
More detailed explanation in the related issue.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2554.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Now it's possible to generate `secp256k1` from seed string shorter than 32 bytes.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Current and fixed version of kagami would provide different keys for the same seed.

Some security concerns I'm not aware of. 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

```
cargo run --bin kagami  -- crypto -s 22 -a secp256k1
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

Another option would be to just raise error if user provide seed shorter than 32bytes on `secp256k1`.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
