### PR TITLE
[fix] #2581: reduce noise in logs

### DIFF
--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -165,7 +165,7 @@ model! {
     ///
     /// Uses **base64** (de-)serialization format.
     #[derive(DebugCustom, Clone, PartialEq, Eq, Hash, Constructor, Decode, Encode, Deserialize, Serialize, IntoSchema)]
-    #[debug(fmt = "WASM binary(len = {})", self.0.len())]
+    #[debug(fmt = "WASM binary(len = {})", "self.0.len()")]
     #[serde(transparent)]
     #[repr(transparent)]
     // SAFETY: `WasmSmartContract` has no trap representation in `Vec<u8>`
@@ -1103,5 +1103,12 @@ mod tests {
         };
 
         assert!(AcceptedTransaction::accept::<true>(tx, &tx_limits).is_ok());
+    }
+
+    #[test]
+    fn wasm_smart_contract_debug_repr_should_contain_just_len() {
+        let contract = WasmSmartContract::new(vec![0, 1, 2, 3, 4]);
+
+        assert_eq!(format!("{contract:?}"), "WASM binary(len = 5)");
     }
 }


### PR DESCRIPTION
## Description

I've researched for possible ways on how to configure logging in `warp`. I found that it's not easy.

Provided warp's tracing filter has hard-coded log levels. To implement something similar, but with patched levels, we need to implement `Filter`. This is not possible because [library authors decided](https://github.com/seanmonstar/warp/issues/555#issuecomment-622568143) that this should be kept internally and consumers should build their filters in a "convenient" way with `warp::any()`.

So, we decided to exclude `/health` route from logging at all, as this is the primary issue.

Also, I found that `WasmSmartContract` debug repr was not that is expected, and fixed it.

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #2581  <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

- less noise in logs
- less noise in TRACE logs (fixed WASM debug repr)

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
