### PR TITLE
[ci]: Add Jenkinsfile for i2-PR-image k8s deployment generator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+@Library('jenkins-library') _
+
+def pipeline = new org.iroha2.AppPipeline(steps: this,
+    k8sPrDeploy: true,
+    vaultPrPath: "argocd-cc/src/charts/iroha2/environments/tachi/",
+    vaultUser: "iroha2-ro",
+    vaultCredId: "iroha2VaultCreds",
+    valuesDestPath: "argocd-cc/src/charts/iroha2/",
+    devValuesPath: "dev/test/"
+)
+pipeline.runPipeline()


### PR DESCRIPTION
### Description of the Change
Add `Jenkinsfile` to connect iroha2 CI `iroha2:pr` building with this image Kubernetes deployment from Soramitsu private Jenkins library.

### Issue
Sometimes we need to have an opportunity to deploy iroha2 image from Pull Request branch before merging to the base branch to confirm that it's workable.


### Benefits
For the particular PRs we will able to deploy this PR-image on the fly and quickly test it if it works as expected.

### Usage
1. It will work only if the PR comes from branch inside `hyperledger/iroha` repository. Work with PRs from forks is impossible.
2. To run this job trigger, you should add `experimental_environment` label to your PR.

### Possible Drawbacks
Actually nothing from GH Actions iroha2 CI process. Only outside PR-deployment Jenkins job could not work.
