### PR TITLE
[feature] #3105: Implement Transfer for AssetDefinition

### DIFF
--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -86,6 +86,22 @@ pub mod isi {
         }
     }
 
+    impl Execute for Transfer<Account, AssetDefinition, Account> {
+        type Error = Error;
+
+        fn execute(self, _authority: AccountId, wsv: &WorldStateView) -> Result<(), Self::Error> {
+            wsv.modify_asset_definition_entry(self.object.id(), |entry| {
+                entry.set_owner(self.destination_id.clone());
+                Ok(AssetDefinitionEvent::OwnerChanged(
+                    AssetDefinitionOwnerChanged {
+                        asset_definition_id: self.object.id().clone(),
+                        new_owner: self.destination_id,
+                    },
+                ))
+            })
+        }
+    }
+
     macro_rules! impl_mint {
         ($ty:ty, $metrics:literal) => {
             impl InnerMint for $ty {}

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -76,8 +76,8 @@ declare_item! {
         /// Asset definition.
         #[cfg_attr(feature = "mutable_api", getset(get_mut = "pub"))]
         definition: AssetDefinition,
-        /// The account that registered this asset.
-        registered_by: <Account as Identifiable>::Id,
+        /// The account that owns this asset definition.
+        owned_by: <Account as Identifiable>::Id,
     }
 }
 
@@ -102,13 +102,10 @@ impl Ord for AssetDefinitionEntry {
 #[cfg_attr(feature = "ffi_import", iroha_ffi::ffi_import)]
 impl AssetDefinitionEntry {
     /// Constructor.
-    pub const fn new(
-        definition: AssetDefinition,
-        registered_by: <Account as Identifiable>::Id,
-    ) -> Self {
+    pub const fn new(definition: AssetDefinition, owned_by: <Account as Identifiable>::Id) -> Self {
         Self {
             definition,
-            registered_by,
+            owned_by,
         }
     }
 }
@@ -121,6 +118,11 @@ impl AssetDefinitionEntry {
     /// If the asset was declared as `Mintable::Infinitely`
     pub fn forbid_minting(&mut self) -> Result<(), MintabilityError> {
         self.definition.forbid_minting()
+    }
+
+    /// Change owner for this asset definition.
+    pub fn set_owner(&mut self, new_owner: <Account as Identifiable>::Id) {
+        self.owned_by = new_owner
     }
 }
 

--- a/data_model/src/domain.rs
+++ b/data_model/src/domain.rs
@@ -311,9 +311,9 @@ impl Domain {
     pub fn add_asset_definition(
         &mut self,
         asset_definition: AssetDefinition,
-        registered_by: <Account as Identifiable>::Id,
+        owned_by: <Account as Identifiable>::Id,
     ) -> Option<AssetDefinitionEntry> {
-        let asset_definition = AssetDefinitionEntry::new(asset_definition, registered_by);
+        let asset_definition = AssetDefinitionEntry::new(asset_definition, owned_by);
 
         self.asset_definitions
             .insert(asset_definition.definition().id().clone(), asset_definition)

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -94,6 +94,8 @@ mod asset {
         #[has_origin(asset_definition => asset_definition.id())]
         Created(NewAssetDefinition),
         MintabilityChanged(AssetDefinitionId),
+        #[has_origin(ownership_changed => &ownership_changed.asset_definition_id)]
+        OwnerChanged(AssetDefinitionOwnerChanged),
         Deleted(AssetDefinitionId),
         #[has_origin(metadata_changed => &metadata_changed.target_id)]
         MetadataInserted(AssetDefinitionMetadataChanged),
@@ -143,6 +145,28 @@ mod asset {
     pub struct AssetDefinitionTotalQuantityChanged {
         pub asset_definition_id: AssetDefinitionId,
         pub total_amount: NumericValue,
+    }
+
+    /// [`Self`] represents updated asset definition ownership.
+    #[derive(
+        Clone,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Hash,
+        Debug,
+        Decode,
+        Encode,
+        Deserialize,
+        Serialize,
+        IntoSchema,
+    )]
+    pub struct AssetDefinitionOwnerChanged {
+        /// Id of asset definition being updated
+        pub asset_definition_id: AssetDefinitionId,
+        /// Id of new owning account
+        pub new_owner: <Account as Identifiable>::Id,
     }
 }
 
@@ -656,7 +680,8 @@ pub mod prelude {
         },
         asset::{
             AssetChanged, AssetDefinitionEvent, AssetDefinitionEventFilter, AssetDefinitionFilter,
-            AssetDefinitionTotalQuantityChanged, AssetEvent, AssetEventFilter, AssetFilter,
+            AssetDefinitionOwnerChanged, AssetDefinitionTotalQuantityChanged, AssetEvent,
+            AssetEventFilter, AssetFilter,
         },
         config::ConfigurationEvent,
         domain::{DomainEvent, DomainEventFilter, DomainFilter},

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -1246,7 +1246,7 @@
           "ty": "iroha_data_model::asset::AssetDefinition"
         },
         {
-          "name": "registered_by",
+          "name": "owned_by",
           "ty": "iroha_data_model::account::Id"
         }
       ]
@@ -1904,23 +1904,28 @@
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "Deleted",
+          "name": "OwnerChanged",
           "discriminant": 2,
+          "ty": "iroha_data_model::events::data::events::asset::AssetDefinitionOwnerChanged"
+        },
+        {
+          "name": "Deleted",
+          "discriminant": 3,
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
           "name": "MetadataInserted",
-          "discriminant": 3,
-          "ty": "iroha_data_model::events::data::events::MetadataChanged<iroha_data_model::asset::DefinitionId>"
-        },
-        {
-          "name": "MetadataRemoved",
           "discriminant": 4,
           "ty": "iroha_data_model::events::data::events::MetadataChanged<iroha_data_model::asset::DefinitionId>"
         },
         {
-          "name": "TotalQuantityChanged",
+          "name": "MetadataRemoved",
           "discriminant": 5,
+          "ty": "iroha_data_model::events::data::events::MetadataChanged<iroha_data_model::asset::DefinitionId>"
+        },
+        {
+          "name": "TotalQuantityChanged",
+          "discriminant": 6,
           "ty": "iroha_data_model::events::data::events::asset::AssetDefinitionTotalQuantityChanged"
         }
       ]
