### PR TITLE
[fix] #2734: Remove logger config from client config

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,6 +1,6 @@
 //! Crate contains iroha client which talks to iroha network via http
 
-use iroha_config::client::Configuration;
+pub use iroha_config::client::Configuration;
 
 /// Module with iroha client itself
 pub mod client;

--- a/config/src/client.rs
+++ b/config/src/client.rs
@@ -89,9 +89,6 @@ pub struct Configuration {
     pub transaction_limits: TransactionLimits,
     /// If `true` add nonce, which make different hashes for transactions which occur repeatedly and simultaneously
     pub add_transaction_nonce: bool,
-    /// `Logger` configuration.
-    #[config(inner)]
-    pub logger_configuration: crate::logger::Configuration,
 }
 
 impl Default for Configuration {
@@ -112,7 +109,6 @@ impl Default for Configuration {
                 max_wasm_size_bytes: transaction::DEFAULT_MAX_WASM_SIZE_BYTES,
             },
             add_transaction_nonce: DEFAULT_ADD_TRANSACTION_NONCE,
-            logger_configuration: crate::logger::Configuration::default(),
         }
     }
 }

--- a/configs/client_cli/config.json
+++ b/configs/client_cli/config.json
@@ -14,6 +14,5 @@
   "PRIVATE_KEY": {
     "digest_function": "ed25519",
     "payload": "9ac47abf59b356e0bd7dcbbbb4dec080e302156a48ca907e47cb6aea1d32719e7233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
-  },
-  "LOGGER_CONFIGURATION": {}
+  }
 }


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Removed logger config from Client config

#### Why remove?

AFAIK Rust libraries are [disallowed](https://crates.io/crates/log#usage) to activate logs by themself. Binaries should enable it. And user should decide if he want to run with logs and with which level of logs.

You can try to create a binary, import `iroha_client` and use something like [`env_logger`](https://crates.io/crates/env_logger) to enable logs. Then run your binary with `RUST_LOG=debug` env var. This will enable logs.

We don't have a lot of logs inside our `iroha_client` crate so that you won't see much of them, especially if you are not doing something. But in you can experiment with some methods or insert your logs in `iroha_client` crate manually to see, that it works.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

- Closes #2734

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

- No more useless config

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None

### LTS update?

I don't think, that this is an important fix. I just remove what does not work. I don't think we need a PR into `iroha2-lts`, but if you insist, I can do that