### PR TITLE
[fix] #2690: Harmonize toolchain with docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@
 ARG  TAG=dev
 FROM hyperledger/iroha2-base:$TAG AS builder
 
-WORKDIR /iroha
 COPY . .
-RUN  rm -f rust-toolchain.toml
 RUN  mold --run cargo build --profile deploy --target x86_64-unknown-linux-musl --features vendored
 
 # final image

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,6 @@
 FROM archlinux:base-devel
 
+WORKDIR /iroha
 ENV NIGHTLY=nightly-2022-08-15
 COPY ./rust-toolchain.toml .
 RUN set -eux && \


### PR DESCRIPTION
<!-- [fix] #2690: Harmonize toolchain with docker images -->
To review this PR you need to build both `hyperledger/iroha2-base` and `iroha2` in local:
```bash
docker build -t hyperledger/iroha2-base:debug -f Dockerfile.base .
```
```bash
docker build -t iroha2:debug --build-arg TAG=debug .
```

### Description of the Change

- Set `/iroha` as `WORKDIR` as early as the `base` stage
- Remove the removal of `/iroha/rust-toolchain.toml`

### Issue

- Closes #2690

### Benefits

- Enable the toolchain file in the `builder` stage
- Fix the docker build

### Possible Drawbacks

- None