### PR TITLE
[feature] #2373: `kagami swarm file` and `kagami swarm dir`

### DIFF
--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -58,23 +58,7 @@ pub enum Args {
     Docs(Box<docs::Args>),
     /// Generate the default validator
     Validator(validator::Args),
-    /// Generate a docker-compose configuration for a variable number of peers
-    /// using a Dockerhub image, GitHub repo, or a local Iroha repo.
-    ///
-    /// This command builds the docker-compose configuration in a specified directory. If the source
-    /// is a GitHub repo, it will be cloned into the directory. Also, the default configuration is
-    /// built and put into `<target>/config` directory, unless `--no-default-configuration` flag is
-    /// provided. The default configuration is equivalent to running `kagami config peer`,
-    /// `kagami validator`, and `kagami genesis default --compiled-validator-path ./validator.wasm` consecutively.
-    ///
-    /// Default configuration building will fail if Kagami is run outside of Iroha repo (tracking
-    /// issue: https://github.com/hyperledger/iroha/issues/3473). If you are going to run it outside
-    /// of the repo, make sure to pass `--no-default-configuration` flag.
-    ///
-    /// Be careful with specifying a Dockerhub image as a source: Kagami Swarm only guarantees that
-    /// the docker-compose configuration it generates is compatible with the same Git revision it
-    /// is built from itself. Therefore, if specified image is not compatible with the version of Swarm
-    /// you are running, the generated configuration might not work.
+    /// Generate Docker Compose configuration
     Swarm(swarm::Args),
 }
 

--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -45,10 +45,10 @@ mod clap_args {
         /// How many peers to generate within the Docker Compose setup.
         #[arg(long, short)]
         pub peers: NonZeroU16,
-        /// Used for deterministic key-generation. 
+        /// Used for deterministic key-generation.
         ///
-        /// Any valid UTF-8 sequence is acceptable. 
-        // TODO: Check for length limitations, and if non-UTF-8 sequences are working. 
+        /// Any valid UTF-8 sequence is acceptable.
+        // TODO: Check for length limitations, and if non-UTF-8 sequences are working.
         #[arg(long, short)]
         pub seed: Option<String>,
         /// Re-create the target directory (for `dir` subcommand) or file (for `file` subcommand)

--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -45,9 +45,10 @@ mod clap_args {
         /// How many peers to generate within the Docker Compose setup.
         #[arg(long, short)]
         pub peers: NonZeroU16,
-        /// Might be useful for deterministic key generation.
+        /// Used for deterministic key-generation. 
         ///
-        /// It could be any string. Its UTF-8 bytes will be used as a seed.
+        /// Any valid UTF-8 sequence is acceptable. 
+        // TODO: Check for length limitations, and if non-UTF-8 sequences are working. 
         #[arg(long, short)]
         pub seed: Option<String>,
         /// Re-create the target directory (for `dir` subcommand) or file (for `file` subcommand)

--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -80,13 +80,6 @@ mod clap_args {
             /// If the directory is not empty, Kagami will prompt it's re-creation. If the TTY is not
             /// interactive, Kagami will stop execution with non-zero exit code. In order to re-create
             /// the directory anyway, pass `--force` flag.
-            ///
-            /// Example:
-            ///
-            /// ```bash
-            /// kagami swarm --outdir ./compose --peers 4 --image hyperledger/iroha2:lts
-            /// ```
-            #[arg(long)]
             outdir: PathBuf,
             /// Do not create default configuration in the `<outdir>/config` directory.
             ///
@@ -109,7 +102,6 @@ mod clap_args {
             /// If file exists, Kagami will prompt its overwriting. If the TTY is not
             /// interactive, Kagami will stop execution with non-zero exit code. In order to
             /// overwrite the file anyway, pass `--force` flag.
-            #[arg(long)]
             outfile: PathBuf,
             /// Path to a directory with Iroha configuration. It will be mapped as volume for containers.
             ///
@@ -192,49 +184,44 @@ mod clap_args {
 
         #[test]
         fn works_in_file_mode() {
-            let _ = match_args("-p 20 file --build . --config-dir ./config --outfile sample.yml")
-                .unwrap();
+            let _ = match_args("-p 20 file --build . --config-dir ./config sample.yml").unwrap();
         }
 
         #[test]
         fn works_in_dir_mode_with_github_source() {
-            let _ = match_args("-p 20 dir --build-from-github --outdir swarm").unwrap();
+            let _ = match_args("-p 20 dir --build-from-github swarm").unwrap();
         }
 
         #[test]
         fn doesnt_allow_config_dir_for_dir_mode() {
-            let _ = match_args("-p 1 dir --build-from-github --outdir swarm --config-dir ./")
-                .unwrap_err();
+            let _ = match_args("-p 1 dir --build-from-github  --config-dir ./ swarm").unwrap_err();
         }
 
         #[test]
         fn doesnt_allow_multiple_sources_in_dir_mode() {
-            let _ =
-                match_args("-p 1 dir --build-from-github --build . --outdir swarm").unwrap_err();
+            let _ = match_args("-p 1 dir --build-from-github --build . swarm").unwrap_err();
         }
 
         #[test]
         fn doesnt_allow_multiple_sources_in_file_mode() {
-            let _ = match_args(
-                "-p 1 file --build . --image hp/iroha --outfile test.yml --config-dir ./",
-            )
-            .unwrap_err();
-        }
-
-        #[test]
-        fn doesnt_allow_github_source_in_file_mode() {
-            let _ = match_args("-p 1 file --build-from-github --outfile test.yml --config-dir ./")
+            let _ = match_args("-p 1 file --build . --image hp/iroha --config-dir ./ test.yml")
                 .unwrap_err();
         }
 
         #[test]
+        fn doesnt_allow_github_source_in_file_mode() {
+            let _ =
+                match_args("-p 1 file --build-from-github --config-dir ./ test.yml").unwrap_err();
+        }
+
+        #[test]
         fn doesnt_allow_omitting_source_in_dir_mode() {
-            let _ = match_args("-p 1 dir --outdir ./test").unwrap_err();
+            let _ = match_args("-p 1 dir ./test").unwrap_err();
         }
 
         #[test]
         fn doesnt_allow_omitting_source_in_file_mode() {
-            let _ = match_args("-p 1 file --outfile test.yml --config-dir ./").unwrap_err();
+            let _ = match_args("-p 1 file test.yml --config-dir ./").unwrap_err();
         }
     }
 }


### PR DESCRIPTION
## Description

#3475 introduces `kagami swarm` command, but it works only in directory mode. Now it is possible to produce both a "battery-included" directory and just a single file. The latter usage is especially helpful to generate sample docker-compose configurations to store them in the repo (`docker-compose.yml`, `docker-compose.single.yml` etc):

```bash
# only `docker-compose.yml`
kagami swarm file ./docker-compose.yml --build . --config-dir ./configs/peer --p 4 --seed "Kagami"

# a whole directory `test-swarm`
kagami swarm dir ./test-swarm --build . -p 4 --seed "Kagami"
```

### Linked issue

Closes #2373

### Benefits

We can automatise Docker Compose configurations generation and avoid problems with having outdated files in the repo. It will help the community.

### Checklist

- [x] Remove `--outfile` and `--outdir` options, use positionals instead
- [x] Create an issue to include compose files generation into CI
  - #3648
- [x] Self-review
