### PR TITLE
BACKPORT [fix] #3330: Fix `untagged` enum de-serialization with `u128` leaves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,23 +154,24 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -181,7 +182,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -516,7 +517,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -949,7 +950,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -960,7 +961,7 @@ checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -994,7 +995,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1135,7 +1136,7 @@ checksum = "b13f1e69590421890f90448c3cd5f554746a31adc6dc0dac406ec6901db8dc25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1146,7 +1147,7 @@ checksum = "4e40a16955681d469ab3da85aaa6b42ff656b3c67b52e1d8d3dd36afe97fd462"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1211,7 +1212,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -1373,7 +1374,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1477,7 +1478,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1748,7 +1749,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1853,7 +1854,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -1863,7 +1864,7 @@ version = "2.0.0-pre-rc.9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "warp",
 ]
 
@@ -1956,7 +1957,7 @@ version = "2.0.0-pre-rc.9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2059,7 +2060,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2069,7 +2070,7 @@ dependencies = [
  "iroha_macro",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -2091,7 +2092,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -2116,7 +2117,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2215,7 +2216,7 @@ dependencies = [
  "iroha_schema",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -2265,7 +2266,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -2297,7 +2298,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "trybuild",
 ]
 
@@ -2690,7 +2691,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2757,7 +2758,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2841,7 +2842,7 @@ checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2947,7 +2948,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2964,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -3002,9 +3003,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3406,9 +3407,9 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -3434,20 +3435,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -3485,7 +3486,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3511,7 +3512,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3703,7 +3704,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3723,9 +3724,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3740,7 +3752,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -3842,7 +3854,7 @@ checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3930,7 +3942,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4033,7 +4045,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4461,7 +4473,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -4483,7 +4495,7 @@ checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4845,7 +4857,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,8 +56,8 @@ color-eyre = "0.6.2"
 eyre = "0.6.8"
 futures = { version = "0.3.21", default-features = false, features = ["std", "async-await"] }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
-serde = { version = "1.0.142", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 thiserror = "1.0.32"
 tokio = { version = "1.20.1", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs", "signal"] }
 warp = "0.3.2"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -30,8 +30,8 @@ attohttpc = "0.18.0"
 eyre = "0.6.8"
 http = "0.2.8"
 rand = "0.8.5"
-serde = { version = "1.0.142", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 tungstenite = { version = "0.16", features = ["native-tls"] }
 base64 = "0.13.0"
 thiserror = "1.0.32"

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -25,7 +25,7 @@ iroha_config = { version = "=2.0.0-pre-rc.9", path = "../config" }
 color-eyre = "0.6.2"
 clap = { version = "3.2.16", features = ["derive"] }
 dialoguer = { version = "0.10.2", default-features = false }
-serde_json = "1.0.83"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 
 [build-dependencies]
 anyhow = "1.0.60"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,8 +14,8 @@ tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", default-features = false, features = ["fmt", "ansi"] }
 url = { version = "2.2.2", features = ["serde"] }
 
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 thiserror = "1.0.32"
 crossbeam = "0.8.2"
 derive_more = "0.99.17"

--- a/config/base/Cargo.toml
+++ b/config/base/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 iroha_config_derive = { path = "derive" }
 
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 thiserror = "1.0.32"
 crossbeam = "0.8.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,8 +53,8 @@ eyre = "0.6.8"
 futures = { version = "0.3.21", default-features = false, features = ["std", "async-await"] }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 rand = "0.8.5"
-serde = { version = "1.0.142", features = ["derive"] }
-serde_json = "1.0.83"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 tokio = { version = "1.20.1", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"] }
 crossbeam-queue = "0.3.6"
 thiserror = "1.0.32"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -26,7 +26,7 @@ iroha_schema = { path = "../schema" }
 
 derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut", "display"] }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive", "full"] }
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 openssl-sys = { version = "0.9.75", features = ["vendored"], optional = true }
 ursa = { version = "0.3.7", optional = true }
@@ -34,4 +34,4 @@ getset = "0.1.2"
 
 [dev-dependencies]
 hex-literal = "0.3.4"
-serde_json = "1.0.83"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -43,8 +43,8 @@ dashmap = { version = "5.3.4", optional = true }
 tokio = { version = "1.20.1", features = ["sync", "rt-multi-thread"], optional = true }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "display", "constructor", "from_str", "from", "into"] }
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.83", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0.95", default-features = false, features = ["arbitrary_precision"] }
 serde_with = {version = "2.0.1", default-features = false, features = ["macros"]}
 warp = { version = "0.3.2", default-features = false, optional = true }
 thiserror = { version = "1.0.32", optional = true }

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro-error = "1.0.4"
 iroha_data_model = { version = "=2.0.0-pre-rc.9", path = "../" }
 iroha_schema = { version = "=2.0.0-pre-rc.9", path = "../../schema" }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }

