### PR TITLE
[ci] #2781: add coverage offsets

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -55,17 +55,6 @@ jobs:
           github_token: ${{ secrets.G_ACCESS_TOKEN }}
           workflow_file_name: update-dependencies.yaml
           ref: iroha2-dev
-      - name: Build and push docker image (load-rs:dev)
-        run: |
-          sleep 10s
-          echo "wait to other workflow"
-      - uses: convictional/trigger-workflow-and-wait@v1.6.2
-        with:
-          owner: soramitsu
-          repo: iroha2-longevity-load-rs
-          github_token: ${{ secrets.G_ACCESS_TOKEN }}
-          workflow_file_name: load-rs-push-from-dev.yaml
-          ref: iroha2-dev
 
   archive_binaries_and_schema:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,13 @@
+codecov:
+  branch: iroha2-dev
+  allow_coverage_offsets: True
+  notify:
+    require_ci_to_pass: false
 coverage:
   status:
     project:
       default:
         target: auto
         threshold: 5%
+        base: "parent"
     patch: off


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
1. Remove duplicated step for `load-rs` script compilation (an unintelligible oversight).
2. Set up Codecov Coverage default branch.
3. Enable Codecov Coverage `commits offsets` feature.
4. Enable old deprecated feature to compare it against the parent commit.
5. Enable to See coverage on CI test failures (Codecov will not wait for all other statuses to pass before sending its status).

### Issue
1. We accidentally admitted double step to trigger `longevity load-rs` script compilation.
2. Codecov Coverage `diff` value continues to work incorrectly. [Issue #2781](https://github.com/hyperledger/iroha/issues/2781)

### Benefits
### By default, Codecov only chooses commits that have successful CI builds.

Perhaps here are some of the latest possible ideas to fix Codecov Coverage `diff` by own strength. I am not sure which one definite change could help because I can't test it on fork really. We can try a several of them.
We also might to turn off the  `Pseudo-Comparison` feature that _is enabled by default_: `When Codecov generates a comparison for a pull-request, but the pull-request’s base in git does not have coverage information, Codecov will try to find an appropriate substitute (a “pseudo-base”). This is referred to as pseudo-comparison`.
It means that the `Coverage Offsets` feature might not work when `Pseudo-Comparison` is turned off: `Sometimes the pseudo-base chosen by Codecov will not be recent enough to directly substitute for the base commit of a pull-request. In this case, Codecov will try to use the diff between the pseudo-base and the true base to adjust the coverage information of the pseudo-base and account for recent changes using the feature of applying that is called “coverage offsets” `.

---

We also can enable `Send coverage notifications even if all CI statuses have not completed` feature if it could be useful.

### Possible Drawbacks
Coverage Codecov still might not work.