### PR TITLE
[fix] #3330: Manually implement `serde::de::Deserialize` for partially tagged enums

### DIFF
--- a/config/base/src/runtime_upgrades.rs
+++ b/config/base/src/runtime_upgrades.rs
@@ -28,8 +28,6 @@ pub enum ReloadError {
 
 /// The field needs to be mutably borrowed to be reloaded.
 pub trait ReloadMut<T> {
-    // TODO: When negative traits/specialisation, remove Debug
-
     /// Reload `self` using provided `item`.
     ///
     /// # Errors

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -474,6 +474,7 @@ fn handle_message(
     let role = current_topology.role(&sumeragi.peer_id);
     let addr = &sumeragi.peer_id.address;
 
+    #[allow(clippy::suspicious_operation_groupings)]
     match (message, role) {
         (Message::ViewChangeSuggested, _) => {
             trace!("Received view change suggestion.");

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -16,6 +16,7 @@ quote = "1.0.23"
 proc-macro2 = "1.0.49"
 proc-macro-error = "1.0.4"
 iroha_macro_utils = { version = "2.0.0-pre-rc.13", path = "../../macro/utils" }
+serde_json = "1.0.91"
 
 [dev-dependencies]
 iroha_data_model = { version = "=2.0.0-pre-rc.13", path = "../", features = ["http"] }

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -362,15 +362,15 @@ pub fn partially_tagged_serialize_derive(input: TokenStream) -> TokenStream {
 ///
 /// #[derive(Debug, PartialEq, Eq, Deserialize)]
 /// enum Inner {
-///     B(u32),
+///     B(u128),
 /// }
 ///
 /// assert_eq!(
-///     serde_json::from_str::<Outer>(r#"{"B":42}"#).expect("Failed to deserialize"), Outer::Inner(Inner::B(42))
+///     serde_json::from_str::<Outer>(r#"{"B":42}"#).expect("Failed to deserialize B"), Outer::Inner(Inner::B(42))
 /// );
 ///
 /// assert_eq!(
-///     serde_json::from_str::<Outer>(r#"{"A":42}"#).expect("Failed to deserialize"), Outer::A(42)
+///     serde_json::from_str::<Outer>(r#"{"A":42}"#).expect("Failed to deserialize A"), Outer::A(42)
 /// );
 /// ```
 ///

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -352,6 +352,7 @@ pub fn partially_tagged_serialize_derive(input: TokenStream) -> TokenStream {
 /// ```
 /// use serde::Deserialize;
 /// use iroha_data_model_derive::PartiallyTaggedDeserialize;
+/// use std::string::ToString;
 ///
 /// #[derive(Debug, PartialEq, Eq, PartiallyTaggedDeserialize)]
 /// enum Outer {

--- a/data_model/derive/src/partially_tagged.rs
+++ b/data_model/derive/src/partially_tagged.rs
@@ -150,7 +150,7 @@ pub fn impl_partially_tagged_serialize(enum_: &PartiallyTaggedEnum) -> TokenStre
                 }
 
                 #[derive(::serde::Serialize)]
-                #[serde(untagged)]
+                #[serde(untagged)] // Unaffected by #3330, because Serialize implementations are unaffected
                 enum SerializeHelper<'re> {
                     #(
                         #(

--- a/data_model/derive/src/partially_tagged.rs
+++ b/data_model/derive/src/partially_tagged.rs
@@ -1,9 +1,4 @@
-#![allow(
-    clippy::str_to_string,
-    clippy::mixed_read_write_in_expression,
-    clippy::unwrap_in_result
-)]
-
+#![allow(clippy::too_many_lines)]
 use proc_macro::TokenStream;
 use proc_macro_error::abort;
 use quote::{format_ident, quote};
@@ -119,6 +114,7 @@ pub fn impl_partially_tagged_serialize(enum_: &PartiallyTaggedEnum) -> TokenStre
     let enum_ident = &enum_.ident;
     let enum_attrs = &enum_.attrs;
     let ref_internal_repr_ident = format_ident!("{}RefInternalRepr", enum_ident);
+    let ser_helper = format_ident!("{}SerializeHelper", enum_ident);
     let (variants_ident, variants_ty, variants_attrs) = variants_to_tuple(enum_.variants());
     let (untagged_variants_ident, untagged_variants_ty, untagged_variants_attrs) =
         variants_to_tuple(enum_.untagged_variants());
@@ -151,7 +147,7 @@ pub fn impl_partially_tagged_serialize(enum_: &PartiallyTaggedEnum) -> TokenStre
 
                 #[derive(::serde::Serialize)]
                 #[serde(untagged)] // Unaffected by #3330, because Serialize implementations are unaffected
-                enum SerializeHelper<'re> {
+                enum #ser_helper<'re> {
                     #(
                         #(
                             #untagged_variants_attrs
@@ -163,9 +159,9 @@ pub fn impl_partially_tagged_serialize(enum_: &PartiallyTaggedEnum) -> TokenStre
 
                 let wrapper = match self {
                     #(
-                        #enum_ident::#untagged_variants_ident(value) => SerializeHelper::#untagged_variants_ident(value),
+                        #enum_ident::#untagged_variants_ident(value) => #ser_helper::#untagged_variants_ident(value),
                     )*
-                    value => SerializeHelper::Other(convert(value)),
+                    value => #ser_helper::Other(convert(value)),
                 };
 
                 wrapper.serialize(serializer)
@@ -179,6 +175,9 @@ pub fn impl_partially_tagged_deserialize(enum_: &PartiallyTaggedEnum) -> TokenSt
     let enum_ident = &enum_.ident;
     let enum_attrs = &enum_.attrs;
     let internal_repr_ident = format_ident!("{}InternalRepr", enum_ident);
+    let deser_helper = format_ident!("{}DeserializeHelper", enum_ident);
+    let no_successful_untagged_variant_match =
+        format!("Data did not match any variant of enum {}", deser_helper);
     let (variants_ident, variants_ty, variants_attrs) = variants_to_tuple(enum_.variants());
     let (untagged_variants_ident, untagged_variants_ty, untagged_variants_attrs) =
         variants_to_tuple(enum_.untagged_variants());
@@ -189,7 +188,7 @@ pub fn impl_partially_tagged_deserialize(enum_: &PartiallyTaggedEnum) -> TokenSt
             where
                 D: ::serde::Deserializer<'de>,
             {
-                #[derive(::serde::Deserialize)]
+                #[derive(::serde::Deserialize, Debug)]
                 #(
                     #enum_attrs
                 )*
@@ -211,9 +210,19 @@ pub fn impl_partially_tagged_deserialize(enum_: &PartiallyTaggedEnum) -> TokenSt
                     }
                 }
 
-                #[derive(::serde::Deserialize)]
-                #[serde(untagged)]
-                enum DeserializeHelper {
+                // FIXME: Due to an oversight in handling of `u128`
+                // values, an untagged containing a `u128` value will
+                // always fail to deserialize, thus
+                // #[derive(::serde::Deserialize)] #[serde(untagged)]
+                // is replaced with a manual implementation until
+                // further notice.
+                //
+                // Also note that this struct isn't necessary for the
+                // current manual implementation of partially tagged
+                // enums, but is needed to neatly return the
+                // derive-based solution.#
+                #[derive(Debug)]
+                enum #deser_helper {
                     #(
                         #(
                             #untagged_variants_attrs
@@ -223,12 +232,63 @@ pub fn impl_partially_tagged_deserialize(enum_: &PartiallyTaggedEnum) -> TokenSt
                     Other(#internal_repr_ident),
                 }
 
-                let wrapper = DeserializeHelper::deserialize(deserializer)?;
+                // TODO: remove once `serde::__private::ContentDeserializer` properly handles `u128`.
+                // Tracking issue: https://github.com/serde-rs/serde/issues/2230
+                impl<'de> ::serde::Deserialize<'de> for #deser_helper {
+                    fn deserialize<D: ::serde::Deserializer<'de>>(
+                        deserializer: D,
+                    ) -> Result<Self, D::Error> {
+                        #[cfg(feature = "std")]
+                        let mut errors = Vec::new();
+
+                        let content = serde_json::Value::deserialize(deserializer)?;
+                        #(
+                            {
+                                let candidate_variant = #untagged_variants_ty::deserialize(&content);
+                                match candidate_variant {
+                                    Ok(candidate) => return Ok(
+                                        #deser_helper::#untagged_variants_ident(candidate)
+                                    ),
+                                    Err(error) => {
+                                        #[cfg(feature = "std")]
+                                        errors.push((error, stringify!(#untagged_variants_ty)));
+                                    }
+                                }
+                            }
+                        )*
+                        {
+                            let candidate_variant = #internal_repr_ident::deserialize(content);
+                            match candidate_variant {
+                                Ok(candidate) => return Ok(#deser_helper::Other(candidate)),
+                                Err(error) => {
+                                    #[cfg(feature = "std")]
+                                    errors.push((error, stringify!(#internal_repr_ident)));
+                                }
+                            }
+                        }
+                        #[cfg(feature = "std")]
+                        {
+                            let mut message = #no_successful_untagged_variant_match.to_string();
+                            for (error, candidate_type) in errors {
+                                message +=". ";
+                                message +="Candidate `";
+                                message += &candidate_type;
+                                message += "` failed to deserialize with error: ";
+                                message += &error.to_string();
+                            }
+                            Err(::serde::de::Error::custom(message))
+                        }
+                        #[cfg(not(feature = "std"))]
+                        Err(::serde::de::Error::custom(#no_successful_untagged_variant_match))
+                    }
+                }
+
+                let wrapper = #deser_helper::deserialize(deserializer)?;
                 match wrapper {
                     #(
-                        DeserializeHelper::#untagged_variants_ident(value) => Ok(#enum_ident::#untagged_variants_ident(value)),
+                        #deser_helper::#untagged_variants_ident(value) => Ok(#enum_ident::#untagged_variants_ident(value)),
                     )*
-                    DeserializeHelper::Other(value) => Ok(convert(value)),
+                    #deser_helper::Other(value) => Ok(convert(value)),
                 }
             }
         }

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -482,7 +482,7 @@ pub mod error {
             IntoSchema,
         )]
         #[display(fmt = "Block was rejected during consensus")]
-        #[serde(untagged)]      // Unaffected by #3330 as it's a unit variant
+        #[serde(untagged)] // Unaffected by #3330 as it's a unit variant
         #[repr(transparent)]
         #[ffi_type]
         pub enum BlockRejectionReason {

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -482,7 +482,7 @@ pub mod error {
             IntoSchema,
         )]
         #[display(fmt = "Block was rejected during consensus")]
-        #[serde(untagged)]
+        #[serde(untagged)]      // Unaffected by #3330 as it's a unit variant
         #[repr(transparent)]
         #[ffi_type]
         pub enum BlockRejectionReason {

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -505,7 +505,7 @@ mod validator {
         )]
         #[non_exhaustive]
         #[ffi_type]
-        #[serde(untagged)]      // Unaffected by #3330, as single unit variant
+        #[serde(untagged)] // Unaffected by #3330, as single unit variant
         #[repr(transparent)]
         pub enum ValidatorEvent {
             Upgraded,

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -505,7 +505,7 @@ mod validator {
         )]
         #[non_exhaustive]
         #[ffi_type]
-        #[serde(untagged)]
+        #[serde(untagged)]      // Unaffected by #3330, as single unit variant
         #[repr(transparent)]
         pub enum ValidatorEvent {
             Upgraded,

--- a/data_model/src/events/data/filters.rs
+++ b/data_model/src/events/data/filters.rs
@@ -34,7 +34,7 @@ pub mod model {
         Serialize,
         IntoSchema,
     )]
-    #[serde(untagged)]
+    #[serde(untagged)] // Unaffected by #3330
     pub enum FilterOpt<F> {
         /// Accept all items that will be passed to `filter()` method
         #[serde(with = "accept_all_as_string")]

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -717,7 +717,7 @@ pub mod model {
     )]
     // SAFETY: `UpgradableBox` has no trap representations in `validator::Validator`
     #[ffi_type(unsafe {robust})]
-    #[serde(untagged)]
+    #[serde(untagged)]          // Unaffected by #3330, because stores binary data with no `u128`
     #[repr(transparent)]
     pub enum UpgradableBox {
         /// [`Validator`](`validator::Validator`) variant.

--- a/data_model/src/lib.rs
+++ b/data_model/src/lib.rs
@@ -717,7 +717,7 @@ pub mod model {
     )]
     // SAFETY: `UpgradableBox` has no trap representations in `validator::Validator`
     #[ffi_type(unsafe {robust})]
-    #[serde(untagged)]          // Unaffected by #3330, because stores binary data with no `u128`
+    #[serde(untagged)] // Unaffected by #3330, because stores binary data with no `u128`
     #[repr(transparent)]
     pub enum UpgradableBox {
         /// [`Validator`](`validator::Validator`) variant.


### PR DESCRIPTION
## Description

As a workaround for the upstream issue in `serde` we must manually implement the code that would be generated by `serde(untagged)`. This also has the added benefit of preserving the error messages, but unfortunately comes at the cost of using `serde_json::Value`, and a `Clone::clone` call to the entire candidate value. 

Unfortunately, until the issue is fixed upstream, there is no better way to handle this. 

### Linked issue

Closes #3330 in `iroha2-dev`. Fix was already implemented in `iroha2-lts`. 

### Benefits

Fully-functional deserialization. 

### Checklist

- [X] I've read `CONTRIBUTING.md`
- [X] I've used the standard signed-off commit format (or will squash just before merging)
- [X] All applicable CI checks pass (or I promised to make them pass later)
- [X] (optional) I've written unit tests for the code changes
- [X] I replied to all comments after code review, marking all implemented changes with thumbs up
