### PR TITLE
[feature] #3019: Add JSON5 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,11 +1928,12 @@ dependencies = [
  "clap 3.2.16",
  "color-eyre",
  "dialoguer",
+ "iroha",
  "iroha_client",
  "iroha_config",
  "iroha_crypto",
  "iroha_data_model",
- "serde_json",
+ "json5",
  "vergen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "iroha_crypto",
  "iroha_data_model",
  "iroha_primitives",
+ "json5",
  "proptest",
  "serde",
  "serde_json",
@@ -1962,6 +1963,7 @@ version = "2.0.0-pre-rc.11"
 dependencies = [
  "crossbeam",
  "iroha_config_derive",
+ "json5",
  "serde",
  "serde_json",
  "thiserror",
@@ -2369,6 +2371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -2838,6 +2851,50 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha1",
+]
 
 [[package]]
 name = "petgraph"
@@ -3611,6 +3668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,6 +4386,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,7 +1928,6 @@ dependencies = [
  "clap 3.2.16",
  "color-eyre",
  "dialoguer",
- "iroha",
  "iroha_client",
  "iroha_config",
  "iroha_crypto",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,13 +3,12 @@
 use core::str::FromStr;
 
 use eyre::WrapErr as _;
-use iroha::Arguments;
 use iroha_core::prelude::AllowAll;
 use iroha_permissions_validators::public_blockchain::default_permissions;
 
 #[tokio::main]
 async fn main() -> Result<(), color_eyre::Report> {
-    let mut args = Arguments::default();
+    let mut args = iroha::Arguments::default();
     if std::env::args().any(|a| is_help(&a)) {
         print_help();
         return Ok(());
@@ -23,7 +22,7 @@ async fn main() -> Result<(), color_eyre::Report> {
     if std::env::args().any(|a| is_submit(&a)) {
         args.submit_genesis = true;
         if let Ok(genesis_path) = std::env::var("IROHA2_GENESIS_PATH") {
-            args.genesis_path = Some(std::path::PathBuf::from_str(&genesis_path)?);
+            args.genesis_path = Some(iroha::ConfigPath::from_str(&genesis_path)?);
         }
     } else {
         args.genesis_path = None;
@@ -37,7 +36,7 @@ async fn main() -> Result<(), color_eyre::Report> {
     }
 
     if let Ok(config_path) = std::env::var("IROHA2_CONFIG_PATH") {
-        args.config_path = std::path::PathBuf::from_str(&config_path)?;
+        args.config_path = iroha::ConfigPath::from_str(&config_path)?;
     }
     if !args.config_path.exists() {
         // Require all the fields defined in default `config.json`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,7 @@
 //! Iroha peer command-line interface.
 
-use core::str::FromStr;
-
 use eyre::WrapErr as _;
+use iroha_config::path::Path as ConfigPath;
 use iroha_core::prelude::AllowAll;
 use iroha_permissions_validators::public_blockchain::default_permissions;
 
@@ -22,7 +21,7 @@ async fn main() -> Result<(), color_eyre::Report> {
     if std::env::args().any(|a| is_submit(&a)) {
         args.submit_genesis = true;
         if let Ok(genesis_path) = std::env::var("IROHA2_GENESIS_PATH") {
-            args.genesis_path = Some(iroha::ConfigPath::from_str(&genesis_path)?);
+            args.genesis_path = Some(ConfigPath::user_provided(&genesis_path)?);
         }
     } else {
         args.genesis_path = None;
@@ -36,7 +35,7 @@ async fn main() -> Result<(), color_eyre::Report> {
     }
 
     if let Ok(config_path) = std::env::var("IROHA2_CONFIG_PATH") {
-        args.config_path = iroha::ConfigPath::from_str(&config_path)?;
+        args.config_path = ConfigPath::user_provided(&config_path)?;
     }
     if !args.config_path.exists() {
         // Require all the fields defined in default `config.json`

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -84,12 +84,12 @@ fn print_help() {
     println!("pass `--version` or `-V` to print version information");
     println!();
     println!("Iroha 2 is configured via environment variables:");
-    println!("    IROHA2_CONFIG_PATH is the location of your `config.json`");
-    println!("    IROHA2_GENESIS_PATH is the location of `genesis.json`");
+    println!("    IROHA2_CONFIG_PATH is the location of your `config.json` or `config.json5`");
+    println!("    IROHA2_GENESIS_PATH is the location of `genesis.json` or `genesis.json5`");
     println!("If either of these is not provided, Iroha checks the current directory.");
     println!(
-        "Additionally, in case of absence of both IROHA2_CONFIG_PATH and `config.json`
-in the current directory, all the variables from `config.json` should be set via the environment
+        "Additionally, in case of absence of both IROHA2_CONFIG_PATH and `config.json`/`config.json5`
+in the current directory, all the variables from `config.json`/`config.json5` should be set via the environment
 as follows:"
     );
     println!("    IROHA_TORII is the torii gateway config");

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -21,11 +21,12 @@ iroha_client = { version = "=2.0.0-pre-rc.11", path = "../client" }
 iroha_data_model = { version = "=2.0.0-pre-rc.11", path = "../data_model" }
 iroha_crypto = { version = "=2.0.0-pre-rc.11", path = "../crypto" }
 iroha_config = { version = "=2.0.0-pre-rc.11", path = "../config" }
+iroha = { version = "=2.0.0-pre-rc.11", path = "../cli" }
 
 color-eyre = "0.6.2"
 clap = { version = "3.2.16", features = ["derive"] }
 dialoguer = { version = "0.10.2", default-features = false }
-serde_json = "1.0.83"
+json5 = "0.4.1"
 
 [build-dependencies]
 anyhow = "1.0.60"

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -21,7 +21,6 @@ iroha_client = { version = "=2.0.0-pre-rc.11", path = "../client" }
 iroha_data_model = { version = "=2.0.0-pre-rc.11", path = "../data_model" }
 iroha_crypto = { version = "=2.0.0-pre-rc.11", path = "../crypto" }
 iroha_config = { version = "=2.0.0-pre-rc.11", path = "../config" }
-iroha = { version = "=2.0.0-pre-rc.11", path = "../cli" }
 
 color-eyre = "0.6.2"
 clap = { version = "3.2.16", features = ["derive"] }

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -26,7 +26,7 @@ use color_eyre::{
 };
 use dialoguer::Confirm;
 use iroha_client::client::Client;
-use iroha_config::client::Configuration as ClientConfiguration;
+use iroha_config::{client::Configuration as ClientConfiguration, path::Path as ConfigPath};
 use iroha_crypto::prelude::*;
 use iroha_data_model::prelude::*;
 
@@ -147,15 +147,16 @@ fn main() -> Result<()> {
     let config = if let Some(config) = config_opt {
         config
     } else {
-        let config_path = iroha::ConfigPath::new("config").with_preconfigured_extensions();
+        let config_path = ConfigPath::default("config")
+            .expect("Never fails, because default `config` path has no extensions");
         #[allow(clippy::expect_used)]
         Configuration::from_str(
             config_path
                 .first_existing_path()
                 .wrap_err("Configuration file does not exist")?
                 .as_ref()
-                .to_str()
-                .expect("Default config path is a valid UTF-8 string, qed."),
+                .to_string_lossy()
+                .as_ref(),
         )?
     };
     let Configuration(config) = config;

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -16,6 +16,7 @@ url = { version = "2.2.2", features = ["serde"] }
 
 serde = { version = "1.0.142", default-features = false, features = ["derive"] }
 serde_json = "1.0.83"
+json5 = "0.4.1"
 thiserror = "1.0.32"
 crossbeam = "0.8.2"
 derive_more = "0.99.17"

--- a/config/base/Cargo.toml
+++ b/config/base/Cargo.toml
@@ -9,5 +9,6 @@ iroha_config_derive = { path = "derive" }
 
 serde = { version = "1.0.142", default-features = false, features = ["derive"] }
 serde_json = "1.0.83"
+json5 = "0.4.1"
 thiserror = "1.0.32"
 crossbeam = "0.8.2"

--- a/config/base/derive/src/proxy.rs
+++ b/config/base/derive/src/proxy.rs
@@ -96,9 +96,12 @@ pub fn impl_load_from_env(ast: &StructWithFields) -> TokenStream {
             let inner = if is_string {
                 quote! { Ok(var) }
             } else if as_str_attr {
-                quote! { serde_json::from_value(var.into()).map_err(#err_variant) }
+                quote! {{
+                    let value: ::serde_json::Value = var.into();
+                    ::json5::from_str(&value.to_string()).map_err(#err_variant)
+                }}
             } else {
-                quote! { serde_json::from_str(&var).map_err(#err_variant) }
+                quote! { ::json5::from_str(&var).map_err(#err_variant) }
             };
             let mut set_field = quote! {
                 let #ident = std::env::var(#field_env)
@@ -165,7 +168,7 @@ pub fn impl_load_from_disk(ast: &StructWithFields) -> TokenStream {
                     })
                     .and_then(
                         |s| -> ::core::result::Result<Self, #error_ty> {
-                            serde_json::from_str(&s).map_err(#serde_err_variant)
+                            json5::from_str(&s).map_err(#serde_err_variant)
                         },
                     )
                     .map_or(#none_proxy, ::std::convert::identity);

--- a/config/base/src/lib.rs
+++ b/config/base/src/lib.rs
@@ -334,7 +334,7 @@ pub mod derive {
         /// Used in [`LoadFromDisk`](`crate::proxy::LoadFromDisk`) trait for deserialization errors
         #[error("Deserializing JSON failed: {0}")]
         #[serde(skip)]
-        SerdeError(#[from] serde_json::Error),
+        SerdeError(#[from] json5::Error),
     }
 
     impl Error {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -10,6 +10,7 @@ pub mod iroha;
 pub mod kura;
 pub mod logger;
 pub mod network;
+pub mod path;
 pub mod queue;
 pub mod sumeragi;
 pub mod telemetry;

--- a/config/src/path.rs
+++ b/config/src/path.rs
@@ -1,0 +1,96 @@
+//! Module with configuration path related structures.
+
+use std::{borrow::Cow, path::PathBuf};
+
+use InnerPath::*;
+
+pub const ALLOWED_CONFIG_EXTENSIONS: [&str; 2] = ["json", "json5"];
+
+/// Error type for [`Path`].
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum Error {
+    #[error(
+        "Provided config file has no extension, allowed extensions are: {:?}.",
+        ALLOWED_CONFIG_EXTENSIONS
+    )]
+    UserProvidedConfigFileHasNoExtension,
+    #[error(
+        "Provided config file has invalid extension `{0}`, \
+        allowed extensions are: {:?}.",
+        ALLOWED_CONFIG_EXTENSIONS
+    )]
+    InvalidExtensionError(String),
+    #[error("Provided by default config file has extension when it should not have one.")]
+    DefaultConfigFileHasExtension,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Inner helper struct.
+///
+/// This could be [`Path`] itself, but it is not because enum can be constructed directly and
+/// we need checked way to construct it with written constructors.
+#[derive(Debug, Clone)]
+enum InnerPath {
+    Default(PathBuf),
+    UserProvided(PathBuf),
+}
+
+/// Wrapper around path to config file (i.e. config.json, genesis.json).
+///
+/// Provides abstraction above user-provided config and default ones.
+#[derive(Debug, Clone)]
+pub struct Path(InnerPath);
+
+impl Path {
+    /// Construct new [`Path`] from the default `path`.
+    ///
+    /// `path` should not contain any extension.
+    pub fn default(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+
+        if path.extension().is_some() {
+            return Err(Error::DefaultConfigFileHasExtension);
+        }
+
+        Ok(Self(Default(path)))
+    }
+
+    /// Construct new [`Path`] from user-provided `path`.
+    ///
+    /// `path` should contain one of the allowed extensions.
+    pub fn user_provided(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+
+        let extension = path
+            .extension()
+            .ok_or_else(|| Error::UserProvidedConfigFileHasNoExtension)?
+            .to_string_lossy();
+        if !ALLOWED_CONFIG_EXTENSIONS.contains(&extension.as_ref()) {
+            return Err(Error::InvalidExtensionError(extension.into_owned()));
+        }
+
+        Ok(Self(UserProvided(path)))
+    }
+
+    /// Try to get first existing path applying possible extensions if there are some.
+    pub fn first_existing_path(&self) -> Option<Cow<PathBuf>> {
+        match &self.0 {
+            Default(path) => ALLOWED_CONFIG_EXTENSIONS.iter().find_map(|extension| {
+                let path_ext = path.with_extension(extension);
+                path_ext.exists().then_some(Cow::Owned(path_ext))
+            }),
+            UserProvided(path) => path.exists().then_some(Cow::Borrowed(&path)),
+        }
+    }
+
+    /// Check if config path exists applying possible extensions if there are some.
+    pub fn exists(&self) -> bool {
+        match &self.0 {
+            Default(path) => ALLOWED_CONFIG_EXTENSIONS
+                .iter()
+                .any(|extension| path.with_extension(extension).exists()),
+            UserProvided(path) => path.exists(),
+        }
+    }
+}

--- a/config/src/path.rs
+++ b/config/src/path.rs
@@ -28,8 +28,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Inner helper struct.
 ///
-/// This could be [`Path`] itself, but it is not because enum can be constructed directly and
-/// we need checked way to construct it with written constructors.
+/// With this struct, we force to use [`Path`]'s constructors instead of constructing it directly.
 #[derive(Debug, Clone)]
 enum InnerPath {
     Default(PathBuf),
@@ -73,7 +72,7 @@ impl Path {
         Ok(Self(UserProvided(path)))
     }
 
-    /// Try to get first existing path applying possible extensions if there are some.
+    /// Try to get first existing path by applying possible extensions if there are any.
     pub fn first_existing_path(&self) -> Option<Cow<PathBuf>> {
         match &self.0 {
             Default(path) => ALLOWED_CONFIG_EXTENSIONS.iter().find_map(|extension| {
@@ -84,7 +83,7 @@ impl Path {
         }
     }
 
-    /// Check if config path exists applying possible extensions if there are some.
+    /// Check if config path exists by applying allowed extensions if there are any.
     pub fn exists(&self) -> bool {
         match &self.0 {
             Default(path) => ALLOWED_CONFIG_EXTENSIONS


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Added JSON5 support in user-provided configs, such as:

- config and genesis for `iroha`
- config, metadata, signature, instructions for `iroha_client_cli`

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

- #3019 

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Better human-reading format

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

`json5` crate I use has lack of some functions and features unlike `serde_json`. But it should be enough to interact with user properly.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests

You can try running `iroha` or `iroha_client_cli` as always but also you can:
- use `json5` file extension (for default and your own configs)
- use all features of `json5` in your configs (which should not necessarily have `json5` extension), i.e. comments

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
