### PR TITLE
[ci]: Fix self-hosted runners occasional execution

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -9,7 +9,7 @@ on:
       - '**.toml'
       - '.github/workflows/**.yml'
 
-      # Not part of the workspace
+      # Not part of the workspace!!!
       - '!wasm/**'
 
 concurrency:
@@ -22,7 +22,6 @@ env:
 jobs:
   check:
     runs-on: [self-hosted, Linux, iroha2ci]
-    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -47,7 +46,6 @@ jobs:
 
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2ci]
-    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     strategy:
@@ -85,7 +83,6 @@ jobs:
 
   integration:
     runs-on: [self-hosted, Linux, iroha2ci]
-    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 30
@@ -99,7 +96,6 @@ jobs:
 
   unstable:
     runs-on: [self-hosted, Linux, iroha2ci]
-    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 60

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   check:
     runs-on: [self-hosted, Linux, iroha2ci]
+    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -46,6 +47,7 @@ jobs:
 
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2ci]
+    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     strategy:
@@ -83,6 +85,7 @@ jobs:
 
   integration:
     runs-on: [self-hosted, Linux, iroha2ci]
+    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 30
@@ -96,6 +99,7 @@ jobs:
 
   unstable:
     runs-on: [self-hosted, Linux, iroha2ci]
+    environment: test-env
     container:
       image: 7272721/i2-ci:nightly
     timeout-minutes: 60


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
Add environment execution rule (the same a for `iroha1` CI) for jobs that are run on the Pull Request to `iroha2-dev` branch within `I2::Dev::Tests` workflow:
  - check
  - with_coverage
  - integration
  - unstable

### Issue
Potential malicious code could be executed on PR workflows from attacker Pull Request. We were asked that we MUST fix it.

### Benefits
By applying `test-env` environment to this test jobs, any person from `hyperledger/iroha-maintainers` and `hyperledger/iroha-admins` teams has to approve and allow to execute  `I2::Dev::Tests` workflow.

### Possible Drawbacks
If any person from this white list forgets to allow workflow execution, then the tests for PR simply will not run.
