### PR TITLE
[ci]: Fix iroha2:dev-nightly image build

### DIFF
--- a/.github/workflows/iroha2-dev-nightly.yml
+++ b/.github/workflows/iroha2-dev-nightly.yml
@@ -20,3 +20,5 @@ jobs:
           tags: hyperledger/iroha2:dev-nightly-${{ github.sha }}
           labels: commit=${{ github.sha }}
           build-args: TAG=dev
+          # This context specification is required
+          context: .


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
Add default git context execution to `build-push-action` Action.

### Issue
`iroha2:nightly` image could not be compiled due to the same error as `iroha2:dev` image had with the same workflow configuration.

### Benefits
Allow to build and publish `iroha2-nightly` image.

### Possible Drawbacks
None.