### PR TITLE
#3318: Interleave rejected and accepted transactions in block

### DIFF
--- a/client/benches/tps/utils.rs
+++ b/client/benches/tps/utils.rs
@@ -135,7 +135,18 @@ impl Config {
                     .next()
                     .expect("The block is not yet in WSV. Need more sleep?");
                 let block = block.as_v1();
-                (block.transactions.len(), block.rejected_transactions.len())
+                (
+                    block
+                        .transactions
+                        .iter()
+                        .filter(|tx| tx.error.is_none())
+                        .count(),
+                    block
+                        .transactions
+                        .iter()
+                        .filter(|tx| tx.error.is_some())
+                        .count(),
+                )
             })
             .fold((0, 0), |acc, pair| (acc.0 + pair.0, acc.1 + pair.1));
         #[allow(clippy::float_arithmetic, clippy::cast_precision_loss)]

--- a/client/tests/integration/burn_public_keys.rs
+++ b/client/tests/integration/burn_public_keys.rs
@@ -85,7 +85,7 @@ fn public_keys_cannot_be_burned_to_nothing() {
     );
     keys_count = charlie_keys_count(&mut client);
     assert_eq!(keys_count, 1);
-    assert!(matches!(committed_txn, TransactionValue::Transaction(_)));
+    assert!(committed_txn.error.is_none());
 
     let burn_the_last_key = burn(charlie_initial_keypair.public_key().clone());
 
@@ -96,8 +96,5 @@ fn public_keys_cannot_be_burned_to_nothing() {
     );
     keys_count = charlie_keys_count(&mut client);
     assert_eq!(keys_count, 1);
-    assert!(matches!(
-        committed_txn,
-        TransactionValue::RejectedTransaction(_)
-    ));
+    assert!(committed_txn.error.is_some());
 }

--- a/client/tests/integration/connected_peers.rs
+++ b/client/tests/integration/connected_peers.rs
@@ -16,16 +16,16 @@ use super::Configuration;
 #[ignore = "ignore, more in #2851"]
 #[test]
 fn connected_peers_with_f_2_1_2() -> Result<()> {
-    connected_peers_with_f(2, 10_050)
+    connected_peers_with_f(2)
 }
 
 #[test]
 fn connected_peers_with_f_1_0_1() -> Result<()> {
-    connected_peers_with_f(1, 10_150)
+    connected_peers_with_f(1)
 }
 
 /// Test the number of connected peers, changing the number of faults tolerated down and up
