### PR TITLE
[feature] #2940: Add an ability to cancel submitting a transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,7 @@ dependencies = [
  "base64",
  "color-eyre",
  "criterion",
+ "crossbeam-channel",
  "derive_more",
  "eyre",
  "futures-util",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.23.0", features = ["rt"] }
 tokio-tungstenite = { version = "0.16", features = ["native-tls"] }
 tungstenite = { version = "0.16", features = ["native-tls"] }
 futures-util = "0.3.25"
+crossbeam-channel = "0.5"
 
 
 [dev-dependencies]

--- a/client/tests/integration/asset.rs
+++ b/client/tests/integration/asset.rs
@@ -36,8 +36,13 @@ fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
         })
     })?;
 
+    let res = test_client.submit_blocking(register_asset);
+    if let Ok(hash) = res {
+        dbg!("some shit", hash);
+    }
+
     // But registering an asset to account already having one should fail
-    assert!(test_client.submit_blocking(register_asset).is_err());
+    assert!(res.is_err());
 
     Ok(())
 }

--- a/client/tests/integration/cancellation.rs
+++ b/client/tests/integration/cancellation.rs
@@ -1,0 +1,39 @@
+use std::str::FromStr;
+
+use eyre::Result;
+use iroha_core::tx::{Account, AccountId, RegisterBox};
+use test_network::*;
+
+#[test]
+fn client_cancel_to_submit_transaction() -> Result<()> {
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_680).start_with_runtime();
+
+    let new_acc_id = AccountId::from_str("bobby@wonderland").expect("Valid");
+    let register_new_acc = RegisterBox::new(Account::new(new_acc_id, []));
+
+    let (tx, rx) = crossbeam_channel::bounded(1);
+    tx.send(()).expect("Sent successfully");
+
+    assert!(client
+        .submit_with_cancellation(register_new_acc, rx)
+        .is_err());
+
+    Ok(())
+}
+
+#[test]
+fn client_cancel_to_blocking_submit_transaction() -> Result<()> {
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_690).start_with_runtime();
+
+    let new_acc_id = AccountId::from_str("bobby@wonderland").expect("Valid");
+    let register_new_acc = RegisterBox::new(Account::new(new_acc_id, []));
+
+    let (tx, rx) = crossbeam_channel::bounded(1);
+    tx.send(()).expect("Sent successfully");
+
+    assert!(client
+        .submit_blocking_with_cancellation(register_new_acc, rx)
+        .is_err());
+
+    Ok(())
+}

--- a/client/tests/integration/mod.rs
+++ b/client/tests/integration/mod.rs
@@ -8,6 +8,7 @@ mod add_domain;
 mod asset;
 mod asset_propagation;
 mod burn_public_keys;
+mod cancellation;
 mod config;
 mod connected_peers;
 mod events;


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

I did some research and figured out that it's hard to find a synchronous library with the ability to cancel an HTTP request. I'm not sure that is possible at all (change my mind if it's not). My solution is that use crossbeam's `Select` feature and select native threads one of these listens to a cancellation channel. I write some tests and looks like this solution works fine.

### Issue

Resolves #2940

### Benefits

Now we can cancel to submit a transaction.

### Possible Drawbacks

The significant negative impact is that it spawns an extra native thread. Theoretically, if the client spawns many requests simultaneously, the OS can throw an error of spawning a native thread due to resource limitations.
Another negative impact is consuming more memory than the previous submitting design. 
Also, it adds `crossbeam` as a dependency.

### Usage Examples or Tests *[optional]*

Take a look at tests in the `integration::cancellation` module.

### Alternate Designs *[optional]*

1. Use an HTTP library that has an API to cancel requests. And replace `attohttpc` with it.
2. Make `DefaultRequestBuilder` (from http_default.rs) an asynchronous and use any async-runtime. It will be more efficient and will consume less memory, but it demands an async runtime on the client side and adds significant API changes.
3. We can also improve the current solution by using a thread pool. Need more research.
