### PR TITLE
[ci]: Use pull_request_target trigger for I2::Dev::Publish workflow

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -1,12 +1,10 @@
 name: I2::Dev::Publish
-permissions:
-  pull-requests: read
 
 on:
   push:
     branches: [iroha2-dev]
   # Run the workflow to check that the docker containers are properly buildable
-  pull_request:
+  pull_request_target:
     branches: [iroha2-dev]
     paths:
       - '.github/workflows/**.yml'


### PR DESCRIPTION
### Description of the Change
1. Change `I2::Dev::Publish` workflow trigger from `pull_request` to `pull_request_target`.
2. Remove unnecessary workflow permissions.

### Issue
`permissions: pull-requests: read` probably won't help to share the secret. `write` permission for PR will not work according to the GH Actions documentation. `on: workflow_run` trigger could be used, but this trigger only works on the default branch, which iroha2-dev is not. And if we put it in the default `main` branch, then the context is read from there.

### Benefits
Make "workflow to check that the docker containers are properly buildable" to be working.

### Possible Drawbacks
`pull_request_target` trigger is not so safe and base-repository permissions limited. It allows to have much more permissions for forks. But we have the policy about outside collaborators PRs limitation, so this should mitigate the potential risks of using this workflow trigger.