### PR TITLE
[documentation] #3070: mention reduced dev activity

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Hyperledger Iroha documentation
 
     The core team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
 
-    These versions are incompatible, so you will have to use Iroha 2 instead of Iroha 1 for the new projects.
+    These versions are incompatible. We recommend using Iroha 2 instead of Iroha 1 for new projects.
     You can read about the differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
 
 .. warning::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ Hyperledger Iroha documentation
     
     The long-term supported version of Iroha v2 (`iroha2-lts`) is your best choice if you want to use Iroha in production and receive tech support from our side. Unfortunately, we cannot offer the same support for Iroha v1, so please consider using Iroha v2.
 
-    Note that Iroha v1 and Iroha v2 are incompatible. You can read about their differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
+    **Note that Iroha v1 and Iroha v2 are incompatible**. You can read about their differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
 
 .. warning::
     For secure deployment on platforms other than new Linux versions, please read `this note <deploy/index.html#security-notice>`_ first before deploying Iroha in production.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Hyperledger Iroha documentation
 .. image:: ../image_assets/iroha_logo.png
 
 .. warning::
-    Please note that support for Hyperledger Iroha v1 is limited because it's no longer actively developed.
+    Please note that support for Hyperledger Iroha v1 is limited because it is no longer actively developed.
 
     The core team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Hyperledger Iroha documentation
 .. image:: ../image_assets/iroha_logo.png
 
 .. warning::
-    Please note that Hyperledger Iroha v1 is **no longer under active development** and the support for Iroha v1 is limited. The core development team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
+    Please note that Hyperledger Iroha v1 is **no longer under active development** therefore, support for Iroha v1 is limited. The core development team is focused on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
     
     For new projects, **we recommend using Iroha v2 instead of Iroha v1**. If you are using Iroha v1, we encourage you to plan an upgrade and switch to using Iroha v2.
     

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Hyperledger Iroha documentation
     
     For new projects, **we recommend using Iroha v2 instead of Iroha v1**. If you are using Iroha v1, we encourage you to plan an upgrade and switch to using Iroha v2.
     
-    The long-term supported version of Iroha v2 (`iroha2-lts`) is your best choice if you want to use Iroha in production and get tech support from our side. Unfortunately, we cannot offer the same support for Iroha v1, so please consider using Iroha v2.
+    The long-term supported version of Iroha v2 (`iroha2-lts`) is your best choice if you want to use Iroha in production and receive tech support from our side. Unfortunately, we cannot offer the same support for Iroha v1, so please consider using Iroha v2.
 
     Note that Iroha v1 and Iroha v2 are incompatible. You can read about their differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,14 @@ Hyperledger Iroha documentation
 .. image:: ../image_assets/iroha_logo.png
 
 .. warning::
+    Please note that support for Hyperledger Iroha v1 is limited because it's no longer actively developed.
+
+    The core team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
+
+    These versions are incompatible, so you will have to use Iroha 2 instead of Iroha 1 for the new projects.
+    You can read about the differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
+
+.. warning::
     For secure deployment on platforms other than new Linux versions, please read `this note <deploy/index.html#security-notice>`_ first before deploying Iroha in production.
 
 Welcome! Hyperledger Iroha is a simple blockchain platform you can use to make trusted, secure, and fast applications by bringing the power of permission-based blockchain with Crash fault-tolerant consensus. It's free, open-source, and works on Linux and Mac OS, with a variety of mobile and desktop libraries.
@@ -14,11 +22,6 @@ You can download the source code of Hyperledger Iroha and latest releases from `
 This documentation will guide you through the installation, deployment, and launch of Iroha network, and explain to you how to write an application for it. We will also see which use case scenarios are feasible now, and are going to be implemented in the future.
 
 As Hyperledger Iroha is an open-source project, we will also cover contribution part and explain you a working process.
-
-.. note::
-    Please note that there exists a complete rewrite of Hyperledger Iroha in Rust, `Iroha 2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_. Both projects are developed concurrently in the same repository. However, they are not compatible. You can read about their differences in `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
-    
-    For all new projects, we recommend using Iroha 2 instead of Iroha 1.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,12 +5,13 @@ Hyperledger Iroha documentation
 .. image:: ../image_assets/iroha_logo.png
 
 .. warning::
-    Please note that support for Hyperledger Iroha v1 is limited because it is no longer actively developed.
+    Please note that Hyperledger Iroha v1 is **no longer under active development** and the support for Iroha v1 is limited. The core development team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
+    
+    For new projects, **we recommend using Iroha v2 instead of Iroha v1**. If you are using Iroha v1, we encourage you to plan an upgrade and switch to using Iroha v2.
+    
+    The long-term supported version of Iroha v2 (`iroha2-lts`) is your best choice if you want to use Iroha in production and get tech support from our side. Unfortunately, we cannot offer the same support for Iroha v1, so please consider using Iroha v2.
 
-    The core team focuses on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
-
-    These versions are incompatible. We recommend using Iroha 2 instead of Iroha 1 for new projects.
-    You can read about the differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
+    Note that Iroha v1 and Iroha v2 are incompatible. You can read about their differences in the `Iroha 2 documentation <https://hyperledger.github.io/iroha-2-docs/guide/iroha-2.html>`_.
 
 .. warning::
     For secure deployment on platforms other than new Linux versions, please read `this note <deploy/index.html#security-notice>`_ first before deploying Iroha in production.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Hyperledger Iroha documentation
 .. image:: ../image_assets/iroha_logo.png
 
 .. warning::
-    Please note that Hyperledger Iroha v1 is **no longer under active development** therefore, support for Iroha v1 is limited. The core development team is focused on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
+    Please note that Hyperledger Iroha v1 is **no longer under active development**; therefore, support for Iroha v1 is limited. The core development team is focused on `Hyperledger Iroha v2 <https://github.com/hyperledger/iroha/tree/iroha2-dev#hyperledger-iroha>`_, a complete rewrite of Iroha in Rust.
     
     For new projects, **we recommend using Iroha v2 instead of Iroha v1**. If you are using Iroha v1, we encourage you to plan an upgrade and switch to using Iroha v2.
     


### PR DESCRIPTION
### Description of the Change

Update the information on the change of core team attention from I1 towards I2.

### Issue

Described in https://github.com/hyperledger/iroha/issues/3070

### Benefits

* Users won't be misdirected by the information on the parallel development
* Iroha 2 will get more attention from the community

### Possible Drawbacks

None