### PR TITLE
[ci] #3562: Fix PR-generator Jenkinsfile & Add Coverall badge & Set up JDK 11

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -43,9 +43,11 @@ jobs:
         if: always()
         with:
           push: true
+          # include the tag for PR-generator image specifically
           tags: |
             hyperledger/iroha2:dev
             docker.soramitsu.co.jp/iroha2/iroha2:dev
+            docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
           labels: commit=${{ github.sha }}
           build-args: TAG=dev
           file: Dockerfile

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -60,9 +60,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.11.0
         with:
-          java-version: 1.11
+          java-version: '1.11'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,16 @@
 @Library('jenkins-library') _
 
-def pipeline = new org.iroha2.AppPipeline(steps: this,
+def pipeline = new org.iroha2PRDeploy.AppPipeline(steps: this,
     k8sPrDeploy: true,
     vaultPrPath: "argocd-cc/src/charts/iroha2/environments/tachi/",
-    vaultUser: "iroha2-ro",
+    vaultUser: "iroha2-rw",
     vaultCredId: "iroha2VaultCreds",
     valuesDestPath: "argocd-cc/src/charts/iroha2/",
-    devValuesPath: "dev/test/"
+    devValuesPath: "dev/dev/",
+    initialSecretName: "iroha2-eso-base",
+    initialNameSpace: "iroha2-dev",
+    targetNameSpace: "iroha2-${env.CHANGE_ID}-web",
+    targetSecretName: "iroha2-${env.CHANGE_ID}-iroha2-pr-eso-base",
+    disableSecretScanner: true
 )
 pipeline.runPipeline()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![Rust](https://github.com/hyperledger/iroha/workflows/Rust/badge.svg?branch=iroha2-dev)
-[![codecov](https://codecov.io/gh/hyperledger/iroha/branch/iroha2-dev/graph/badge.svg)](https://codecov.io/gh/hyperledger/iroha)
+[![Coverage Status](https://coveralls.io/repos/github/hyperledger/iroha/badge.svg)](https://coveralls.io/github/hyperledger/iroha)
 
 Iroha is a simple and efficient blockchain ledger based on the **distributed ledger technology (DLT)**. Its design principles are inspired by the Japanese Kaizen principle of eliminating excesses (*muri*).
 


### PR DESCRIPTION
## Description
1. Change `README.MD` badge from `Codecov` to `Coveralls` tool.
2. Update PR-generator `Jenkinsfile`.
3. Add `docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}` iroha2 image tag to push to Soramitsu registry for PR-generator.
4. Add JDK distribution to `Set up JDK 11` step into `java-api` job inside `I2::Release::Tests` workflow.

### Linked issue
1. We don't have `Coveralls` coverage tool badge.
2. PR-generator deployment hasn't bee finished.
3. #3562 

### Benefits
1. `Coveralls` badge.
2. PR-generator should work after merging the corresponding PR with Jenkins library (I'LL NOTIFY WHEN IT WILL BE ABLE TO BE TESTED)!
3. Fix JDK 11 Set up in the `Release-PR` workflow.

### Checklist

- [X] Done the work
- [X] CI checks pass
- [X] Commits are good
- [ ] Addressed comments
- [ ] Tested badge as UI element. 