--- a/data_model/src/expression.rs
+++ b/data_model/src/expression.rs
@@ -20,7 +20,7 @@ use iroha_macro::FromVariant;
 use iroha_schema::prelude::*;
 use operation::*;
 use parity_scale_codec::{Decode, Encode};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error};
 
 use super::{query::QueryBox, Value, ValueBox};
 
@@ -490,30 +490,61 @@ impl<T: Into<Value>> From<T> for ExpressionBox {
     }
 }
 
-/// Deserialize [`Expression`] with possibility to omit [`Raw`](Expression::Raw) tag
-/// as it is the most popular variant.
-///
-/// First will try to deserialize as `Raw` and if it fails will try to deserialize as `Expression`.
+/// Allow deserializing expression by first assuming it's an
+/// [`Expression::Raw`], and only then checking for an explicit tag.
+
 impl<'de> Deserialize<'de> for Expression {
     fn deserialize<D>(deserializer: D) -> Result<Expression, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        #[allow(variant_size_differences)]
-        enum ExpressionDeserializeWrapper {
-            Raw(ValueBox),
-            Expression(serde_internal_repr::Expression),
-        }
+        where
+            D: serde::Deserializer<'de>,
+        {
+            // DO NOT DERIVE DESERIALIZE.  Because some formats have
+            // an opt-in support for `u128`, only a manual
+            // implementation of re-entrant deserialization does what
+            // you expect it to do. Specifically
+            // `serde::de::_private::ContentRefDeserializer` which is
+            // not private contrary to all other indications, does not
+            // have the `u128` variant and is being used for un-tagged
+            // `enum` de-serialization.
 
-        let wrapper = ExpressionDeserializeWrapper::deserialize(deserializer)?;
-        match wrapper {
-            ExpressionDeserializeWrapper::Expression(expression) => Ok(expression.into()),
-            ExpressionDeserializeWrapper::Raw(raw) => Ok(Expression::Raw(raw)),
+            // This is a `serde` design oversight, but not a bug. 
+            #[allow(variant_size_differences)]
+            enum ExpressionDeserializeWrapper {
+                Raw(ValueBox),
+                Expression(serde_internal_repr::Expression),
+            }
+
+            impl<'de> serde::Deserialize<'de> for ExpressionDeserializeWrapper {
+                fn deserialize<D>(deserializer: D) -> serde::__private::Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
+                    let buffer = serde_json::value::Value::deserialize(deserializer)?;
+
+                    let e1 = match ValueBox::deserialize(buffer.clone())
+                        .map(ExpressionDeserializeWrapper::Raw)
+                    {
+                        Ok(raw_candidate) => return Ok(raw_candidate),
+                        Err(er) => D::Error::custom(er.to_string()),
+                    };
+                    let e2 = match serde_internal_repr::Expression::deserialize(buffer) {
+                        Ok(wrapper) => return Ok(Self::Expression(wrapper)),
+                        Err(e) => D::Error::custom(e.to_string()),
+                    };
+                    Err(
+                        serde::de::Error::custom(format!("Could not parse input as `Expression`.\nRaw expression failed: {e1}.\nExtended expression failed: {e2}"),
+                        ),
+                    )
+                }
+            }
+            let wrapper = ExpressionDeserializeWrapper::deserialize(deserializer)?;
+            match wrapper {
+                ExpressionDeserializeWrapper::Expression(expression) => Ok(expression.into()),
+                ExpressionDeserializeWrapper::Raw(raw) => Ok(Expression::Raw(raw)),
+            }
         }
-    }
 }
