### PR TITLE
[fix] #2819: Move non-essential members out of WSV.

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -250,7 +250,7 @@ impl Iroha {
         );
 
         let kura = Kura::from_configuration(&config.kura)?;
-        let wsv = WorldStateView::from_configuration(config.wsv, world, events_sender.clone());
+        let wsv = WorldStateView::from_configuration(config.wsv, world);
 
         let query_judge = Arc::from(query_judge);
 

--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -413,8 +413,7 @@ async fn handle_metrics(sumeragi: Arc<Sumeragi>, _network: Addr<IrohaNetwork>) -
         iroha_logger::error!(%error, "Error while calling sumeragi::update_metrics.");
     }
     sumeragi
-        .wsv_mutex_access()
-        .metrics
+        .metrics_mutex_access()
         .try_to_string()
         .map_err(Error::Prometheus)
 }
@@ -426,7 +425,7 @@ async fn handle_status(sumeragi: Arc<Sumeragi>, _network: Addr<IrohaNetwork>) ->
     if let Err(error) = sumeragi.update_metrics() {
         iroha_logger::error!(%error, "Error while calling `sumeragi::update_metrics`.");
     }
-    let status = Status::from(&sumeragi.wsv_mutex_access().metrics);
+    let status = Status::from(&sumeragi.metrics_mutex_access());
     Ok(reply::json(&status))
 }
 

--- a/client/benches/tps/config.json
+++ b/client/benches/tps/config.json
@@ -1,7 +1,7 @@
 {
     "peers": 4,
-    "interval_us_per_tx": 10000,
-    "max_txs_per_block": 512,
+    "interval_us_per_tx": 0,
+    "max_txs_per_block": 1024,
     "blocks": 15,
     "sample_size": 10
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,15 +48,6 @@ pub type PermissionTokenDefinitionsMap =
 
 /// Type of `Sender<Event>` which should be used for channels of `Event` messages.
 pub type EventsSender = broadcast::Sender<Event>;
-/// Type of `Receiver<Event>` which should be used for channels of `Event` messages.
-pub type EventsReceiver = broadcast::Receiver<Event>;
-
-/// Send `event` and log error if failure occurred.
-fn send_event(events_sender: &EventsSender, event: Event) {
-    if let Err(error) = events_sender.send(event) {
-        iroha_logger::debug!(%error, event = ?error.0, "Failed send event");
-    }
-}
 
 /// The network message
 #[derive(Clone, Debug, Encode, Decode, iroha_actor::Message)]

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -619,9 +619,7 @@ mod tests {
     fn concurrent_stress_test() {
         let max_block_tx = 10;
         let alice_key = KeyPair::generate().expect("Failed to generate keypair.");
-        let wsv = Arc::new(WorldStateView::new(world_with_test_domains([alice_key
-            .public_key()
-            .clone()])));
+        let wsv = WorldStateView::new(world_with_test_domains([alice_key.public_key().clone()]));
 
         let queue = Arc::new(Queue::from_configuration(&Configuration {
             maximum_transactions_in_block: max_block_tx,

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -85,7 +85,6 @@ pub mod isi {
                 Ok(DomainEvent::Created(domain_id).into())
             })?;
 
-            wsv.metrics.domains.inc();
             Ok(())
         }
     }
@@ -109,7 +108,6 @@ pub mod isi {
                 Ok(DomainEvent::Deleted(domain_id).into())
             })?;
 
-            wsv.metrics.domains.dec();
             Ok(())
         }
     }

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -293,6 +293,9 @@ where
         .wsv
         .apply(block.clone())
         .expect("Failed to apply block on WSV. This is absolutely not acceptable.");
+
+    let events_buffer = state.wsv.events_buffer.replace(Vec::new());
+
     // Update WSV copy that is public facing
     {
         let mut wsv = sumeragi
@@ -302,7 +305,7 @@ where
         *wsv = state.wsv.clone();
     }
 
-    for event in Vec::<Event>::from(&block) {
+    for event in events_buffer.into_iter().chain(Vec::<Event>::from(&block)) {
         trace!(?event);
         sumeragi
             .events_sender

--- a/data_model/src/trigger/set.rs
+++ b/data_model/src/trigger/set.rs
@@ -379,8 +379,7 @@ impl Set {
     /// Repeats count of failed actions won't be decreased.
     pub fn inspect_matched<F, E>(&self, f: F) -> Result<(), Vec<E>>
     where
-        F: Fn(&dyn ActionTrait, Event) -> std::result::Result<(), E> + Send + Copy,
-        E: Send + Sync,
+        F: Fn(&dyn ActionTrait, Event) -> std::result::Result<(), E> + Copy,
     {
         let (succeed, res) = self.map_matched(f);
 
@@ -410,8 +409,7 @@ impl Set {
     /// and result with errors vector if there are some
     fn map_matched<F, E>(&self, f: F) -> (Vec<Id>, Result<(), Vec<E>>)
     where
-        F: Fn(&dyn ActionTrait, Event) -> std::result::Result<(), E> + Send + Copy,
-        E: Send + Sync,
+        F: Fn(&dyn ActionTrait, Event) -> std::result::Result<(), E> + Copy,
     {
         let mut succeed = Vec::new();
         let mut errors = Vec::new();


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Consolidate structure of `WorldStateView` object. Remove unnecessary duplication and allow things to be accessed from a more appropriate object. 

### Issue

Closes #2819 

### Benefits

Smaller memory footprint. 

### Possible Drawbacks

None
