### PR TITLE
[ci]: move jobs to github runners

### DIFF
--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -41,7 +41,7 @@ jobs:
         run: cargo doc --no-deps --quiet
 
   tests:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -45,7 +45,7 @@ jobs:
         run: mold --run cargo +nightly-2022-08-15 build --target wasm32-unknown-unknown --quiet
 
   with_coverage:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     strategy:
@@ -102,7 +102,7 @@ jobs:
           integration:: --skip unstable_network
 
   unstable:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 60

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   cli:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -48,7 +48,7 @@ jobs:
     # burning CI hours, we will instead run these tests locally, and
     # push the docker image from main only after QA passes.
     if: false
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -73,7 +73,7 @@ jobs:
         run: bash -c './scripts/test_env.sh cleanup docker'
 
   bench:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -85,7 +85,7 @@ jobs:
   # ------------------------------ SDK tests go here ------------------------
 
   java-api:
-    runs-on: [self-hosted, Linux] #ubuntu-latest
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -130,7 +130,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   long:
-    runs-on: [self-hosted, Linux] #ubuntu-latest
+    runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
       image: 7272721/i2-ci:nightly
     steps:


### PR DESCRIPTION
### Description of the Change
Replace self-hosted runners inside `tests` workflows with the default `ubuntu-latest` Gihub Runners.

### Issue
Some long tests are failed on self-hosted runners due to undetected reason.

### Benefits
Long tests should not be failed when they are run on the deault GH Runners.

### Possible Drawbacks
Should be none, but we have to re-implement self-hosted runners.
