### PR TITLE
[ci]: Fix I2::Dev::Publish workflow

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -1,12 +1,15 @@
 name: I2::Dev::Publish
+permissions:
+  pull-requests: read
 
 on:
   push:
     branches: [iroha2-dev]
   # Run the workflow to check that the docker containers are properly buildable
-  workflow_run:
-    workflows: [I2::Dev::Tests]
-    types: [requested]
+  pull_request:
+    branches: [iroha2-dev]
+    paths:
+      - '.github/workflows/**.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### Description of the Change

1. Come back to `pull_request` trigger in `I2::Dev::Publish` to build `iroha2-dev` before merge.
2. Increase `I2::Dev::Publish` workflow permission to read secrets.

### Issue
1. The problem is that workflow with `workflow_run` trigger could be run only if it belongs to the default branch. Currently the default branch is `main.` To keep this workflow file in `main` branch is not really solves this issue.
2. `pull_request` trigger doesn't allow to share secrets.

### Benefits
Should solve the mentioned issues above.


### Possible Drawbacks
Probably this workflow permission specification could be not enough.
