### PR TITLE
[ci]: Adding five more self-hosted runners

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -17,7 +17,7 @@ env:
 # `ubuntu-latest` and not `[self-hosted, Linux]`.
 jobs:
   dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, iroha2-dev-push]
     container:
       image: 7272721/i2-ci:nightly
     steps:
@@ -46,9 +46,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-# FIXME: This workflow never worked properly. Should we remove it? 
   load-rs:
-    if: false
+    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       image: 7272721/i2-ci:nightly


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

### Description of the Change
1. Add four more self-hosted runners for `I2::Dev::Tests` workflow.
2. Add a new self-hosted runner for `I2::Dev::Publish` workflow.
3. Make `load-rs` job inside `I2::Dev::Publish` workflow conditional.

### Issue
1. We can not run a two `I2::Dev::Tests` workflows in parallel on self-hosted runners (increase their amount from 4 to 8 for four tests jobs).
2. A `dockerhub` job  inside `I2::Dev::Publish` workflow takes a lot of time.
3. `I2::Dev::Publish` workflow fails if `load-rs` job was failed or `load-rs` job doesn't run.

### Benefits

1. Now a two`I2::Dev::Tests` workflows could be run in parallel.
2. Increase `dockerhub` job  inside `I2::Dev::Publish` speed.
3. Do not failI `2::Dev::Publish` workflow if `load-rs` job was fails.

### Possible Drawbacks

None.