@@ -1940,23 +1945,28 @@
           "ty": null
         },
         {
-          "name": "ByDeleted",
+          "name": "ByOwnerChanged",
           "discriminant": 2,
           "ty": null
         },
         {
-          "name": "ByMetadataInserted",
+          "name": "ByDeleted",
           "discriminant": 3,
           "ty": null
         },
         {
-          "name": "ByMetadataRemoved",
+          "name": "ByMetadataInserted",
           "discriminant": 4,
           "ty": null
         },
         {
-          "name": "ByTotalQuantityChanged",
+          "name": "ByMetadataRemoved",
           "discriminant": 5,
+          "ty": null
+        },
+        {
+          "name": "ByTotalQuantityChanged",
+          "discriminant": 6,
           "ty": null
         }
       ]
@@ -1972,6 +1982,20 @@
         {
           "name": "event_filter",
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::events::asset::AssetDefinitionEventFilter>"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::events::data::events::asset::AssetDefinitionOwnerChanged": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "asset_definition_id",
+          "ty": "iroha_data_model::asset::DefinitionId"
+        },
+        {
+          "name": "new_owner",
+          "ty": "iroha_data_model::account::Id"
         }
       ]
     }

--- a/permissions_validators/src/public_blockchain/key_value.rs
+++ b/permissions_validators/src/public_blockchain/key_value.rs
@@ -403,7 +403,7 @@ impl IsGrantAllowed for GrantMyAssetDefinitionSet {
 }
 
 // Validator that checks Grant instruction so that the access is granted to the assets defintion
