### PR TITLE
[refactor] #2909: Hardcode ports for nextest

### DIFF
--- a/client/benches/tps/lib.rs
+++ b/client/benches/tps/lib.rs
@@ -51,7 +51,7 @@ impl Config {
     pub fn measure(self) -> Result<Tps> {
         // READY
         let (_rt, network, _genesis_client) =
-            <Network>::start_test_with_runtime(self.peers, self.max_txs_per_block);
+            <Network>::start_test_with_runtime(self.peers, self.max_txs_per_block, None);
         let clients = network.clients();
         wait_for_genesis_committed(&clients, 0);
 

--- a/client/tests/integration/add_account.rs
+++ b/client/tests/integration/add_account.rs
@@ -10,8 +10,7 @@ use test_network::*;
 #[test]
 fn client_add_account_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_505).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let pipeline_time = super::Configuration::pipeline_time();

--- a/client/tests/integration/add_domain.rs
+++ b/client/tests/integration/add_domain.rs
@@ -12,8 +12,7 @@ use super::Configuration;
 #[test]
 fn client_add_domain_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()>
 {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_500).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/asset.rs
+++ b/client/tests/integration/asset.rs
@@ -12,7 +12,7 @@ use super::Configuration;
 
 #[test]
 fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_620).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -44,7 +44,7 @@ fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
 
 #[test]
 fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_555).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -79,8 +79,7 @@ fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
 
 #[test]
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_000).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -111,8 +110,7 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
 
 #[test]
 fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_510).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -143,8 +141,7 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
 
 #[test]
 fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_515).start_with_runtime();
 
     // Given
     let account_id = AccountId::from_str("alice@wonderland").expect("Valid");
