### PR TITLE
[fix] #0: Remove `/iroha/rust-toolchain.toml` from the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM hyperledger/iroha2-base:$TAG AS builder
 
 WORKDIR /iroha
 COPY . .
+RUN  rm -f rust-toolchain.toml
 RUN  mold --run cargo build --profile deploy --target x86_64-unknown-linux-musl --features vendored
 
 # final image


### PR DESCRIPTION
### Description of the Change

- Cherry-pick of 1d4a9499 from #2680

### Issue

- Docker fails to build

### Benefits

- Fix

### Possible Drawbacks

- None