### PR TITLE
[fix] #3109: Prevent sumeragi sleep after role agnostic message

### DIFF
--- a/core/src/block_sync.rs
+++ b/core/src/block_sync.rs
@@ -101,7 +101,7 @@ pub mod message {
     //! Module containing messages for [`BlockSynchronizer`](super::BlockSynchronizer).
 
     use super::*;
-    use crate::block::VersionedCandidateCommittedBlock;
+    use crate::{block::VersionedCandidateCommittedBlock, sumeragi::view_change::ProofChain};
 
     /// Message to initiate receiving of latest blocks from other peers
     ///
@@ -242,7 +242,7 @@ pub mod message {
                     use crate::sumeragi::message::{BlockSyncUpdate, Message, MessagePacket};
                     for block in blocks.clone() {
                         block_sync.sumeragi.incoming_message(MessagePacket::new(
-                            Vec::new(),
+                            ProofChain::default(),
                             Message::BlockSyncUpdate(BlockSyncUpdate { block }),
                         ));
                     }

--- a/core/src/sumeragi/message.rs
+++ b/core/src/sumeragi/message.rs
@@ -51,14 +51,14 @@ impl VersionedPacket {
 pub struct MessagePacket {
     /// Proof of view change. As part of this message handling, all
     /// peers which agree with view change should sign it.
-    pub view_change_proofs: Vec<view_change::Proof>,
+    pub view_change_proofs: view_change::ProofChain,
     /// Actual Sumeragi message in this packet.
     pub message: Message,
 }
 
 impl MessagePacket {
     /// Construct [`Self`]
-    pub fn new(view_change_proofs: Vec<view_change::Proof>, message: impl Into<Message>) -> Self {
+    pub fn new(view_change_proofs: view_change::ProofChain, message: impl Into<Message>) -> Self {
         Self {
             view_change_proofs,
             message: message.into(),

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -36,7 +36,7 @@ use parking_lot::{Mutex, MutexGuard};
 use self::{
     main_loop::{NoFault, SumeragiWithFault},
     message::{Message, *},
-    view_change::{Proof, ProofChain as ViewChangeProofs},
+    view_change::{Proof, ProofChain},
 };
 use crate::{
     block::VersionedPendingBlock, kura::Kura, prelude::*, queue::Queue, tx::TransactionValidator,


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Changes tend to improve sumeragi message processing speed.

- Fix bug when iroha sleep after role-agnostic message
- Refactor view change proof chain and improve it's processing speed.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Issue

Closes #3109.

<!-- Put in the note about what issue is resolved by this PR, especially if it is a GitHub issue. It should be in the form of "Resolves #N" ("Closes", "Fixes" also work), where N is the number of the issue.
More information about this is available in GitHub documentation: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<!-- If it is not a GitHub issue but a JIRA issue, just put the link here -->

### Benefits

Better sumeragi message processing speed.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
 
None.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Alternate Designs


There is still problem with: 

```
This peer is faulty. Incoming messages have to be dropped due to low processing speed.
```

This happens because sumeragi blocks on committing/revalidating block and if it takes time greater than `pipeline` `ViewChangeSuggested` start flooding queue. 
When queue is full it's staring to drop messages which in turn provoke even more `ViewChangeSuggested` messages.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
