### PR TITLE
[fix] #3448: Fix compiling `iroha_client_cli` separately

### DIFF
--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -542,7 +542,7 @@ mod account {
     impl RunArgs for ListPermissions {
         fn run(self, cfg: &ClientConfiguration) -> Result<Box<dyn Serialize>> {
             let client = Client::new(cfg)?;
-            let find_all_permissions = FindPermissionTokensByAccountId { id: self.id.into() };
+            let find_all_permissions = FindPermissionTokensByAccountId::new(self.id);
             let permissions = client
                 .request(find_all_permissions)
                 .wrap_err("Failed to get all account permissions")?;


### PR DESCRIPTION
## Description

It fixes compiling `iroha_client_cli` as a separate package.

@timofeevmd noticed that `cargo build` works but `cargo run -p iroha_client_cli` doesn't in the DEV branch.

Some thoughts:
1) I suppose it happened because of the wrong public/private field mods we use when defining query struct fields. 
2) It was merged somehow and avoided CI checks.

### Linked issue

Close #3448 

### Benefits

developers and other contributors will be able to build `iroha_client_cli` separately. 

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
