### PR TITLE
[feature] #3027: implement lockfile for Kura

### DIFF
--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -55,6 +55,7 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
             .find(|asset| asset.id().definition_id == asset_definition_id)
             .expect("Asset not found");
         assert_eq!(AssetValue::Quantity(quantity), *asset.value());
+        peer.stop();
     }
 
     {

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -4,12 +4,7 @@ use std::{str::FromStr as _, sync::Arc};
 
 use byte_unit::Byte;
 use criterion::{criterion_group, criterion_main, Criterion};
-use iroha_core::{
-    kura::{BlockStoreTrait, StdFileBlockStore},
-    prelude::*,
-    tx::TransactionValidator,
-    wsv::World,
-};
+use iroha_core::{kura::BlockStore, prelude::*, tx::TransactionValidator, wsv::World};
 use iroha_crypto::KeyPair;
 use iroha_data_model::prelude::*;
 use iroha_version::scale::EncodeVersioned;
@@ -64,7 +59,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
             .unwrap();
     }
     let block: VersionedCommittedBlock = block.commit_unchecked().into();
-    let mut block_store = StdFileBlockStore::new(dir.path());
+    let mut block_store = BlockStore::new(dir.path());
     block_store.create_files_if_they_do_not_exist().unwrap();
 
     let serialized_block: Vec<u8> = block.encode_versioned();

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -59,7 +59,9 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
             .unwrap();
     }
     let block: VersionedCommittedBlock = block.commit_unchecked().into();
-    let mut block_store = BlockStore::new(dir.path());
+    let mut block_store = BlockStore::new(dir.path())
+        .lock()
+        .expect("Failed to lock store");
     block_store.create_files_if_they_do_not_exist().unwrap();
 
     let serialized_block: Vec<u8> = block.encode_versioned();
@@ -69,7 +71,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
 
     let metadata = fs::metadata(dir.path().join("blocks.data")).await.unwrap();
     let file_size = Byte::from_bytes(u128::from(metadata.len())).get_appropriate_unit(false);
-    println!("For {} validators: {}", n_validators, file_size);
+    println!("For {n_validators} validators: {file_size}");
 }
 
 async fn measure_block_size_async() {

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -7,10 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
-use iroha_core::{
-    kura::{BlockStoreTrait, StdFileBlockStore},
-    prelude::VersionedCommittedBlock,
-};
+use iroha_core::{kura::BlockStore, prelude::VersionedCommittedBlock};
 use iroha_version::scale::DecodeVersioned;
 
 /// Kura inspector
@@ -73,7 +70,7 @@ fn print_blockchain(block_store_path: &Path, from_height: u64, block_count: u64)
         }
     }
 
-    let block_store = StdFileBlockStore::new(&block_store_path);
+    let block_store = BlockStore::new(&block_store_path);
 
     let index_count = block_store
         .read_index_count()


### PR DESCRIPTION
### Description of the Change

Introduced a lockfile mechanism to Kura to prevent running multiple writing instances over one store.

### Issue

#3027 

### Benefits

As per #3027

### Possible Drawbacks

More complexity in Kura.

### Alternate Designs

- This PR uses typestate pattern to encode lock state in attempt to prevent accidental misuse when changing Kura code. One could argue for a simpler design that would allow slightly more room for mistakes.
- Storage is locked for full lifetime of Kura. There was an alternate design discussed where lock is acquired only when writing blocks, however it is worse for performance and still allows starting multiple Iroha instances backed by the same storage, postponing failure for indeterminate time in the future.
