### PR TITLE
[feature] #2508: Add a new client CLI subcommand that accepts wasm

### DIFF
--- a/client_cli/README.md
+++ b/client_cli/README.md
@@ -102,3 +102,19 @@ To know how many units of a particular asset an account has, use `asset get` wit
 ```
 
 This query returns the quantity of `XOR#Soramitsu` asset for the `White Rabbit@Soramitsu` account.
+
+### Execute WASM transaction
+
+Use `--file` to specify a path to the WASM file:
+
+```bash
+./iroha_client_cli wasm --file=/path/to/file.wasm
+```
+
+Or skip `--file` to read WASM from standard input:
+
+```bash
+cat /path/to/file.wasm | ./iroha_client_cli wasm
+```
+
+These subcommands submit the provided wasm binary as an `Executable` to be executed outside a trigger context.

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -11,7 +11,13 @@
     clippy::print_stderr
 )]
 
-use std::{fmt, fs::File, str::FromStr, time::Duration};
+use std::{
+    fmt,
+    fs::{read as read_file, File},
+    io::stdin,
+    str::FromStr,
+    time::Duration,
+};
 
 use clap::StructOpt;
 use color_eyre::{
@@ -96,6 +102,8 @@ pub enum Subcommand {
     /// The subcommand related to event streaming
     #[clap(subcommand)]
     Events(events::Args),
+    /// The subcommand related to Wasm
+    Wasm(wasm::Args),
 }
 
 /// Runs subcommand
@@ -118,7 +126,7 @@ macro_rules! match_run_all {
 impl RunArgs for Subcommand {
     fn run(self, cfg: &ClientConfiguration) -> Result<()> {
         use Subcommand::*;
-        match_run_all!((self, cfg), { Domain, Account, Asset, Peer, Events })
+        match_run_all!((self, cfg), { Domain, Account, Asset, Peer, Events, Wasm })
     }
 }
 
@@ -159,21 +167,21 @@ fn main() -> Result<()> {
 /// Fails if submitting over network fails
 #[allow(clippy::shadow_unrelated)]
 pub fn submit(
-    instruction: impl Into<Instruction>,
+    instructions: impl Into<Executable>,
     cfg: &ClientConfiguration,
     metadata: UnlimitedMetadata,
 ) -> Result<()> {
-    let instruction = instruction.into();
     let iroha_client = Client::new(cfg)?;
+    let instructions = instructions.into();
     #[cfg(debug_assertions)]
     let err_msg = format!(
         "Failed to build transaction from instruction {:?}",
-        instruction
+        instructions
     );
     #[cfg(not(debug_assertions))]
     let err_msg = "Failed to build transaction.";
     let tx = iroha_client
-        .build_transaction(vec![instruction].into(), metadata)
+        .build_transaction(instructions, metadata)
         .wrap_err(err_msg)?;
     let tx = match iroha_client.get_original_transaction(
         &tx,
@@ -280,8 +288,8 @@ mod domain {
                 id,
                 metadata: Metadata(metadata),
             } = self;
-            let create_domain = RegisterBox::new(Domain::new(id));
-            submit(create_domain, cfg, metadata).wrap_err("Failed to create domain")
+            let create_domain = RegisterBox::new(Domain::new(id)).into();
+            submit([create_domain], cfg, metadata).wrap_err("Failed to create domain")
         }
     }
 
@@ -365,8 +373,8 @@ mod account {
                 key,
                 metadata: Metadata(metadata),
             } = self;
-            let create_account = RegisterBox::new(Account::new(id, [key]));
-            submit(create_account, cfg, metadata).wrap_err("Failed to register account")
+            let create_account = RegisterBox::new(Account::new(id, [key])).into();
+            submit([create_account], cfg, metadata).wrap_err("Failed to register account")
         }
     }
 
@@ -418,12 +426,9 @@ mod account {
                 condition: Signature(condition),
                 metadata: Metadata(metadata),
             } = self;
-            submit(
-                MintBox::new(account, EvaluatesTo::new_unchecked(condition.into())),
-                cfg,
-                metadata,
-            )
-            .wrap_err("Failed to set signature condition")
+            let mint_box =
+                MintBox::new(account, EvaluatesTo::new_unchecked(condition.into())).into();
+            submit([mint_box], cfg, metadata).wrap_err("Failed to set signature condition")
         }
     }
 
@@ -487,8 +492,8 @@ mod account {
                 permission,
                 metadata: Metadata(metadata),
             } = self;
-            let grant = GrantBox::new(permission.0, id);
-            submit(grant, cfg, metadata).wrap_err("Failed to grant the permission to the account")
+            let grant = GrantBox::new(permission.0, id).into();
+            submit([grant], cfg, metadata).wrap_err("Failed to grant the permission to the account")
         }
     }
 
@@ -577,8 +582,8 @@ mod asset {
             if unmintable {
                 asset_definition = asset_definition.mintable_once();
             }
-            submit(RegisterBox::new(asset_definition), cfg, metadata)
-                .wrap_err("Failed to register asset")
+            let create_asset_definition = RegisterBox::new(asset_definition).into();
+            submit([create_asset_definition], cfg, metadata).wrap_err("Failed to register asset")
         }
     }
 
@@ -610,8 +615,10 @@ mod asset {
             let mint_asset = MintBox::new(
                 Value::U32(quantity),
                 IdBox::AssetId(AssetId::new(asset, account)),
-            );
-            submit(mint_asset, cfg, metadata).wrap_err("Failed to mint asset of type `Value::U32`")
+            )
+            .into();
+            submit([mint_asset], cfg, metadata)
+                .wrap_err("Failed to mint asset of type `Value::U32`")
         }
     }
 