-fn connected_peers_with_f(faults: u64, port: u16) -> Result<()> {
+fn connected_peers_with_f(faults: u64) -> Result<()> {
     let n_peers = 3 * faults + 1;
 
     #[allow(clippy::expect_used)]
@@ -33,7 +33,7 @@ fn connected_peers_with_f(faults: u64, port: u16) -> Result<()> {
         (n_peers)
             .try_into()
             .wrap_err("`faults` argument `u64` value too high, cannot convert to `u32`")?,
-        Some(port),
+        None,
     );
     wait_for_genesis_committed(&network.clients(), 0);
     let pipeline_time = Configuration::pipeline_time();

--- a/core/benches/apply_blocks/apply_blocks.rs
+++ b/core/benches/apply_blocks/apply_blocks.rs
@@ -50,8 +50,10 @@ fn create_block(
 
     let pending_block = PendingBlock {
         header,
-        rejected_transactions: Vec::new(),
-        transactions: vec![transaction],
+        transactions: vec![TransactionValue {
+            tx: transaction,
+            error: None,
+        }],
         event_recommendations: Vec::new(),
         signatures,
     };

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -223,7 +223,7 @@ impl Queue {
     pub fn push(&self, tx: AcceptedTransaction, wsv: &WorldStateView) -> Result<(), Failure> {
         trace!(?tx, "Pushing to the queue");
         if let Err(err) = self.check_tx(&tx, wsv) {
-            warn!("Failed to evaluate signature check");
+            warn!("Failed to evaluate signature check. Error = {}", err);
             return Err(Failure { tx, err });
         }
 

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -334,13 +334,13 @@ mod tests {
         assert_eq!(txs.len() as u64, num_blocks * 2);
         assert_eq!(
             txs.iter()
-                .filter(|txn| matches!(txn.transaction, TransactionValue::RejectedTransaction(_)))
+                .filter(|txn| txn.transaction.error.is_some())
                 .count() as u64,
             num_blocks
         );
         assert_eq!(
             txs.iter()
-                .filter(|txn| matches!(txn.transaction, TransactionValue::Transaction(_)))
+                .filter(|txn| txn.transaction.error.is_none())
                 .count() as u64,
             num_blocks
         );
@@ -387,11 +387,11 @@ mod tests {
         assert!(matches!(not_found, Err(_)));
 
         let found_accepted = FindTransactionByHash::new(va_tx.hash()).execute(&wsv)?;
-        match found_accepted.transaction {
-            TransactionValue::Transaction(tx) => {
-                assert_eq!(va_tx.hash().transmute(), tx.hash())
-            }
-            TransactionValue::RejectedTransaction(_) => {}
+        if found_accepted.transaction.error.is_none() {
+            assert_eq!(
+                va_tx.hash().transmute(),
+                found_accepted.transaction.tx.hash()
+            )
         }
         Ok(())
     }

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -262,7 +262,7 @@ impl Sumeragi {
         }
         .build();
         assert!(
-            block.rejected_transactions.is_empty(),
+            !block.transactions.iter().any(|tx| tx.error.is_some()),
             "Genesis transaction set contains invalid transactions"
         );
 

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -112,8 +112,15 @@ impl SumeragiHandle {
                     break;
                 };
                 block_index += 1;
-                let block_txs_accepted = block.as_v1().transactions.len() as u64;
-                let block_txs_rejected = block.as_v1().rejected_transactions.len() as u64;
+                let mut block_txs_accepted = 0;
+                let mut block_txs_rejected = 0;
+                for tx in &block.as_v1().transactions {
+                    if tx.error.is_none() {
+                        block_txs_accepted += 1;
+                    } else {
+                        block_txs_rejected += 1;
+                    }
+                }
 
                 self.metrics
                     .txs

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -695,12 +695,8 @@
         "type": "BlockHeader"
       },
       {
-        "name": "rejected_transactions",
-        "type": "Vec<RejectedTransaction>"
-      },
-      {
         "name": "transactions",
-        "type": "Vec<VersionedSignedTransaction>"
+        "type": "Vec<TransactionValue>"
       },
       {
         "name": "event_recommendations",
@@ -3021,6 +3017,9 @@
   "Option<TimeInterval>": {
     "Option": "TimeInterval"
   },
+  "Option<TransactionRejectionReason>": {
+    "Option": "TransactionRejectionReason"
+  },
   "Option<u32>": {
     "Option": "u32"
   },
@@ -3681,18 +3680,6 @@
       }
     ]
   },
-  "RejectedTransaction": {
-    "Struct": [
-      {
-        "name": "transaction",
-        "type": "VersionedSignedTransaction"
-      },
-      {
-        "name": "error",
-        "type": "TransactionRejectionReason"
-      }
-    ]
-  },
   "RemoveKeyValueBox": {
     "Struct": [
       {
@@ -4256,16 +4243,14 @@
     ]
   },
   "TransactionValue": {
-    "Enum": [
+    "Struct": [
       {
-        "tag": "Transaction",
-        "discriminant": 0,
+        "name": "tx",
         "type": "VersionedSignedTransaction"
       },
       {
-        "tag": "RejectedTransaction",
-        "discriminant": 1,
-        "type": "RejectedTransaction"
+        "name": "error",
+        "type": "Option<TransactionRejectionReason>"
       }
     ]
   },
@@ -4768,17 +4753,14 @@
   "Vec<PeerId>": {
     "Vec": "PeerId"
   },
-  "Vec<RejectedTransaction>": {
-    "Vec": "RejectedTransaction"
+  "Vec<TransactionValue>": {
+    "Vec": "TransactionValue"
   },
   "Vec<Value>": {
     "Vec": "Value"
   },
   "Vec<Vec<InstructionBox>>": {
     "Vec": "Vec<InstructionBox>"
-  },
-  "Vec<VersionedSignedTransaction>": {
-    "Vec": "VersionedSignedTransaction"
   },
   "Vec<u8>": {
     "Vec": "u8"

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -312,7 +312,6 @@ types!(
     RaiseTo,
     RegisterBox,
     RegistrableBox,
-    RejectedTransaction,
     RemoveKeyValueBox,
     Repeats,
     RevokeBox,


### PR DESCRIPTION
## Description

Adds an index on rejected transactions that is then used to revalidate in the same order as when the block was created.

### Linked issue #3318