+
 
 /// Serialize [`Expression`] omitting tag if `self` is [`Raw`](Expression::Raw) variant
 impl Serialize for Expression {
@@ -527,6 +558,8 @@ impl Serialize for Expression {
             Raw(&'expr ValueBox),
             Expression(&'expr Expression),
         }
+        // This is fine, as evidenced by kagami producing the right
+        // type in the output.
 
         match self {
             Expression::Raw(raw) => ExpressionSerializeWrapper::Raw(raw).serialize(serializer),

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -519,6 +519,35 @@ pub enum Value {
     Ipv6Addr(iroha_primitives::addr::Ipv6Addr),
 }
 
+#[cfg(test)]
+mod test {
+    use isi::RegisterBox;
+
+    use super::*;
+    use crate::domain::NewDomain;
+
+    #[test]
+    fn deserialize_u128() {
+        serde_json::from_str::<RegisterBox>(
+            "
+           {
+            \"Identifiable\": {
+              \"NewDomain\": {
+                \"id\": \"wonderland\",
+                \"logo\": null,
+                \"metadata\": {
+                  \"key\": {
+                     \"U128\": 1
+                  }
+                }
+              }
+            }
+          }",
+        )
+        .expect("Valid");
+    }
+}
+
 #[cfg(not(target_arch = "aarch64"))]
 ffi::declare_item! {
     /// Cross-platform wrapper for `BlockValue`.

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -17,8 +17,8 @@ iroha_futures_derive = { version = "=2.0.0-pre-rc.9", path = "derive" }
 iroha_logger = { version = "=2.0.0-pre-rc.9", path = "../logger" }
 
 rand = "0.8.5"
-serde_json = "1.0.83"
-serde = { version = "1.0.142", features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
+serde = { version = "1.0.159", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 iroha_config = { version = "=2.0.0-pre-rc.9", path = "../config" }
 
 color-eyre = "0.6.2"
-serde_json = "1.0.83"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 tracing = "0.1.36"
 tracing-core = "0.1.29"
 tracing-futures = { version = "0.2.5", default-features = false, features = ["std-future", "std"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,7 +21,7 @@ iroha_data_model_derive = { version = "=2.0.0-pre-rc.9", path = "../data_model/d
 
 rand = "0.8.5"
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
-async-stream = "0.3.3"
+async-stream = "0.3.4"
 futures = { version = "0.3.21", default-features = false }
 async-trait = "0.1.57"
 parity-scale-codec = { version = "3.1.5", features = ["derive"] }

--- a/permissions_validators/Cargo.toml
+++ b/permissions_validators/Cargo.toml
@@ -12,7 +12,7 @@ iroha_data_model = { version = "=2.0.0-pre-rc.9", path = "../data_model", defaul
 iroha_macro = { version = "=2.0.0-pre-rc.9", path = "../macro" }
 iroha_schema = { version = "=2.0.0-pre-rc.9", path = "../schema" }
 
-serde = { version = "1.0.142", features = ["derive"] }
+serde = { version = "1.0.159", features = ["derive"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 once_cell = "1.13.0"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -35,12 +35,12 @@ iroha_ffi = { path = "../ffi", version = "=2.0.0-pre-rc.9" }
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
 fixnum = { version = "0.8.0", default-features = false, features = ["serde", "parity", "i64"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "as_ref", "as_mut", "deref", "constructor"] }
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 smallvec = { version = "1.9.0", default-features = false, features = ["serde", "union"] }
 smallstr = { version = "0.3.0", default-features = false, features = ["serde", "union"] }
 thiserror = { version = "1.0.32", optional = true }
 
 
 [dev-dependencies]
-serde_json = { version = "1.0.83", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.95", default-features = false, features = ["alloc", "arbitrary_precision"] }
 trybuild = "1.0.64"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 iroha_schema_derive = { version = "=2.0.0-pre-rc.9", path = "derive" }
 
-serde = { version = "1.0.142", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.159", default-features = false, features = ["derive", "alloc"] }
 fixnum = { version = "0.8.0", default-features = false, features = ["i64"] }
 
 [dev-dependencies]

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -23,9 +23,9 @@ async-trait = "0.1.57"
 chrono = "0.4.22"
 eyre = "0.6.8"
 futures = { version = "0.3.21", default-features = false, features = ["std", "async-await"] }
-serde_json = "1.0.83"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
 streaming-stats = "0.2.3"
-serde = { version = "1.0.142", features = ["derive"] }
+serde = { version = "1.0.159", features = ["derive"] }
 tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.9", features = ["fs"] }
 tokio-tungstenite = "0.17.2"

--- a/tools/kagami/Cargo.toml
+++ b/tools/kagami/Cargo.toml
@@ -36,4 +36,4 @@ iroha_primitives = { version = "2.0.0-pre-rc.9", path = "../../primitives" }
 
 color-eyre = "0.6.2"
 clap = { version = "3.2.16", features = ["derive"] }
-serde_json = "1.0.83"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }

--- a/tools/parity_scale_decoder/Cargo.toml
+++ b/tools/parity_scale_decoder/Cargo.toml
@@ -29,5 +29,5 @@ iroha_schema_gen = { version = "=2.0.0-pre-rc.9", path = "../../schema/gen"}
 [build-dependencies]
 iroha_data_model = { version = "=2.0.0-pre-rc.9", path = "../../data_model", features = ["warp", "mutable_api"]}
 parity-scale-codec = { version = "3.1.5", default-features = false }
-serde_json = "1.0.83"
-serde = "1.0.142"
+serde_json = { version = "1.0.95", features = ["arbitrary_precision"] }
+serde = "1.0.159"

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -24,8 +24,8 @@ iroha_macro = { version = "=2.0.0-pre-rc.9", path = "../macro", default-features
 iroha_schema = { version = "=2.0.0-pre-rc.9", path = "../schema", default-features = false }
 
 parity-scale-codec = { version = "3.1.5", default-features = false, optional = true, features = ["derive"] }
-serde_json = { version = "1.0.83", default-features = false, optional = true, features = ["alloc"] }
-serde = { version = "1.0.142", default-features = false, optional = true, features = ["derive"] }
+serde_json = { version = "1.0.95", default-features = false, optional = true, features = ["alloc", "arbitrary_precision"] }
+serde = { version = "1.0.159", default-features = false, optional = true, features = ["derive"] }
 thiserror = { version = "1.0.32", default-features = false, optional = true }
 warp = { version = "0.3.2", default-features = false, optional = true }
 

--- a/version/derive/Cargo.toml
+++ b/version/derive/Cargo.toml
@@ -20,7 +20,7 @@ iroha_version = { version = "=2.0.0-pre-rc.9", path = "..", features = ["scale",
 iroha_macro = { version = "=2.0.0-pre-rc.9", path = "../../macro" }
 
 parity-scale-codec = { version = "3.1.5", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.83", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.142", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.95", features = ["alloc", "arbitrary_precision"] }
+serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 
 trybuild = "1.0.64"


### PR DESCRIPTION
## Description

Fixed deserialization of `#[serde(untagged)]` enums with `u128` leaf types. 

### Linked issue

Closes #3330  <!-- Replace with an actual number,  -->

### Benefits

Can use `u128` in `Expression` and `FilterOpt`. 

### Checklist

- [X] I've read `CONTRIBUTING.md`
- [X] I've used the standard signed-off commit format (or will squash just before merging)
- [X] All applicable CI checks pass (or I promised to make them pass later)
- [X] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
