### PR TITLE
[feature] #3274: Add to `kagami` a subcommand that generates examples

### DIFF
--- a/tools/kagami/README.md
+++ b/tools/kagami/README.md
@@ -22,15 +22,16 @@ kagami <SUBCOMMAND>
 
 ### Subcommands
 
-|        Command        |                             Description                              |
-| --------------------- | -------------------------------------------------------------------- |
-| [`crypto`](#crypto)   | Generate cryptographic key pairs                                     |
-| [`docs`](#docs)       | Generate a Markdown reference of configuration parameters            |
-| [`genesis`](#genesis) | Generate the default genesis block that is used in tests             |
-| [`schema`](#schema)   | Generate the schema used for code generation in Iroha SDKs           |
-| [`tokens`](#tokens)   | Generate a list of predefined permission tokens and their parameters |
-| [`config`](#config)   | Generate the default configuration for the client or the peer        |
-| `help`                | Print the help message for the tool or a subcommand                  |
+|        Command          |                             Description                              |
+| ----------------------- | -------------------------------------------------------------------- |
+| [`crypto`](#crypto)     | Generate cryptographic key pairs                                     |
+| [`docs`](#docs)         | Generate a Markdown reference of configuration parameters            |
+| [`genesis`](#genesis)   | Generate the default genesis block that is used in tests             |
+| [`schema`](#schema)     | Generate the schema used for code generation in Iroha SDKs           |
+| [`tokens`](#tokens)     | Generate a list of predefined permission tokens and their parameters |
+| [`config`](#config)     | Generate the default configuration for the client or the peer        |
+| [`examples`](#examples) | Generate an instruction by the chosen use case                       |
+| `help`                  | Print the help message for the tool or a subcommand                  |
 
 ## `crypto`
 
@@ -189,4 +190,23 @@ The output should be identical to the [reference configuration](../../docs/sourc
 
     ```bash
     kagami config client > client-config.json
+    ```
+
+## `examples`
+To see which use cases you can choose from, run the following command:
+```bash
+kagami examples --help
+```
+
+- Generate an instruction as JSON that creates a new account:
+    ```bash
+    kagami examples create-account
+    ```
+- Generate an instruction as JSON that mints a public key:
+    ```bash
+    kagami examples mint-public-key --account-id "bob@wonderland" --public-key "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
+    ```
+- Generate an instruction as JSON that burns a public key:
+    ```bash
+    kagami examples burn-public-key --account-id "bob@wonderland" --public-key "ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"
     ```

--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -57,6 +57,8 @@ pub enum Args {
     Docs(Box<docs::Args>),
     /// Generate a list of predefined permission tokens and their parameters
     Tokens(tokens::Args),
+    /// Generate an example instruction based on the chosen usecase
+    Examples(examples::Args),
 }
 
 impl<T: Write> RunArgs<T> for Args {
@@ -70,6 +72,7 @@ impl<T: Write> RunArgs<T> for Args {
             Config(args) => args.run(writer),
             Docs(args) => args.run(writer),
             Tokens(args) => args.run(writer),
+            Examples(args) => args.run(writer),
         }
     }
 }
@@ -772,5 +775,116 @@ mod tokens {
             )
             .wrap_err("Failed to write serialized token map into the buffer.")
         }
+    }
+}
+
+mod examples {
+    use clap::{Parser, Subcommand};
+    use color_eyre::Result;
+    use iroha_crypto::{KeyPair, PublicKey};
+
+    use super::*;
+
+    #[derive(Parser, Debug, Clone)]
+    pub struct Args {
+        #[clap(subcommand)]
+        usecase: Usecase,
+    }
+
+    impl<T: Write> RunArgs<T> for Args {
+        fn run(self, writer: &mut BufWriter<T>) -> Outcome {
+            let instructions = match self.usecase {
+                Usecase::CreateAccount {
+                    account_id,
+                    public_key,
+                } => create_account(account_id, public_key)?,
+                Usecase::MintPublicKey {
+                    account_id,
+                    public_key,
+                } => mint_public_key(account_id, public_key)?,
+                Usecase::BurnPublicKey {
+                    account_id,
+                    public_key,
+                } => burn_public_key(account_id.as_str(), public_key.as_str())?,
+            };
+            write!(
+                writer,
+                "{}",
+                serde_json::to_string_pretty(&instructions).wrap_err("Serialization error")?
+            )
+            .wrap_err("Failed to write.")
+        }
+    }
+
+    #[derive(Subcommand, Debug, Clone)]
+    pub enum Usecase {
+        /// Generate an instruction that creates a new account.
+        CreateAccount {
+            /// A new account id.
+            #[clap(long)]
+            account_id: Option<String>,
+            /// A new account public key.
+            /// If this flag isn't provided, will generate a new key pair.
+            #[clap(long)]
+            public_key: Option<String>,
+        },
+        /// Generate an instruction that mints public key.
+        MintPublicKey {
+            /// Mint on behalf of this account.
+            #[clap(long)]
+            account_id: Option<String>,
+            /// Mint this public key. If this flag isn't provided, will generate a new key pair.
+            #[clap(long)]
+            public_key: Option<String>,
+        },
+        /// Generate an instruction that burns the given public key.
+        BurnPublicKey {
+            /// Burn on behalf of this account.
+            #[clap(long)]
+            account_id: String,
+            /// Burn this public key.
+            #[clap(long)]
+            public_key: String,
+        },
+    }
+
+    fn create_account(
+        account_id: Option<String>,
+        public_key: Option<String>,
+    ) -> Result<Vec<InstructionBox>> {
+        let account_id: AccountId =
+            account_id.map_or_else(|| "bob@wonderland".parse(), |str| str.parse())?;
+        let public_key = if let Some(str) = public_key {
+            PublicKey::from_str(str.as_str())?
+        } else {
+            let (public_key, _) = KeyPair::generate()?.into();
+            public_key
+        };
+        Ok(vec![RegisterBox::new(Account::new(
+            account_id,
+            [public_key],
+        ))
+        .into()])
+    }
+
+    fn mint_public_key(
+        account_id: Option<String>,
+        public_key: Option<String>,
+    ) -> Result<Vec<InstructionBox>> {
+        let account_id: AccountId =
+            account_id.map_or_else(|| "bob@wonderland".parse(), |str| str.parse())?;
+        let public_key = if let Some(str) = public_key {
+            PublicKey::from_str(str.as_str())?
+        } else {
+            let (public_key, _) = KeyPair::generate()?.into();
+            public_key
+        };
+        Ok(vec![MintBox::new(public_key, account_id).into()])
+    }
+
+    fn burn_public_key(account_id: &str, public_key: &str) -> Result<Vec<InstructionBox>> {
+        let account_id: AccountId = account_id.parse()?;
+        let public_key = PublicKey::from_str(public_key)?;
+        Ok(vec![BurnBox::new(public_key, account_id).into()])
     }
 }


### PR DESCRIPTION
## Description

Add a new subcommand to `kagami` that generates an example by the chosen use case.

Another identical PR but aimed at [the LTS branch](https://github.com/hyperledger/iroha/pull/3398).

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3274  <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

This feature will be helpful for our QA team, at least, and will reduce the complexity of using the `iroha_client_cli json` command.  

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] Update kagami's README.md
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] Test with `client_cli`
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->