### PR TITLE
[fix] #3461: Logic error in defaults handling

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -462,7 +462,13 @@ pub fn combine_configs(args: &Arguments) -> color_eyre::eyre::Result<Configurati
                 eprintln!("Configuration file not found. Using environment variables as fallback.");
                 ConfigurationProxy::default()
             },
-            |path| ConfigurationProxy::from_path(&path.as_path()),
+            |path| {
+				let path_proxy = ConfigurationProxy::from_path(&path.as_path());
+				// Override the default to ensure that the variables
+				// not specified in the config file don't have to be
+				// explicitly specified in the env.
+				ConfigurationProxy::default().override_with(path_proxy)
+			},
         )
         .override_with(ConfigurationProxy::from_env())
         .build()


### PR DESCRIPTION
## Description

Make config params not specified in env or config file fall back to defaults. 

### Linked issue

Helps #3461. 

### Benefits

Less tedium
