### PR TITLE
[fix] #3013: properly chain burn validators: backport for LTS

### DIFF
--- a/permissions_validators/src/public_blockchain/mod.rs
+++ b/permissions_validators/src/public_blockchain/mod.rs
@@ -120,10 +120,9 @@ pub fn default_permissions() -> InstructionJudgeBoxed {
                     .or(mint::GrantedByAssetCreator.into_validator()),
             )
             .with_recursive_validator(
-                burn::OnlyOwnedAssets.or(burn::GrantedByAssetOwner.into_validator()),
-            )
-            .with_recursive_validator(
-                burn::OnlyAssetsCreatedByThisAccount
+                burn::OnlyOwnedAssets
+                    .or(burn::GrantedByAssetOwner.into_validator())
+                    .or(burn::OnlyAssetsCreatedByThisAccount)
                     .or(burn::GrantedByAssetCreator.into_validator()),
             )
             .with_recursive_validator(


### PR DESCRIPTION
Signed-off-by: Artemii Gerasimovich <gerasimovich@soramitsu.co.jp>

### Description of the Change

Backport of #3025 