### PR TITLE
[refactor]: Revert disable caching

### DIFF
--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -104,10 +104,10 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 /// Panics if something is wrong with the configuration.
 /// Configuration is hardcoded and tested, so this function should never panic.
 pub fn create_engine() -> Engine {
-    let config = create_config();
-
-    Engine::new(&config)
-        .map_err(|err| Error::Initialization(eyre!(Box::new(err))))
+    create_config()
+        .and_then(|config| {
+            Engine::new(&config).map_err(|err| Error::Initialization(eyre!(Box::new(err))))
+        })
         .expect("Failed to create WASM engine with a predefined configuration. This is a bug")
 }
 
@@ -122,10 +122,13 @@ pub fn load_module(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<wasmtime:
     Module::new(engine, bytes).map_err(|err| Error::Instantiation(eyre!(Box::new(err))))
 }
 
-fn create_config() -> Config {
+fn create_config() -> Result<Config> {
     let mut config = Config::new();
-    config.consume_fuel(true);
     config
+        .consume_fuel(true)
+        .cache_config_load_default()
+        .map_err(|err| Error::Initialization(eyre!(Box::new(err))))?;
+    Ok(config)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This reverts commit d7f59a3d91f9df390e685085cf5ddd0aab7f1f61.

## Description

seems that disabling of wasmtime caching affects start-up time of our integration tests. My suspicion is that this is because `wasmtime` cache is shared between tests. In particular, validator from `genesis` seems to be cached.

I'll explore this after #3231 , until then I'm reverting this commit

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
