### PR TITLE
[refactor]: Disable wasmtime cache

### DIFF
--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -104,10 +104,10 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 /// Panics if something is wrong with the configuration.
 /// Configuration is hardcoded and tested, so this function should never panic.
 pub fn create_engine() -> Engine {
-    create_config()
-        .and_then(|config| {
-            Engine::new(&config).map_err(|err| Error::Initialization(eyre!(Box::new(err))))
-        })
+    let config = create_config();
+
+    Engine::new(&config)
+        .map_err(|err| Error::Initialization(eyre!(Box::new(err))))
         .expect("Failed to create WASM engine with a predefined configuration. This is a bug")
 }
 
@@ -122,13 +122,10 @@ pub fn load_module(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<wasmtime:
     Module::new(engine, bytes).map_err(|err| Error::Instantiation(eyre!(Box::new(err))))
 }
 
-fn create_config() -> Result<Config> {
+fn create_config() -> Config {
     let mut config = Config::new();
+    config.consume_fuel(true);
     config
-        .consume_fuel(true)
-        .cache_config_load_default()
-        .map_err(|err| Error::Initialization(eyre!(Box::new(err))))?;
-    Ok(config)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description

This created permission problems for devops
It's being removed as unnecessary ATM 

### Linked issue

Revert a change in  #3106 that enabled `wasmtime` cache. 
Whether this should be implemented is to be investigated in #3400

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