-/// registered by signer account.
+/// owned by signer account.
 #[derive(Debug, Display, Copy, Clone, Serialize)]
 #[display(fmt = "the signer is the asset creator")]
 pub struct GrantMyAssetDefinitionRemove;
@@ -421,7 +421,7 @@ impl IsGrantAllowed for GrantMyAssetDefinitionRemove {
     }
 }
 
-/// Checks that account can set keys for asset definitions only registered by the signer account.
+/// Checks that account can set keys for asset definitions only owned by the signer account.
 #[derive(Debug, Display, Copy, Clone, Serialize)]
 #[display(fmt = "Allow only the asset creator to set asset definition metadata keys")]
 pub struct AssetDefinitionSetOnlyForSignerAccount;
@@ -442,21 +442,20 @@ impl IsAllowed for AssetDefinitionSetOnlyForSignerAccount {
         let object_id: AssetDefinitionId =
             ok_or_skip!(try_evaluate_or_deny!(set_kv_box.object_id, wsv).try_into());
 
-        let registered_by_signer_account = wsv
+        let owned_by_signer_account = wsv
             .asset_definition_entry(&object_id)
-            .map(|asset_definition_entry| asset_definition_entry.registered_by() == authority)
+            .map(|asset_definition_entry| asset_definition_entry.owned_by() == authority)
             .unwrap_or(false);
-        if !registered_by_signer_account {
+        if !owned_by_signer_account {
             return Deny(
-                "Cannot set key values to asset definitions registered by other accounts"
-                    .to_owned(),
+                "Cannot set key values to asset definitions owned by other accounts".to_owned(),
             );
         }
         Allow
     }
 }
 
-/// Checks that account can set keys for asset definitions only registered by the signer account.
+/// Checks that account can set keys for asset definitions only owned by the signer account.
 #[derive(Debug, Display, Copy, Clone, Serialize)]
 #[display(fmt = "Allow only the asset creator to remove asset definition metadata keys")]
 pub struct AssetDefinitionRemoveOnlyForSignerAccount;
