### PR TITLE
[feature] #3597: Permisison Token Analysis (Iroha side)

### DIFF
--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -17,6 +17,8 @@ impl Registrable for NewRole {
 
 /// Iroha Special Instructions that have `World` as their target.
 pub mod isi {
+    // use std::collections::HashSet;
+
     use eyre::Result;
     use iroha_data_model::{
         isi::error::{InvalidParameterError, RepetitionError},
@@ -343,7 +345,10 @@ pub mod isi {
     }
 
     impl Execute for Upgrade<Validator> {
+        // TODO: Uncomment code in this function when `permission_tokens()` entrypoint will be
+        // implemented on WASM side (#3598)
         #[metrics(+"upgrade_validator")]
+        #[allow(unused_parens, clippy::double_parens)] // TODO: Remove when code will be uncommented
         fn execute(self, _authority: &AccountId, wsv: &mut WorldStateView) -> Result<(), Error> {
             #[cfg(test)]
             use crate::validator::MockValidator as Validator;
@@ -352,10 +357,43 @@ pub mod isi {
 
             let raw_validator = self.object;
             let engine = wsv.engine.clone(); // Cloning engine is cheap
+
+            let (new_validator /*, new_permission_token_definitions*/) =
+                || -> Result<_, crate::smartcontracts::wasm::error::Error> {
+                    {
+                        let new_validator = Validator::new(raw_validator, &engine)?;
+                        // let new_permission_token_definitions =
+                        //     new_validator.permission_tokens(wsv)?;
+                        Ok((new_validator /*, new_permission_token_definitions*/))
+                    }
+                }()
+                .map_err(|error| {
+                    InvalidParameterError::Wasm(format!("{:?}", eyre::Report::from(error)))
+                })?;
+
             let world = wsv.world_mut();
-            let new_validator = Validator::new(raw_validator, &engine)
-                .map_err(|err| InvalidParameterError::Wasm(err.to_string()))?;
             let _ = world.upgraded_validator.insert(new_validator);
+
+            // let old_permission_token_definitions = wsv
+            //     .permission_token_definitions()
+            //     .values()
+            //     .cloned()
+            //     .collect::<HashSet<_>>();
+            // let new_permission_token_definitions =
+            //     HashSet::from_iter(new_permission_token_definitions);
+
+            // old_permission_token_definitions
+            //     .difference(&new_permission_token_definitions)
+            //     .map(|definition| Unregister::<PermissionTokenDefinition> {
+            //         object_id: definition.id.clone(),
+            //     })
+            //     .try_for_each(|unregister| unregister.execute(authority, wsv))?;
+
+            // new_permission_token_definitions
+            //     .difference(&old_permission_token_definitions)
+            //     .cloned()
+            //     .map(|definition| Register::<PermissionTokenDefinition> { object: definition })
+            //     .try_for_each(|new| new.execute(authority, wsv))?;
 
             wsv.emit_events(Some(ValidatorEvent::Upgraded));
 

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -232,9 +232,9 @@ impl TransactionValidator {
             instruction
                 .clone()
                 .execute(authority, wsv)
-                .map_err(|reason| InstructionExecutionFail {
+                .map_err(|error| InstructionExecutionFail {
                     instruction,
-                    reason: reason.to_string(),
+                    reason: format!("{:?}", eyre::Report::from(error)),
                 })
                 .map_err(TransactionRejectionReason::InstructionExecution)?;
         }

--- a/wasm_codec/src/lib.rs
+++ b/wasm_codec/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-pub use iroha_core_wasm_codec_derive::wrap;
+pub use iroha_core_wasm_codec_derive::{wrap, wrap_trait_fn};
 use parity_scale_codec::{DecodeAll, Encode};
 use wasmtime::Trap;
 


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

This PR is based on PR #3588 branch, so most of the code diff is not related directly no this PR.

So, please, review only the latest commit.

I plan to merge this after #3588.

- Implemented a new state for `wasm::Runtime` related to `permission_tokens()` *Validator* entrypoint
- Added execution of this new entrypoint
- Added permission tokens replacement in `Upgrade<Validator>` execution

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

- Closes #3597  <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

- Support for permission token analysis on Iroha side

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

## When undraft?

- After the merge of #3588 

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
