### PR TITLE
[refactor]: Add `storage` folder into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/target/
-**/blocks/
+**/storage/
 **/*.rs.bk
 **/rusty-tags.vi
 /**/Cargo.lock


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This PR hides from Git the annoying `storage/` folder, which appears after every running of the Iroha.

### Issue

None

### Benefits

It slightly improves the developer experience using the Iroha locally. 

### Possible Drawbacks

None