### PR TITLE
[feature] #3116: Add sorting of any values (not only u128)

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -777,6 +777,47 @@ impl Client {
         )
     }
 
+    /// Create a request with sorting and the given filter.
+    ///
+    /// # Errors
+    /// Fails if sending request fails
+    pub fn request_with_sorting_and_filter<R>(
+        &self,
+        request: R,
+        sorting: Sorting,
+        filter: PredicateBox,
+    ) -> QueryHandlerResult<ClientQueryOutput<R>>
+    where
+        R: Query + Into<QueryBox> + Debug,
+        <R::Output as TryFrom<Value>>::Error: Into<eyre::Error>, // Seems redundant
+    {
+        self.request_with_pagination_and_filter_and_sorting(
+            request,
+            Pagination::default(),
+            sorting,
+            filter,
+        )
+    }
+
+    /// Query API entry point. Requests quieries from `Iroha` peers with filter.
+    ///
+    /// Uses default blocking http-client. If you need some custom integration, look at
+    /// [`Self::prepare_query_request`].
+    ///
+    /// # Errors
+    /// Fails if sending request fails
+    pub fn request_with_filter<R>(
+        &self,
+        request: R,
+        filter: PredicateBox,
+    ) -> QueryHandlerResult<ClientQueryOutput<R>>
+    where
+        R: Query + Into<QueryBox> + Debug,
+        <R::Output as TryFrom<Value>>::Error: Into<eyre::Error>,
+    {
+        self.request_with_pagination_and_filter(request, Pagination::default(), filter)
+    }
+
     /// Query API entry point. Requests queries from `Iroha` peers with pagination.
     ///
     /// Uses default blocking http-client. If you need some custom integration, look at


### PR DESCRIPTION
Signed-off-by: Vladimir Pesterev <pesterev@pm.me>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Now we can sort by any values from metadata. Not only by u128. Also, this sorting implementation places all elements that cannot be sorted at the head of a result list. 

### Issue

Resolves #3116 

### Benefits

Better sorting feature.

### Possible Drawbacks

None

### Usage Examples or Tests *[optional]*

Take a look at tests in these changes.

### Alternate Designs *[optional]*

Another design is to remove all elements that we can't sort.

<!--
NOTE: User may want skip pull request and push workflows with [skip ci]
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
Phrases: [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]
-->
