### PR TITLE
[refactor] #3615: Preserve wsv after validation

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -245,7 +245,7 @@ impl Iroha {
         let wsv = WorldStateView::from_configuration(config.wsv, world, Arc::clone(&kura));
 
         let notify_shutdown = Arc::new(Notify::new());
-        let block_hashes = kura.init()?;
+        let block_count = kura.init()?;
 
         let queue = Arc::new(Queue::from_configuration(&config.queue));
         if Self::start_telemetry(telemetry, &config).await? {
@@ -264,7 +264,7 @@ impl Iroha {
             kura: Arc::clone(&kura),
             network: network.clone(),
             genesis_network: genesis,
-            block_hashes: &block_hashes,
+            block_count,
         });
 
         let block_sync = BlockSynchronizer::from_configuration(

--- a/client/benches/tps/README.md
+++ b/client/benches/tps/README.md
@@ -38,5 +38,5 @@ You can also run a single trial of the measurement:
 
 ```
 cd client
-cargo run --example tps-oneshot
+cargo run --release --example tps-oneshot
 ```

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -44,7 +44,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
         view_change_index: 0,
         committed_with_topology: iroha_core::sumeragi::network_topology::Topology::new(Vec::new()),
         key_pair: KeyPair::generate().expect("Failed to generate KeyPair"),
-        wsv: WorldStateView::new(World::new(), kura),
+        wsv: &mut WorldStateView::new(World::new(), kura),
     }
     .build();
 

--- a/core/benches/validate_blocks/validate_blocks.rs
+++ b/core/benches/validate_blocks/validate_blocks.rs
@@ -20,7 +20,7 @@ fn create_block(
     instructions: Vec<InstructionBox>,
     account_id: AccountId,
     key_pair: KeyPair,
-    wsv: WorldStateView,
+    wsv: &mut WorldStateView,
 ) -> Result<VersionedCommittedBlock> {
     let transaction = TransactionBuilder::new(account_id)
         .with_instructions(instructions)
@@ -227,13 +227,8 @@ impl WsvValidateBlocks {
 
         for instructions in instructions {
             finalized_wsv = wsv.clone();
-            let block = create_block(
-                instructions,
-                account_id.clone(),
-                key_pair.clone(),
-                wsv.clone(),
-            )?;
-            wsv.apply(&block)?;
+            let block = create_block(instructions, account_id.clone(), key_pair.clone(), &mut wsv)?;
+            wsv.apply_without_execution(&block)?;
             assert_eq!(wsv.height(), finalized_wsv.height() + 1);
         }
 

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -156,7 +156,7 @@ fn sign_blocks(criterion: &mut Criterion) {
                 view_change_index: 0,
                 committed_with_topology: Topology::new(Vec::new()),
                 key_pair: key_pair.clone(),
-                wsv: WorldStateView::new(World::new(), kura.clone()),
+                wsv: &mut WorldStateView::new(World::new(), kura.clone()),
             }
             .build();
 

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -133,7 +133,7 @@ pub struct PendingBlock {
 }
 
 /// Builder for `PendingBlock`
-pub struct BlockBuilder<'a> {
+pub struct BlockBuilder<'world> {
     /// Block's transactions.
     pub transactions: Vec<AcceptedTransaction>,
     /// Block's event recommendations.
@@ -145,7 +145,7 @@ pub struct BlockBuilder<'a> {
     /// The keypair used to sign this block.
     pub key_pair: KeyPair,
     /// The world state to be used when validating the block.
-    pub wsv: &'a mut WorldStateView,
+    pub wsv: &'world mut WorldStateView,
 }
 
 impl BlockBuilder<'_> {

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -217,7 +217,7 @@ mod tests {
             view_change_index: 0,
             committed_with_topology: crate::sumeragi::network_topology::Topology::new(vec![]),
             key_pair: ALICE_KEYS.clone(),
-            wsv: wsv.clone(),
+            wsv: &mut wsv.clone(),
         }
         .build()
         .commit_unchecked()
@@ -233,7 +233,7 @@ mod tests {
                 view_change_index: 0,
                 committed_with_topology: crate::sumeragi::network_topology::Topology::new(vec![]),
                 key_pair: ALICE_KEYS.clone(),
-                wsv: wsv.clone(),
+                wsv: &mut wsv.clone(),
             }
             .build()
             .commit_unchecked()
@@ -368,7 +368,7 @@ mod tests {
             view_change_index: 0,
             committed_with_topology: crate::sumeragi::network_topology::Topology::new(vec![]),
             key_pair: ALICE_KEYS.clone(),
-            wsv: wsv.clone(),
+            wsv: &mut wsv.clone(),
         }
         .build()
         .commit_unchecked()

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -322,26 +322,36 @@ pub const PEERS_CONNECT_INTERVAL: Duration = Duration::from_secs(1);
 pub const TELEMETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Structure represents a block that is currently in discussion.
-#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct VotingBlock {
     /// At what time has this peer voted for this block
     pub voted_at: Instant,
     /// Valid Block
     pub block: PendingBlock,
+    /// WSV after applying transactions to it
+    pub new_wsv: WorldStateView,
 }
 
 impl VotingBlock {
     /// Construct new `VotingBlock` with current time.
-    pub fn new(block: PendingBlock) -> VotingBlock {
+    pub fn new(block: PendingBlock, new_wsv: WorldStateView) -> VotingBlock {
         VotingBlock {
             block,
             voted_at: Instant::now(),
+            new_wsv,
         }
     }
     /// Construct new `VotingBlock` with the given time.
-    pub(crate) fn voted_at(block: PendingBlock, voted_at: Instant) -> VotingBlock {
-        VotingBlock { block, voted_at }
+    pub(crate) fn voted_at(
+        block: PendingBlock,
+        new_wsv: WorldStateView,
+        voted_at: Instant,
+    ) -> VotingBlock {
+        VotingBlock {
+            block,
+            voted_at,
+            new_wsv,
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Reuse wsv created during validation.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Partially closes #3615 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Improve performance by executing instructions only once.

```
validate_blocks/validate_blocks                                                                          
      time:   [705.06 ms 709.27 ms 713.55 ms]
      change: [-46.177% -45.775% -45.415%] (p = 0.00 < 0.10)
      Performance has improved.
```

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
