### PR TITLE
[ci]: Add regular image tag for Soramitsu registry

### DIFF
--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -43,6 +43,7 @@ jobs:
           tags: |
             hyperledger/iroha2:${{ env.TAG }}
             docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}-${{ github.sha }}
+            docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}
           labels: commit=${{ github.sha }}
           build-args: TAG=${{ env.TAG }}
           file: Dockerfile


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
Add one more iroha2 ordinary image tag to be uploaded to Soramitsu images registry.

### Issue
We redeploy some of k8s deployments based on iroha quite often. Free DockerHub account has images pull limit.

### Benefits

By uploading iroha2 stable & lts images with the same tags as iroha2 has on DockerHub, we will get rid of images pull limit and avoid delays with iroha2 deployments (not only Orillion projects).

### Possible Drawbacks

None.