### PR TITLE
[feature] #2163: Add trait to handle log-and-ignore pattern

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -281,7 +281,7 @@ impl Iroha {
         if Self::start_telemetry(telemetry, &config).await? {
             iroha_logger::info!("Telemetry started")
         } else {
-            iroha_logger::error!("Telemetry did not start")
+            iroha_logger::warn!("Telemetry did not start")
         }
 
         let kura_thread_handler = Kura::start(Arc::clone(&kura));
@@ -450,6 +450,8 @@ fn domains(configuration: &Configuration) -> [Domain; 1] {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic, clippy::print_stdout)]
+
     use std::{iter::repeat, panic, thread};
 
     use futures::future::join_all;
@@ -457,7 +459,6 @@ mod tests {
 
     use super::*;
 
-    #[allow(clippy::panic, clippy::print_stdout)]
     #[tokio::test]
     #[serial]
     async fn iroha_should_notify_on_panic() {

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -68,6 +68,8 @@ pub enum Error {
     },
 }
 
+iroha_logger::impl_logged!(?Error => warn);
+
 impl Queue {
     /// Makes queue from configuration
     pub fn from_configuration(cfg: &Configuration) -> Self {

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -82,6 +82,8 @@ pub mod error {
         Validate(#[from] ValidationError),
     }
 
+    iroha_logger::impl_logged!(?Error => warn);
+
     impl From<FindError> for Error {
         fn from(err: FindError) -> Self {
             Self::Find(Box::new(err))

--- a/logger/src/error.rs
+++ b/logger/src/error.rs
@@ -1,0 +1,159 @@
+//! Ergonomic log-and-ignore syntax.
+
+/// Trait used to pipeline the common log-and-ignore pattern by
+/// providing better handling of the process, and a clearer more
+/// expressive syntax.
+pub trait Logged {
+    /// Log the provided value. Useful for logging objects in a chain
+    /// of events, or before the `?` operator.
+    #[must_use]
+    fn logged(self) -> Self;
+
+    /// Ignore the provided error.
+    ///
+    /// # Motivation
+    ///
+    /// Sometimes errors cannot be sensibly handled, they can only be
+    /// reported to the user. If the error isn't handled further this
+    /// allows one to cheaply explain to the user of the debug build
+    /// **why** a particular error cannot be ignored.  More
+    /// importantly when one sees an explicit
+    /// ```rust
+    /// err.logged().ignore("I can't handle this error because of X")
+    /// ```
+    /// the reader of the code doesn't need to be provided
+    /// with a comment as to why the error message was ignored
+    #[inline]
+    fn ignored(self, reason: &str)
+    where
+        Self: Sized,
+    {
+        #[cfg(debug_assertions)]
+        crate::debug!(reason, "Ignored");
+    }
+
+    /// Promote the error from a lower log level to `ERROR`.
+    ///
+    /// # Motivation
+    ///
+    /// The implementation of `Logged` assumes that most errors have a
+    /// log level that's strictly between `DEBUG` and `ERROR`, in most
+    /// cases, but in some contexts, while they can still only be
+    /// logged and ignored, they signal a configuration issue and call
+    /// for the user's attention.
+    #[inline]
+    fn promoted(self) -> ImportantError<Self>
+    where
+        Self: Sized + core::fmt::Debug,
+    {
+        ImportantError(self)
+    }
+}
+
+impl<T, E: Logged> Logged for core::result::Result<T, E> {
+    #[inline]
+    fn logged(self) -> Self {
+        self.map_err(E::logged)
+    }
+}
+
+impl<T> Logged for tokio::sync::broadcast::error::SendError<T> {
+    #[inline]
+    fn logged(self) -> Self {
+        crate::warn!("Some `{}` Failed to send", std::any::type_name::<T>());
+        self
+    }
+}
+
+impl<T> Logged for tokio::sync::mpsc::error::SendError<T> {
+    #[inline]
+    fn logged(self) -> Self {
+        crate::error!("Some `{}` Failed to send", std::any::type_name::<T>());
+        self
+    }
+}
+
+#[must_use]
+/// An instance of `Logged` temporarily promoted to an important
+/// error. This object deliberately has neither logic nor standard
+/// trait implementations as it's only meant for printing.
+pub struct ImportantError<T: Logged + core::fmt::Debug>(T);
+
+impl<T: Logged + core::fmt::Debug> ImportantError<T> {
+    /// Log part of the log-and-ignore
+    #[inline]
+    pub fn logged(self) -> Self {
+        crate::error!("{:?}", self.0);
+        self
+    }
+
+    /// ignore part of the log-and-ignore.
+    #[inline]
+    pub fn ignored(self, message: &str) {
+        crate::info!("HELP: {message}");
+    }
+}
+
+// TODO: this should really be a `derive`.
+
+/// Derive macro substitute for implementing `Logged`.
+#[macro_export]
+macro_rules! impl_logged {
+    (%$typ:ty => $lvl:ident) => {
+        impl $crate::error::Logged for $typ {
+            #[inline]
+            fn logged(self) -> Self {
+                $crate::$lvl!("{self}");
+                self
+            }
+        }
+    };
+    (?$typ:ty => $lvl:ident) => {
+        impl $crate::error::Logged for $typ {
+            #[inline]
+            fn logged(self) -> Self {
+                #[cfg(debug_assertions)]
+                $crate::$lvl!("{self:?}");
+                #[cfg(not(debug_assertions))]
+                $crate::$lvl!("{self}");
+                self
+            }
+        }
+    };
+}
+
+impl_logged!(?color_eyre::eyre::Report => warn);
+impl_logged!(?tokio::task::JoinError => error);
+
+impl Logged for std::vec::Vec<color_eyre::eyre::Report> {
+    #[inline]
+    fn logged(self) -> Self {
+        crate::warn!("The following {} errors have occurred:", self.len());
+        self.into_iter().map(Logged::logged).collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    pub fn setup_logger() {
+        let config = iroha_config::logger::Configuration {
+            max_log_level: crate::Level::TRACE.into(),
+            telemetry_capacity: 100,
+            compact_mode: true,
+            log_file_path: None,
+            terminal_colors: true,
+        };
+        crate::init(&config).unwrap().unwrap();
+    }
+
+    #[test]
+    fn test_name() {
+        setup_logger();
+        color_eyre::eyre::eyre!("eyre::hello world")
+            .wrap_err("Some traceback")
+            .logged()
+            .ignored("Not an error");
+    }
+}

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,10 +1,7 @@
 //! Iroha's logging utilities.
-#![allow(
-    clippy::expect_used,
-    clippy::std_instead_of_core,
-    clippy::std_instead_of_alloc
-)]
+#![allow(clippy::std_instead_of_core, clippy::std_instead_of_alloc)]
 
+pub mod error;
 pub mod layer;
 pub mod telemetry;
 
@@ -42,9 +39,10 @@ pub type Telemetries = (SubstrateTelemetry, FutureTelemetry);
 
 static LOGGER_SET: AtomicBool = AtomicBool::new(false);
 
-/// Initializes `Logger` with given [`Configuration`].
-/// After the initialization `log` macros will print with the use of this `Logger`.
-/// Returns the receiving side of telemetry channels (regular telemetry, future telemetry)
+/// Initializes `Logger` with given [`Configuration`].  After the
+/// initialization `log` macros will print with the use of this
+/// `Logger`.  Returns the receiving side of telemetry channels
+/// (regular telemetry, future telemetry)
 ///
 /// # Errors
 /// If the logger is already set, raises a generic error.
@@ -123,6 +121,7 @@ fn add_telemetry_and_set_default<S: Subscriber + Send + Sync + 'static>(
     configuration: &Configuration,
     subscriber: S,
 ) -> Result<Telemetries> {
+    #![allow(clippy::expect_used)]
     // static global_subscriber: dyn Subscriber = once_cell::new;
     let (subscriber, receiver, receiver_future) = TelemetryLayer::from_capacity(
         subscriber,
@@ -276,7 +275,8 @@ macro_rules! telemetry_future {
     );
 }
 
-/// Installs the panic hook with [`color_eyre::install`] if it isn't installed yet
+/// Installs the panic hook with [`color_eyre::install`] if it isn't
+/// installed yet
 ///
 /// # Errors
 /// Fails if [`color_eyre::install`] fails
@@ -293,7 +293,10 @@ pub fn install_panic_hook() -> Result<(), Report> {
 }
 
 pub mod prelude {
-    //! Module with most used items. Needs to be imported when using `log` macro to avoid `tracing` crate dependency
+    //! Module with most used items. Needs to be imported when using
+    //! `log` macro to avoid `tracing` crate dependency
 
     pub use tracing::{self, debug, error, info, instrument as log, trace, warn};
+
+    pub use crate::error::Logged as LoggedError;
 }


### PR DESCRIPTION
Signed-off-by: Aleksandr Petrosyan <a-p-petrosyan@yandex.ru>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

The log-and-ignore pattern is all too common in our code base. I've added a trait that makes it much easier to enforce "best practices" for such errors. Specifically, errors now need to be explicitly ignored using an `expect`-like `ignored` function. 

For most errors their kind determines the severity. So instead of writing 
```rust
if let Err(e) = some_fallible_operation() {
    warn!(%e, "Some erorr occurred")
}
```

We write 
```rust
some_fallible_operation()
	.logged()
	.ignored("If `some_fallible_operation` failed, you probably have something wrong with your ports");
```
Less code, more information, the message in the `ignored` doubles as a comment for why we aren't handling the error. 

Additionally the code generated here will make use of the fact that `eyre::Report`'s `core::fmt::Debug` implementation prints the traceback, so as to print the entire traceback in the logs for the **debug** build, while reducing the verbosity in the **release** build. 



### Issue

#2163 

### Benefits

Less boilerplate, more diagnostic information when you need it. 

### Possible Drawbacks

For all errors handled this way, the `error` span is attached to the implementation for this error type and not the call-site where the error "first" occurred. 

Resolution pending 
https://discord.com/channels/500028886025895936/627649734592561152/1034897182333091850

### Alternate Designs *[optional]*

A (postfix) macro based solution could do just as well. 

A prefix macro with a mini-syntax could resolve the issue of spans, but be more cumbersome to use. 

An attribute-like macro is also possible with the following syntax:
```rust 
#[log_on_err]
fn function_calling_fallible(… ) -> … {
	some_fallible_operation().logged().ignored("Helpful message");
	another_fallible_op()
		.map(do_something)
		.map_err(do_something_else)
		.logged!() // Expands in-place. 
		.map_err(one_last_time)
		.ignored("With this error"); 
	for e in results {
		e.is_err().break() now; // `.break()` returns `ControlFlow::Break` which then gets applied by the `now` keyword
	} // functions as `if let Err(e)` break. 
	result.if_error().short_circuit()
}
```
which corrects the span information and adds functionality and posprocesses the methods via keywords, but complicates the system and removes the flexibility of the trait implementation using the full-fat type level information. 

