### PR TITLE
[ci] #2577, #2606: Make CI independent from 7272721/i2-ci & Push i2-d…

### DIFF
--- a/.github/workflows/iroha2-ci-image.yml
+++ b/.github/workflows/iroha2-ci-image.yml
@@ -1,24 +1,22 @@
-name: I2::Dev::Nightly::Publish
+name: I2::CI::Publish
 
 on: workflow_dispatch
 
 jobs:
   dockerhub:
     runs-on: ubuntu-latest
-    container:
-      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push iroha2:dev-nightly image
+      - name: Build and push iroha2-ci image
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: hyperledger/iroha2:dev-nightly-${{ github.sha }}
+          tags: hyperledger/iroha2-ci:nightly-2022-12-22
           labels: commit=${{ github.sha }}
-          build-args: TAG=dev
+          file: Dockerfile.build
           # This context specification is required
           context: .

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -23,7 +23,7 @@ jobs:
   analysis:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-dev-pr-ui.yml
+++ b/.github/workflows/iroha2-dev-pr-ui.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -26,7 +26,7 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -43,7 +43,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -23,7 +23,7 @@ jobs:
   check:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -50,7 +50,7 @@ jobs:
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       # TODO Remove this step #2165
@@ -78,7 +78,7 @@ jobs:
   integration:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
   unstable:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -3,11 +3,10 @@ name: I2::Dev::Publish
 on:
   push:
     branches: [iroha2-dev]
-    # Run the workflow to check that the docker containers are properly buildable
-  pull_request:
-    branches: [iroha2-dev]
-    paths:
-      - '.github/workflows/**.yml'
+  # Run the workflow to check that the docker containers are properly buildable
+  workflow_run:
+    workflows: [I2::Dev::Tests]
+    types: [requested]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,10 +15,10 @@ env:
 # no point in burning our AWS self-hosted runners' time. Hence
 # `ubuntu-latest` and not `[self-hosted, Linux]`.
 jobs:
-  dockerhub:
+  registry:
     runs-on: [self-hosted, Linux, iroha2-dev-push]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: docker/login-action@v2
@@ -39,7 +38,7 @@ jobs:
         with:
           install: true
       - name: Build and push iroha2:dev image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         if: always()
         with:
           push: true
@@ -58,7 +57,7 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - name: Build and push docker image (load-rs:dev)
         run: |
@@ -75,7 +74,7 @@ jobs:
   archive_binaries_and_schema:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -111,7 +110,7 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -15,7 +15,7 @@ jobs:
   cli:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -44,7 +44,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -56,15 +56,15 @@ jobs:
   java-api:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 1.11
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -101,7 +101,7 @@ jobs:
   long:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - name: Run long tests

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -11,7 +11,7 @@ jobs:
   registry:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
@@ -37,7 +37,7 @@ jobs:
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
       - name: Build and push iroha2 image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |
@@ -55,7 +55,7 @@ jobs:
   load-rs:
     runs-on: ubuntu-latest
     container:
-      image: 7272721/i2-ci:nightly
+      image: hyperledger/iroha2-ci:nightly-2022-12-22
     steps:
       - name: Get tag from branch name
         run: |


### PR DESCRIPTION
### Description of the Change
1. Create a workflow to build and push `iroha2-ci:nightly-<>` image.
2. In `I2::Dev::Publish` substitute `on pull_request` trigger by `on workflow_run` trigger that allows to share Actions Secrets to push dev images before base branch merging.
3. Update some Actions versions.

### Issue
1. #2577  
2. #2606 

### Benefits
1. Covers #2577 issue.
2. Covers #2606 issue.

### Possible Drawbacks
We have to build and push `iroha2-ci:nightly-<>` image before to apply changes to `container: image` value. 
