### PR TITLE
[ci]: Switсh dev tests to Equinix self-hosted runners

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, iroha2ci]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -45,7 +45,7 @@ jobs:
         run: mold --run cargo +nightly-2022-08-15 build --target wasm32-unknown-unknown --quiet
 
   with_coverage:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: [self-hosted, Linux, iroha2ci]
     container:
       image: 7272721/i2-ci:nightly
     strategy:
@@ -82,7 +82,7 @@ jobs:
           commit_parent: ${{ github.event.pull_request.base.sha }}
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, iroha2ci]
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 30
@@ -95,7 +95,7 @@ jobs:
           integration:: --skip unstable_network
 
   unstable:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: [self-hosted, Linux, iroha2ci]
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 60

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -44,7 +44,7 @@ jobs:
     container:
       image: 7272721/i2-ci:nightly
     steps:
-      - name: Check and merge Cargo dependencies (load-rs:dev)
+      - name: Build and push docker image (load-rs:dev)
         run: |
           sleep 10s
           echo "wait to other workflow"
@@ -53,7 +53,7 @@ jobs:
           owner: soramitsu
           repo: iroha2-longevity-load-rs
           github_token: ${{ secrets.G_ACCESS_TOKEN }}
-          workflow_file_name: update-dependencies.yaml
+          workflow_file_name: load-rs-push-from-dev.yaml
           ref: iroha2-dev
 
   archive_binaries_and_schema:

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -62,7 +62,7 @@ jobs:
           PREFIX='iroha2-'
           TAG=${BRANCH#$PREFIX}
           echo "TAG=$TAG" >>$GITHUB_ENV
-      - name: Build and push docker image (load-rs:release)
+      - name: Build and push docker image (load-rs:release/stable)
         run: |
           sleep 10s
           echo "wait to finish other workflow"


### PR DESCRIPTION
### Description of the Change
1. Substitute default GitHub Actions runners with the `self-hosted` demand persistent instances _[s(1-4)-dev-iroha2-iroha-tech]_ with the following characteristics:
- CPU: 1 x Intel(R) Xeon(R) E-2278G
- RAM: 32 Gb
- Drive: 2 x 500 Gb
- OS: Ubuntu 22.04 LTS

For the following CI test jobs into `I2::Dev::Tests` workflow:
- check
- with_coverage
- integration
- unstable

2. Update links to `load-rs` CI.

### Issue
1. A long and heavy jobs from iroha2 CI take too much time on the default GitHub Actions runners.
2. Wrong configuration to call `load-rs` image compiltation.

### Benefits
1. Increase the speed, effectiveness and reliability of the heavy parts of iroha2 CI.
2. Fix `load-rs` CI trigger.

### Possible Drawbacks
1. Using a `self-hosted` runners, especially demand instances, for PR trigger workflows for open repositories is not a good practice: theoretically someone could execute malicious and undesirable code from his fork as PR's code. This requires being attentive and careful.
3. According to GitHub Actions settings, `self-hosted` runner can execute only one job from single workflow per unit of time. We added four instances for now, that means they can execute four jobs in the same time. May be we can try to add this `self-hosted` runners to job that builds `iroha2-dev` image as well. Perhaps we can add several instances more if it will be useful in the future.
