### PR TITLE
[fix] #3411: Properly handle peers simultaneous connection

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -5,7 +5,13 @@
 use std::{io, net::AddrParseError};
 
 use iroha_crypto::ursa::{
-    encryption::symm::prelude::ChaCha20Poly1305, kex::x25519::X25519Sha256, CryptoError,
+    blake2::{
+        digest::{Update, VariableOutput},
+        VarBlake2b,
+    },
+    encryption::symm::prelude::ChaCha20Poly1305,
+    kex::x25519::X25519Sha256,
+    CryptoError,
 };
 pub use network::message::*;
 use parity_scale_codec::{Decode, Encode};
@@ -157,4 +163,16 @@ pub(crate) mod unbounded_with_len {
             Ok(())
         }
     }
+}
+
+/// Create Blake2b hash as u64 value
+pub fn blake2b_hash(slice: impl AsRef<[u8]>) -> u64 {
+    const U64_SIZE: usize = core::mem::size_of::<u64>();
+    let hash = VarBlake2b::new(U64_SIZE)
+        .expect("Failed to create hash with given length")
+        .chain(&slice)
+        .finalize_boxed();
+    let mut bytes = [0; U64_SIZE];
+    bytes.copy_from_slice(&hash);
+    u64::from_be_bytes(bytes)
 }


### PR DESCRIPTION
## Description

- Prevent simultaneous connections by selecting who will be passive and active when connecting.
- Prevent connection duplication by keeping track of outgoing connections.
- If simultaneous connection happen add policy to resolve which connection to preserve. 

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3411.
<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Test flakes at much smaller rate, i run it like 10000 times without any error + works a lot faster.

There still can be cases where we can lose message (and thus `multiple_networks` test can fail).

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
