### PR TITLE
[refactor]: simplify sumeragi

### DIFF
--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -114,14 +114,16 @@ pub(crate) async fn handle_instructions(
     )
     .map_err(Error::AcceptTransaction)?;
     #[allow(clippy::map_err_ignore)]
-    let push_result = queue
+    queue
         .push(transaction, &sumeragi.wsv_mutex_access())
-        .map_err(|(_, err)| err);
-    if let Err(ref error) = push_result {
-        iroha_logger::warn!(%error, "Failed to push into queue")
-    }
-    push_result
-        .map_err(Box::new)
+        .map_err(|(tx, err)| {
+            iroha_logger::warn!(
+                tx_hash=%tx.hash(), ?err,
+                "Failed to push into queue"
+            );
+
+            Box::new(err)
+        })
         .map_err(Error::PushIntoQueue)
         .map(|()| Empty)
 }

--- a/core/src/block_sync.rs
+++ b/core/src/block_sync.rs
@@ -240,10 +240,10 @@ pub mod message {
                 }
                 Message::ShareBlocks(ShareBlocks { blocks, .. }) => {
                     use crate::sumeragi::message::{BlockSyncUpdate, Message, MessagePacket};
-                    for block in blocks {
+                    for block in blocks.clone() {
                         block_sync.sumeragi.incoming_message(MessagePacket::new(
                             Vec::new(),
-                            Message::BlockSyncUpdate(BlockSyncUpdate::from(block.clone())),
+                            Message::BlockSyncUpdate(BlockSyncUpdate { block }),
                         ));
                     }
                 }

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -470,7 +470,7 @@ impl WorldStateView {
 
     /// Returns reference for trusted peer ids
     #[inline]
-    pub fn trusted_peers_ids(&self) -> &PeersIds {
+    pub fn peers_ids(&self) -> &PeersIds {
         &self.world.trusted_peers_ids
     }
 

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -476,24 +476,18 @@ impl<T> SignaturesOf<T> {
         self.signatures.insert(SignatureWrapperOf(signature));
     }
 
-    /// Returns signatures that have passed verification.
+    /// Return signatures that have passed verification, remove all others.
     #[cfg(feature = "std")]
-    pub fn verified_by_hash(&self, hash: HashOf<T>) -> impl Iterator<Item = &SignatureOf<T>> {
+    pub fn retain_verified_by_hash(
+        &mut self,
+        hash: HashOf<T>,
+    ) -> impl Iterator<Item = &SignatureOf<T>> {
+        self.signatures
+            .retain(|sign| sign.verify_hash(&hash).is_ok());
         self.iter()
-            .filter(move |sign| sign.verify_hash(&hash).is_ok())
     }
 
-    /// Returns signatures that have passed verification.
-    #[cfg(feature = "std")]
-    pub fn into_verified_by_hash(
-        self,
-        hash: &HashOf<T>,
-    ) -> impl Iterator<Item = SignatureOf<T>> + '_ {
-        self.into_iter()
-            .filter(move |sign| sign.verify_hash(hash).is_ok())
-    }
-
-    /// Returns all signatures.
+    /// Return all signatures.
     #[inline]
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &SignatureOf<T>> {
         self.into_iter()
@@ -538,9 +532,9 @@ impl<T: Encode> SignaturesOf<T> {
         self.verify_hash(&HashOf::new(item))
     }
 
-    /// Returns signatures that have passed verification.
-    pub fn verified(&self, value: &T) -> impl Iterator<Item = &SignatureOf<T>> {
-        self.verified_by_hash(HashOf::new(value))
+    /// Return signatures that have passed verification, remove all others.
+    pub fn retain_verified(&mut self, value: &T) -> impl Iterator<Item = &SignatureOf<T>> {
+        self.retain_verified_by_hash(HashOf::new(value))
     }
 }
 

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -538,10 +538,6 @@
         {
           "name": "sorted_peers",
           "ty": "Vec<iroha_data_model::peer::Id>"
-        },
-        {
-          "name": "at_block",
-          "ty": "Option<iroha_crypto::hash::HashOf<iroha_core::block::VersionedCommittedBlock>>"
         }
       ]
     }


### PR DESCRIPTION
Signed-off-by: Marin Veršić <marin.versic101@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

I believe you will find it much more easier to understand now
I also left some comments in the code

The hanging issue still persists:
1. `Failed to push into queue err=InBlockchain` is observed:
```
2023-01-12T22:42:41.821378Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54960}: iroha::torii::routing: Failed to push into queue tx_hash=d543e665272d74fd5f6733d1ca01869c78ac8633e7b5a49c36b563fb6baa51b9 err=InBlockchain
2023-01-12T22:42:41.821378Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54955}: iroha::torii::routing: Failed to push into queue tx_hash=5b042f8b52a4d9cc1fca8f57d237cb8c5ff8f92aa58333f61314eb859dc5ae37 err=InBlockchain
2023-01-12T22:42:41.821378Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54966}: iroha::torii::routing: Failed to push into queue tx_hash=5a272b4b5f92ad980bb23a7632672ebcf1ba076ca56cd7b967cbd88b182d90f7 err=InBlockchain
2023-01-12T22:42:41.821423Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54960}: warp::filters::trace: unable to serve request (client error) status=400 error=None
2023-01-12T22:42:41.821423Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54955}: warp::filters::trace: unable to serve request (client error) status=400 error=None
2023-01-12T22:42:41.821456Z  WARN request{method=POST path=/transaction version=HTTP/1.1 remote.addr=127.0.0.1:54966}: warp::filters::trace: unable to serve request (client error) status=400 error=None
2
```
2. And is followed by endless view changes where view change index increases:
```
2023-01-12T21:55:55.603155Z  WARN run: iroha_core::sumeragi::main_loop: Block not committed in due time, requesting view change... role=ObservingPeer
2023-01-12T21:55:55.607356Z  WARN run: iroha_core::sumeragi::main_loop: Block not committed in due time, requesting view change... role=ProxyTail
2023-01-12T21:55:55.610777Z  WARN run: iroha_core::sumeragi::main_loop: Block not committed in due time, requesting view change... role=Leader
2023-01-12T21:55:55.615403Z  WARN run: iroha_core::sumeragi::main_loop: Block not committed in due time, requesting view change... role=ValidatingPeer
2023-01-12T21:55:55.617158Z ERROR run: iroha_core::sumeragi::main_loop: No consensus, updating view change ... current_view_change_index=4
2023-01-12T21:55:55.618910Z ERROR run: iroha_core::sumeragi::main_loop: No consensus, updating view change ... current_view_change_index=4
2023-01-12T21:55:55.622082Z ERROR run: iroha_core::sumeragi::main_loop: No consensus, updating view change ... current_view_change_index=4
2023-01-12T21:55:55.625818Z ERROR run: iroha_core::sumeragi::main_loop: No consensus, updating view change ... current_view_change_index=4
2
```

This might also mean that there are no new incoming transactions

### Issue

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