@@ -477,13 +476,13 @@ impl IsAllowed for AssetDefinitionRemoveOnlyForSignerAccount {
         let object_id: AssetDefinitionId =
             ok_or_skip!(try_evaluate_or_deny!(rem_kv_box.object_id, wsv).try_into());
 
-        let registered_by_signer_account = wsv
+        let owned_by_signer_account = wsv
             .asset_definition_entry(&object_id)
-            .map(|asset_definition_entry| asset_definition_entry.registered_by() == authority)
+            .map(|asset_definition_entry| asset_definition_entry.owned_by() == authority)
             .unwrap_or(false);
-        if !registered_by_signer_account {
+        if !owned_by_signer_account {
             return Deny(
-                "Cannot remove key values from asset definitions registered by other accounts"
+                "Cannot remove key values from asset definitions owned by other accounts"
                     .to_owned(),
             );
         }

--- a/permissions_validators/src/public_blockchain/mint.rs
+++ b/permissions_validators/src/public_blockchain/mint.rs
@@ -12,7 +12,7 @@ declare_token!(
     "can_mint_user_asset_definitions"
 );
 
-/// Checks that account can mint only the assets which were registered by this account.
+/// Checks that account can mint only the assets which were owned by this account.
 #[derive(Debug, Display, Copy, Clone, Serialize)]
 #[display(fmt = "Allow to mint only the assets created by the signer")]
 pub struct OnlyAssetsCreatedByThisAccount;
@@ -35,10 +35,10 @@ impl IsAllowed for OnlyAssetsCreatedByThisAccount {
                             .map_or_else(
                                 |err| Deny(err.to_string()),
                                 |asset_definition_entry| {
-                                if asset_definition_entry.registered_by() == authority {
+                                if asset_definition_entry.owned_by() == authority {
                                     Allow
                                 } else {
-                                    Deny("Can't register assets with definitions registered by other accounts.".to_owned()) }
+                                    Deny("Can't register assets with definitions owned by other accounts.".to_owned()) }
                                 }
                             )
                     }
@@ -53,11 +53,11 @@ impl IsAllowed for OnlyAssetsCreatedByThisAccount {
                     .map_or_else(
                         |err| Deny(err.to_string()),
                         |asset_definition_entry| {
-                            if asset_definition_entry.registered_by() == authority {
+                            if asset_definition_entry.owned_by() == authority {
                                 Allow
                             } else {
                                 Deny(
-                                    "Can't mint assets with definitions registered by other accounts."
+                                    "Can't mint assets with definitions owned by other accounts."
                                         .to_owned(),
                                 )
                             }

--- a/permissions_validators/src/public_blockchain/mod.rs
+++ b/permissions_validators/src/public_blockchain/mod.rs
@@ -173,12 +173,12 @@ pub fn check_asset_creator_for_asset_definition(
     authority: &AccountId,
     wsv: &WorldStateView,
 ) -> ValidatorVerdict {
-    let registered_by_signer_account = wsv
+    let owned_by_signer_account = wsv
         .asset_definition_entry(definition_id)
-        .map(|asset_definition_entry| asset_definition_entry.registered_by() == authority)
+        .map(|asset_definition_entry| asset_definition_entry.owned_by() == authority)
         .unwrap_or(false);
-    if !registered_by_signer_account {
-        return Deny("Cannot grant access for assets registered by another account.".to_owned());
+    if !owned_by_signer_account {
+        return Deny("Cannot grant access for assets owned by another account.".to_owned());
     }
     Allow
 }

--- a/permissions_validators/src/public_blockchain/unregister.rs
+++ b/permissions_validators/src/public_blockchain/unregister.rs
@@ -13,7 +13,7 @@ declare_token!(
 );
 
 /// Checks that account can un-register only the assets which were
-/// registered by this account in the first place.
+/// owned by this account in the first place.
 #[derive(Debug, Display, Copy, Clone, Serialize)]
 #[display(fmt = "Allow to unregister only the assets created by the signer")]
 pub struct OnlyAssetsCreatedByThisAccount;
@@ -33,12 +33,12 @@ impl IsAllowed for OnlyAssetsCreatedByThisAccount {
 
         let object_id = try_evaluate_or_deny!(unregister_box.object_id, wsv);
         let asset_definition_id: AssetDefinitionId = ok_or_skip!(object_id.try_into());
-        let registered_by_signer_account = wsv
+        let owned_by_signer_account = wsv
             .asset_definition_entry(&asset_definition_id)
-            .map(|asset_definition_entry| asset_definition_entry.registered_by() == authority)
+            .map(|asset_definition_entry| asset_definition_entry.owned_by() == authority)
             .unwrap_or(false);
-        if !registered_by_signer_account {
-            return Deny("Cannot unregister assets registered by other accounts.".to_owned());
+        if !owned_by_signer_account {
+            return Deny("Cannot unregister assets owned by other accounts.".to_owned());
         }
         Allow
     }

--- a/tools/parity_scale_decoder/src/generate_map.rs
+++ b/tools/parity_scale_decoder/src/generate_map.rs
@@ -76,6 +76,7 @@ pub fn generate_map() -> DumpDecodedMap {
         AssetDefinitionEventFilter,
         AssetDefinitionFilter,
         AssetDefinitionId,
+        AssetDefinitionOwnerChanged,
         AssetDefinitionTotalQuantityChanged,
         AssetEvent,
         AssetEventFilter,


### PR DESCRIPTION
### Description of the Change

- Implement Transfer for AssetDefinition
- Change terminology from asset registrar to asset owner

Split into two commits for reviewing/discarding convenience.

### Issue

#3105 

### Benefits

Genesis transactions can assign asset ownership to accounts other than genesis.
Probably could be useful in other use-cases.

### Possible Drawbacks

AIUI none.