@@ -196,8 +193,7 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
 
 #[test]
 fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_520).start_with_runtime();
     let pipeline_time = Configuration::pipeline_time();
 
     // Given

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -13,9 +13,8 @@ use super::Configuration;
 #[test]
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_another_peer(
 ) -> Result<()> {
-    prepare_test_for_nextest!();
     // Given
-    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1);
+    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1, Some(10_450));
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/burn_public_keys.rs
+++ b/client/tests/integration/burn_public_keys.rs
@@ -28,12 +28,11 @@ fn account_keys_count(client: &mut Client, account_id: AccountId) -> usize {
 #[ignore = "ignore, more in #2851"]
 #[test]
 fn public_keys_cannot_be_burned_to_nothing() {
-    prepare_test_for_nextest!();
     const KEYS_COUNT: usize = 3;
     let bob_id: AccountId = "bob@wonderland".parse().expect("Valid");
     let bob_keys_count = |client: &mut Client| account_keys_count(client, bob_id.clone());
 
-    let (_rt, _peer, mut client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut client) = <PeerBuilder>::new().with_port(10_045).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     let register_bob = RegisterBox::new(Account::new(bob_id.clone(), [])).into();

--- a/client/tests/integration/connected_peers.rs
+++ b/client/tests/integration/connected_peers.rs
@@ -11,21 +11,26 @@ use super::Configuration;
 #[ignore = "ignore, more in #2851"]
 #[test]
 fn connected_peers_with_f_2_1_2() {
-    prepare_test_for_nextest!();
-    connected_peers_with_f(2)
+    connected_peers_with_f(2, 10_050)
 }
 
 #[test]
 fn connected_peers_with_f_1_0_1() {
-    prepare_test_for_nextest!();
-    connected_peers_with_f(1)
+    connected_peers_with_f(1, 10_150)
 }
 
 /// Test the number of connected peers, changing the number of faults tolerated down and up
-fn connected_peers_with_f(faults: u64) {
+fn connected_peers_with_f(faults: u64, port: u16) {
     let n_peers = 3 * faults + 1;
 
-    let (_rt, network, genesis_client) = <Network>::start_test_with_runtime(n_peers as u32, 1);
+    #[allow(clippy::expect_used)]
+    let (_rt, network, genesis_client) = <Network>::start_test_with_runtime(
+        (n_peers)
+            .try_into()
+            .expect("`faults` argument `u64` value too high, cannot convert to `u32`"),
+        1,
+        Some(port),
+    );
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/events/data.rs
+++ b/client/tests/integration/events/data.rs
@@ -45,7 +45,7 @@ fn produce_instructions() -> Vec<Instruction> {
 #[test]
 fn instruction_execution_should_produce_events() -> Result<()> {
     let instructions = produce_instructions().into();
-    transaction_execution_should_produce_events(instructions)
+    transaction_execution_should_produce_events(instructions, 10_665)
 }
 
 #[test]
@@ -87,13 +87,16 @@ fn wasm_execution_should_produce_events() -> Result<()> {
         isi_calls = isi_calls
     );
 
-    transaction_execution_should_produce_events(Executable::Wasm(WasmSmartContract {
-        raw_data: wat.into_bytes(),
-    }))
+    transaction_execution_should_produce_events(
+        Executable::Wasm(WasmSmartContract {
+            raw_data: wat.into_bytes(),
+        }),
+        10_615,
+    )
 }
 
-fn transaction_execution_should_produce_events(executable: Executable) -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().start_with_runtime();
+fn transaction_execution_should_produce_events(executable: Executable, port: u16) -> Result<()> {
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(port).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     // spawn event reporter
@@ -131,7 +134,7 @@ fn transaction_execution_should_produce_events(executable: Executable) -> Result
 #[test]
 #[allow(clippy::too_many_lines)]
 fn produce_multiple_events() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_645).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     // Spawn event reporter

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -15,26 +15,29 @@ const PEER_COUNT: usize = 7;
 #[ignore = "ignore, more in #2851"]
 #[test]
 fn transaction_with_no_instructions_should_be_committed() -> Result<()> {
-    prepare_test_for_nextest!();
-    test_with_instruction_and_status(None, PipelineStatusKind::Committed)
+    test_with_instruction_and_status_and_port(None, PipelineStatusKind::Committed, 10_250)
 }
 
 #[ignore = "ignore, more in #2851"]
 // #[ignore = "Experiment"]
 #[test]
 fn transaction_with_fail_instruction_should_be_rejected() -> Result<()> {
-    prepare_test_for_nextest!();
     let fail = FailBox::new("Should be rejected");
-    test_with_instruction_and_status(Some(fail.into()), PipelineStatusKind::Rejected)
+    test_with_instruction_and_status_and_port(
+        Some(fail.into()),
+        PipelineStatusKind::Rejected,
+        10_350,
+    )
 }
 
 #[allow(dead_code, clippy::needless_range_loop, clippy::needless_pass_by_value)]
-fn test_with_instruction_and_status(
+fn test_with_instruction_and_status_and_port(
     instruction: Option<Instruction>,
     should_be: PipelineStatusKind,
+    port: u16,
 ) -> Result<()> {
     let (_rt, network, genesis_client) =
-        <Network>::start_test_with_runtime(PEER_COUNT.try_into().unwrap(), 1);
+        <Network>::start_test_with_runtime(PEER_COUNT.try_into().unwrap(), 1, Some(port));
     let clients = network.clients();
     wait_for_genesis_committed(&clients, 0);
     let pipeline_time = Configuration::pipeline_time();

--- a/client/tests/integration/multiple_blocks_created.rs
+++ b/client/tests/integration/multiple_blocks_created.rs
@@ -15,7 +15,7 @@ const N_BLOCKS: usize = 510;
 #[test]
 fn long_multiple_blocks_created() {
     // Given
-    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1);
+    let (_rt, network, iroha_client) = <Network>::start_test_with_runtime(4, 1, None);
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/multisignature_account.rs
+++ b/client/tests/integration/multisignature_account.rs
@@ -12,7 +12,7 @@ use super::Configuration;
 
 #[test]
 fn transaction_signed_by_new_signatory_of_account_should_pass() -> Result<()> {
-    let (_rt, peer, iroha_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, peer, iroha_client) = <PeerBuilder>::new().with_port(10_605).start_with_runtime();
     wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -15,7 +15,7 @@ use super::Configuration;
 #[ignore = "Multisignature is not working for now. See #2595"]
 #[test]
 fn multisignature_transactions_should_wait_for_all_signatures() {
-    let (_rt, network, _) = <Network>::start_test_with_runtime(4, 1);
+    let (_rt, network, _) = <Network>::start_test_with_runtime(4, 1, None);
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();
 

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -9,7 +9,7 @@ use test_network::*;
 
 #[test]
 fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_625).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -57,7 +57,7 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
 
 #[test]
 fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_610).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given
@@ -90,7 +90,7 @@ fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Re
 
 #[test]
 fn non_mintable_asset_can_be_minted_if_registered_with_zero_value() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_630).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     // Given

--- a/client/tests/integration/offline_peers.rs
+++ b/client/tests/integration/offline_peers.rs
@@ -7,11 +7,15 @@ use tokio::runtime::Runtime;
 
 #[test]
 fn genesis_block_is_commited_with_some_offline_peers() {
-    prepare_test_for_nextest!();
     // Given
     let rt = Runtime::test();
 
-    let (network, iroha_client) = rt.block_on(<Network>::start_test_with_offline(4, 1, 1));
+    let (network, iroha_client) = rt.block_on(<Network>::start_test_with_offline_and_set_n_shifts(
+        4,
+        1,
+        1,
+        Some(10_560),
+    ));
     wait_for_genesis_committed(&network.clients(), 1);
 
     //When

--- a/client/tests/integration/queries/role.rs
+++ b/client/tests/integration/queries/role.rs
@@ -21,8 +21,7 @@ fn create_role_ids() -> [<Role as Identifiable>::Id; 5] {
 
 #[test]
 fn find_roles() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_525).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();
@@ -51,8 +50,7 @@ fn find_roles() -> Result<()> {
 
 #[test]
 fn find_role_ids() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_530).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();
@@ -78,8 +76,7 @@ fn find_role_ids() -> Result<()> {
 
 #[test]
 fn find_role_by_id() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_535).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id: <Role as Identifiable>::Id = "root".parse().expect("Valid");
@@ -99,8 +96,7 @@ fn find_role_by_id() -> Result<()> {
 
 #[test]
 fn find_unregistered_role_by_id() {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_540).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id: <Role as Identifiable>::Id = "root".parse().expect("Valid");
@@ -117,8 +113,7 @@ fn find_unregistered_role_by_id() {
 
 #[test]
 fn find_roles_by_account_id() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_545).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_ids = create_role_ids();

--- a/client/tests/integration/query_errors.rs
+++ b/client/tests/integration/query_errors.rs
@@ -8,7 +8,9 @@ use iroha_data_model::prelude::*;
 
 #[test]
 fn non_existent_account_is_specific_error() {
-    let (_rt, _peer, client) = <test_network::PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, client) = <test_network::PeerBuilder>::new()
+        .with_port(10_670)
+        .start_with_runtime();
     // we cannot wait for genesis committment
 
     let err = client

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -7,18 +7,17 @@ use iroha_client::client;
 use iroha_core::prelude::*;
 use iroha_data_model::prelude::*;
 use tempfile::TempDir;
-use test_network::{Peer as TestPeer, *};
+use test_network::*;
 use tokio::runtime::Runtime;
 
 use super::Configuration;
 
 #[test]
 fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
-    prepare_test_for_nextest!();
     let temp_dir = Arc::new(TempDir::new()?);
 
     let mut configuration = Configuration::test();
-    let mut peer = <TestPeer>::new()?;
+    let mut peer = <PeerBuilder>::new().with_port(10_000).build()?;
     configuration.sumeragi.trusted_peers.peers = std::iter::once(peer.id.clone()).collect();
 
     let account_id = AccountId::from_str("alice@wonderland").unwrap();

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -108,7 +108,7 @@ fn register_empty_role() -> Result<()> {
 
 #[test]
 fn register_role_with_empty_token_params() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_550).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let role_id = "root".parse().expect("Valid");

--- a/client/tests/integration/sorting.rs
+++ b/client/tests/integration/sorting.rs
@@ -8,7 +8,7 @@ use test_network::*;
 
 #[test]
 fn correct_pagination_assets_after_creating_new_one() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_635).start_with_runtime();
 
     let sort_by_metadata_key = Name::from_str("sort").expect("Valid");
 
@@ -117,7 +117,7 @@ fn correct_pagination_assets_after_creating_new_one() {
 
 #[test]
 fn correct_sorting_of_asset_definitions() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_640).start_with_runtime();
 
     let sort_by_metadata_key = Name::from_str("test_sort").expect("Valid");
 

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -12,8 +12,7 @@ const TRIGGER_NAME: &str = "mint_rose";
 
 #[test]
 fn call_execute_trigger() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_005).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -37,8 +36,7 @@ fn call_execute_trigger() -> Result<()> {
 
 #[test]
 fn execute_trigger_should_produce_event() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_010).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -73,8 +71,7 @@ fn execute_trigger_should_produce_event() -> Result<()> {
 
 #[test]
 fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_015).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -101,8 +98,7 @@ fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
 
 #[test]
 fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_020).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -156,8 +152,7 @@ fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
 
 #[test]
 fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_025).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -206,8 +201,7 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
 
 #[test]
 fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_030).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse()?;
@@ -252,8 +246,7 @@ fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
 
 #[test]
 fn unregister_trigger() -> Result<()> {
-    prepare_test_for_nextest!();
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_035).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let account_id = AccountId::from_str("alice@wonderland")?;
@@ -311,8 +304,6 @@ fn unregister_trigger() -> Result<()> {
 // This feature will be activated by the build-script on nightly builds/
 #[ignore = "Only on nightly"]
 fn trigger_in_genesis_using_base64() -> Result<()> {
-    prepare_test_for_nextest!();
-
     // Reading wasm smartcontract
     let wasm = std::fs::read(concat!(
         env!("OUT_DIR"),
@@ -354,6 +345,7 @@ fn trigger_in_genesis_using_base64() -> Result<()> {
 
     let (_rt, _peer, mut test_client) = <PeerBuilder>::new()
         .with_genesis(genesis)
+        .with_port(10_040)
         .start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 

--- a/client/tests/integration/triggers/data_trigger.rs
+++ b/client/tests/integration/triggers/data_trigger.rs
@@ -8,7 +8,7 @@ use test_network::*;
 
 #[test]
 fn must_execute_both_triggers() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_650).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let account_id: AccountId = "alice@wonderland".parse()?;
@@ -60,6 +60,7 @@ fn must_execute_both_triggers() -> Result<()> {
 fn domain_scoped_trigger_must_be_executed_only_on_events_in_its_domain() -> Result<()> {
     let (_rt, _peer, mut test_client) = <PeerBuilder>::new()
         .with_query_judge(Box::new(AllowAll::new()))
+        .with_port(10_655)
         .start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 

--- a/client/tests/integration/triggers/time_trigger.rs
+++ b/client/tests/integration/triggers/time_trigger.rs
@@ -83,7 +83,7 @@ fn time_trigger_execution_count_error_should_be_less_than_15_percent() -> Result
 fn change_asset_metadata_after_1_sec() -> Result<()> {
     const PERIOD_MS: u64 = 1000;
 
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_660).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
     let start_time = current_time();
 
@@ -124,7 +124,7 @@ fn change_asset_metadata_after_1_sec() -> Result<()> {
 fn pre_commit_trigger_should_be_executed() -> Result<()> {
     const CHECKS_COUNT: usize = 5;
 
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().start_with_runtime();
+    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_600).start_with_runtime();
     wait_for_genesis_committed(&vec![test_client.clone()], 0);
 
     let asset_definition_id = "rose#wonderland".parse().expect("Valid");

--- a/client/tests/integration/unregister_peer.rs
+++ b/client/tests/integration/unregister_peer.rs
@@ -99,7 +99,7 @@ fn init() -> Result<(
     AccountId,
     AssetDefinitionId,
 )> {
-    let (rt, network, client) = <Network>::start_test_with_runtime(4, 1);
+    let (rt, network, client) = <Network>::start_test_with_runtime(4, 1, None);
     let pipeline_time = Configuration::pipeline_time();
     thread::sleep(pipeline_time * 2);
     iroha_logger::info!("Started");

--- a/client/tests/integration/unstable_network.rs
+++ b/client/tests/integration/unstable_network.rs
@@ -68,7 +68,7 @@ fn unstable_network(
         configuration.queue.maximum_transactions_in_block = MAXIMUM_TRANSACTIONS_IN_BLOCK;
         configuration.logger.max_log_level = Level::ERROR.into();
         let network =
-            <Network>::new_with_offline_peers(Some(configuration), n_peers, n_offline_peers)
+            <Network>::new_with_offline_peers(Some(configuration), n_peers, n_offline_peers, None)
                 .await
                 .expect("Failed to init peers");
         let client = Client::test(

--- a/data_model/tests/data_model.rs
+++ b/data_model/tests/data_model.rs
@@ -10,7 +10,7 @@ use iroha_core::{
 };
 use iroha_data_model::{prelude::*, ParseError};
 use iroha_primitives::small::SmallStr;
-use test_network::{prepare_test_for_nextest, Peer as TestPeer, PeerBuilder, TestRuntime};
+use test_network::{PeerBuilder, TestRuntime};
 use tokio::runtime::Runtime;
 
 fn asset_id_new(
@@ -155,7 +155,6 @@ mod register {
 #[allow(unused_must_use)]
 #[test]
 fn find_rate_and_make_exchange_isi_should_succeed() {
-    prepare_test_for_nextest!();
     let kp = KeyPair::new(
         PublicKey::from_str(
             r#"ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"#,
@@ -166,7 +165,10 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
             "9AC47ABF 59B356E0 BD7DCBBB B4DEC080 E302156A 48CA907E 47CB6AEA 1D32719E 7233BFC8 9DCBD68C 19FDE6CE 61582252 98EC1131 B6A130D1 AEB454C1 AB5183C0"
         ).expect("Valid"),
     ).expect("Valid");
-    let mut peer = <TestPeer>::new().expect("Failed to create peer");
+    let mut peer = <PeerBuilder>::new()
+        .with_port(11_100)
+        .build()
+        .expect("Failed to create peer");
     let configuration = get_config(std::iter::once(peer.id.clone()).collect(), Some(kp.clone()));
     let pipeline_time = Duration::from_millis(configuration.sumeragi.pipeline_time_ms());
 


### PR DESCRIPTION
Signed-off-by: Ilia Churin <churin.ilya@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change
For each test that is run by nextest in `iroha_client`, `iroha_data_model` and `iroha_p2p`, replace usage of `prepare_for_nextest!` macro with hardcoded ports. 
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue
Closes #2909.
<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits
Nextest now doesn't fail on either of those packages and finishes successfully. Full manual control.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
If any new tests are added, the programmer will have to keep track of ports already in use and maybe do some simple arithmetic. Also might have some debugging involved in case of failing to get it right at first. Also some code duplication introduced with parallel methods that just allow specifying a port.
<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests
`cargo nextest run -p iroha_client` or any other of the mentioned crates
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs
Making that `unique_port` crate work by making an inhouse solution with other primitives?..
<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
