### PR TITLE
[feature] #2899: Add multi-instructions subcommand into `client_cli`

### DIFF
--- a/client_cli/README.md
+++ b/client_cli/README.md
@@ -118,3 +118,12 @@ cat /path/to/file.wasm | ./iroha_client_cli wasm
 ```
 
 These subcommands submit the provided wasm binary as an `Executable` to be executed outside a trigger context.
+
+### Multiple instructions
+
+Accept instructions as JSON to stdin:
+```bash
+cat /path/to/file.json | ./iroha_client_cli json
+```
+
+Run multiple instructions with a single subcommand using the JSON representation.

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -106,6 +106,8 @@ pub enum Subcommand {
     Wasm(wasm::Args),
     /// The subcommand related to block streaming
     Blocks(blocks::Args),
+    /// The subcommand related to multi-instructions as Json
+    Json(json::Args),
 }
 
 /// Runs subcommand
@@ -128,7 +130,7 @@ macro_rules! match_run_all {
 impl RunArgs for Subcommand {
     fn run(self, cfg: &ClientConfiguration) -> Result<()> {
         use Subcommand::*;
-        match_run_all!((self, cfg), { Domain, Account, Asset, Peer, Events, Wasm, Blocks })
+        match_run_all!((self, cfg), { Domain, Account, Asset, Peer, Events, Wasm, Blocks, Json })
     }
 }
 
@@ -851,6 +853,25 @@ mod wasm {
                 UnlimitedMetadata::new(),
             )
             .wrap_err("Failed to submit a Wasm smart contract")
+        }
+    }
+}
+
+mod json {
+    use std::io::BufReader;
+
+    use super::*;
+
+    /// Subcommand for submitting multi-instructions
+    #[derive(Clone, Copy, Debug, StructOpt)]
+    pub struct Args;
+
+    impl RunArgs for Args {
+        fn run(self, cfg: &ClientConfiguration) -> Result<()> {
+            let reader = BufReader::new(stdin());
+            let instructions: Vec<Instruction> = serde_json::from_reader(reader)?;
+            submit(instructions, cfg, UnlimitedMetadata::new())
+                .wrap_err("Failed to submit parsed instructions")
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

More details about the suggestion you can find [here.](https://github.com/hyperledger/iroha/issues/2899)

I spent some time trying to reuse `GenesisTransaction`s format (`configs/peer/genesis.json`) but it's a bad way cause demand depends on `iroha_core` and a lot of boilerplate code being converted. But I noticed that we can just use `Serialize/Deserialize` which already implemented for `Instruction`s and use those traits to represent instructions as JSON. As a result, I got a way to make a more convenient and simple implementation of this command.

### Issue

Closes #2899 

### Benefits

Submit multiple instructions using one command

### Possible Drawbacks

None

### Usage Examples or Tests

Save these instructions into a file:
```json
[
    {
        "Register": {
            "Identifiable": {
                "NewDomain": {
                    "id": "neverland",
                    "logo": null,
                    "metadata": {}
                }
            }
        }
    },
    {
        "Register": {
            "Identifiable": {
                "NewAccount": {
                    "id": "steve@neverland",
                    "signatories": [
                        "ed0120cc25624d62896d3a0bfd8940f928dc2abf27cc57cefeb442aa96d9081aae58a1"
                    ],
                    "metadata": {}
                }
            }
        }
    },
    {
        "Register": {
            "Identifiable": {
                "NewAssetDefinition": {
                    "id": "sapporo#neverland",
                    "value_type": "Quantity",
                    "mintable": "Infinitely",
                    "metadata": {}
                }
            }
        }
    },
    {
        "Mint": {
            "object": {
                "U32": 1010
            },
            "destination_id": {
                "Id": {
                    "AssetId": "sapporo##steve@neverland"
                }
            }
        }
    }
]
```

And then pass to `client_cli` like this:
```
cat ./test.json | ./iroha_client_cli json
```