### PR TITLE
[feature] #2774, #2775: `kagami` genesis improvments

### DIFF
--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -239,15 +239,19 @@ mod genesis {
         accounts_per_domain: u64,
         assets_per_domain: u64,
     ) -> color_eyre::Result<RawGenesisBlock> {
-        let mut builder = RawGenesisBlockBuilder::new();
+        // Add default `Domain` and `Account` to still be able to query
+        let mut builder = RawGenesisBlockBuilder::new()
+            .domain("wonderland".parse()?)
+            .with_account("alice".parse()?, crate::DEFAULT_PUBLIC_KEY.parse()?)
+            .finish_domain();
+
         for domain in 0..domains {
             let mut domain_builder = builder.domain(format!("domain_{domain}").parse()?);
 
             for account in 0..accounts_per_domain {
-                domain_builder = domain_builder.with_account(
-                    format!("account_{account}").parse()?,
-                    DEFAULT_PUBLIC_KEY.parse()?,
-                );
+                let (public_key, _) = iroha_crypto::KeyPair::generate()?.into();
+                domain_builder =
+                    domain_builder.with_account(format!("account_{account}").parse()?, public_key);
             }
 
             for asset in 0..assets_per_domain {


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

- Generate key for every `Account`;
- Extend synthetic genesis with default domain (`wonderland`) and account (`alice`) to be able to perform query;
- Make genesis generation mode subcommand instead of flag.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #2774, #2775.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Improved UX and generation.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

Generation of default genesis left unchanged:

```bash
cargo run --bin kagami -- genesis
```

Generation of synthetic genesis:

```bash
cargo run --bin kagami -- genesis synthetic --domians 100 --accounts-per-domain 10 --assets-per-domain 10
```

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
