### PR TITLE
[ci]: Fix `buildx` error with `docker/build-push-action`

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -36,6 +36,8 @@ jobs:
           tags: hyperledger/iroha2:dev
           labels: commit=${{ github.sha }}
           build-args: TAG=dev
+          # This context specification is required
+          context: .
 
   load-rs:
     runs-on: ubuntu-latest

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -50,6 +50,8 @@ jobs:
             docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}-${{ github.sha }}
           labels: commit=${{ github.sha }}
           build-args: TAG=${{ env.TAG }}
+          # This context specification is required
+          context: .
 
   load-rs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- [ci]: Fix `buildx` error with `docker/build-push-action` -->
### Description of the Change

- Apply [the diff](https://github.com/s8sato/iroha/commit/aade1ee304301c89d883926b41c33553025a110b) between [a reproduction](https://github.com/s8sato/iroha/actions/runs/3044140289/jobs/4904192521) and [a fix](https://github.com/s8sato/iroha/actions/runs/3044430691/jobs/4904811102) on my fork

### Issue

- https://github.com/hyperledger/iroha/actions/runs/3042899274/jobs/4902058622

### Benefits

- Publish `iroha2:<tag>` images

### Possible Drawbacks

- None