### PR TITLE
[documentation] #3079: reintroduce m2r2 dependency

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -34,5 +34,6 @@ urllib3
 watchdog==0.8.3
 yarg==0.1.9
 mistune==2.0.3
+m2r2==0.3.2
 pygments-lexer-solidity
 sphinxext-remoteliteralinclude


### PR DESCRIPTION
### Description of the Change

This change reintroduces the `m2r2` dependency, since Read the Docs builds are broken for Iroha 1.

### Issue

Documentation for Iroha 1 isn't building correctly.

### Benefits

Documentation updates will show for Iroha 1.

### Possible Drawbacks

More dependencies may be broken.