@@ -648,8 +655,9 @@ mod asset {
                 IdBox::AssetId(AssetId::new(asset_id.clone(), from)),
                 Value::U32(quantity),
                 IdBox::AssetId(AssetId::new(asset_id, to)),
-            );
-            submit(transfer_asset, cfg, metadata).wrap_err("Failed to transfer asset")
+            )
+            .into();
+            submit([transfer_asset], cfg, metadata).wrap_err("Failed to transfer asset")
         }
     }
 
@@ -741,12 +749,8 @@ mod peer {
                 key,
                 metadata: Metadata(metadata),
             } = self;
-            submit(
-                RegisterBox::new(Peer::new(PeerId::new(&address, &key))),
-                cfg,
-                metadata,
-            )
-            .wrap_err("Failed to register peer")
+            let register_peer = RegisterBox::new(Peer::new(PeerId::new(&address, &key))).into();
+            submit([register_peer], cfg, metadata).wrap_err("Failed to register peer")
         }
     }
 
@@ -771,12 +775,44 @@ mod peer {
                 key,
                 metadata: Metadata(metadata),
             } = self;
+            let unregister_peer =
+                UnregisterBox::new(IdBox::PeerId(PeerId::new(&address, &key))).into();
+            submit([unregister_peer], cfg, metadata).wrap_err("Failed to unregister peer")
+        }
+    }
+}
+
+mod wasm {
+    use std::{io::Read, path::PathBuf};
+
+    use super::*;
+
+    /// Subcommand for dealing with Wasm
+    #[derive(Debug, StructOpt)]
+    pub struct Args {
+        /// Specify a path to the Wasm file or skip this flag to read from stdin
+        #[structopt(short, long)]
+        path: Option<PathBuf>,
+    }
+
+    impl RunArgs for Args {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let raw_data = if let Some(path) = self.path {
+                read_file(path).wrap_err("Failed to read a Wasm from the file into the buffer")?
+            } else {
+                let mut buf = Vec::<u8>::new();
+                stdin()
+                    .read_to_end(&mut buf)
+                    .wrap_err("Failed to read a Wasm from stdin into the buffer")?;
+                buf
+            };
+
             submit(
-                UnregisterBox::new(IdBox::PeerId(PeerId::new(&address, &key))),
+                Executable::Wasm(WasmSmartContract { raw_data }),
                 cfg,
-                metadata,
+                UnlimitedMetadata::new(),
             )
-            .wrap_err("Failed to unregister peer")
+            .wrap_err("Failed to submit a Wasm smart contract")
         }
     }
 }

--- a/config/src/client.rs
+++ b/config/src/client.rs
@@ -108,8 +108,8 @@ impl Default for ConfigurationProxy {
 }
 
 // TODO: explain why these values were chosen.
-pub const TTL_TOO_SMALL_THRESHOLD: u64 = 500;
-pub const WASM_SIZE_TOO_SMALL_THRESHOLD: u64 = 2_u64.pow(10); // 1 KiB
+const TTL_TOO_SMALL_THRESHOLD: u64 = 500;
+const WASM_SIZE_TOO_SMALL_THRESHOLD: u64 = 2_u64.pow(10); // 1 KiB
 
 impl ConfigurationProxy {
     /// Finalise Iroha client config proxy by checking that certain fields identify reasonable limits or

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -888,6 +888,6 @@ pub mod prelude {
         Transaction, TransactionLimits, TransactionQueryResult, TransactionRejectionReason,
         TransactionValue, Txn, UnsatisfiedSignatureConditionFail, ValidTransaction,
         VersionedPendingTransactions, VersionedRejectedTransaction, VersionedSignedTransaction,
-        VersionedValidTransaction, WasmExecutionFail,
+        VersionedValidTransaction, WasmExecutionFail, WasmSmartContract,
     };
 }


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Add a new subcommand to the Client CLI that accepts wasm binaries and executes them.

### Issue

Closes #2508

### Benefits

Allow executing wasm binaries from the Client CLI.

### Possible Drawbacks

None

### Usage Examples or Tests *[optional]*

Save it into a WAT file.
```wasm
(module
            
        ;; Import host function to execute instruction
        (import "iroha" "execute_instruction"
            (func $exec_isi (param i32 i32)))

        ;; Import host function to execute query
        (import "iroha" "execute_query"
            (func $exec_query (param i32 i32) (result i32)))

        ;; Embed ISI into WASM binary memory
        (memory (export "memory") 1)
        (data (i32.const 0) "\00\0d\09\00\04\30\00\00\06\00\0d\09\00\04\31\00\00\05\0d\02\00\08\2c\75\6e\72\65\61\63\68\61\62\6c\65\01\07\08\00\0d\09\00\04\32\00\00\00\0d\09\00\04\33\00\00")

        ;; Variable which tracks total allocated size
        (global $mem_size (mut i32) i32.const 53)

        ;; Export mock allocator to host. This allocator never frees!
        (func (export "_iroha_wasm_alloc") (param $size i32) (result i32)
            global.get $mem_size

            (global.set $mem_size
                (i32.add (global.get $mem_size) (local.get $size)))
        )
        

            ;; Function which starts the smartcontract execution
            (func (export "_iroha_wasm_main") (param)
                (call $exec_isi (i32.const 0) (i32.const 8))(call $exec_isi (i32.const 8) (i32.const 45))))
```

Pass the file like this
```sh
./iroha_client_cli wasm --path=./test.wat
```