### PR TITLE
[fix] #3516: make FindTrigger queries return original WASM

### DIFF
--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -4,7 +4,7 @@ use std::{str::FromStr as _, sync::mpsc, thread, time::Duration};
 
 use eyre::{eyre, Result, WrapErr};
 use iroha_client::client::{self, Client};
-use iroha_data_model::{prelude::*, query::error::FindError, trigger::OptimizedExecutable};
+use iroha_data_model::{prelude::*, query::error::FindError};
 use iroha_genesis::GenesisNetwork;
 use iroha_logger::info;
 use test_network::*;
@@ -289,7 +289,7 @@ fn unregister_trigger() -> Result<()> {
     };
     let found_trigger = test_client.request(find_trigger.clone())?;
     let found_action = found_trigger.action;
-    let OptimizedExecutable::Instructions(found_instructions) = found_action.executable else {
+    let Executable::Instructions(found_instructions) = found_action.executable else {
         panic!("Expected instructions");
     };
     let found_trigger = Trigger::new(

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -1019,7 +1019,7 @@ pub mod trigger {
         events::FilterBox,
         expression::EvaluatesTo,
         prelude::InstructionBox,
-        trigger::{OptimizedExecutable, Trigger, TriggerId},
+        trigger::{Trigger, TriggerId},
         Executable, Identifiable, Name, Value,
     };
 
@@ -1073,7 +1073,7 @@ pub mod trigger {
     }
 
     impl Query for FindTriggerById {
-        type Output = Trigger<FilterBox, OptimizedExecutable>;
+        type Output = Trigger<FilterBox, Executable>;
     }
 
     impl Query for FindTriggerKeyValueByIdAndKey {
@@ -1081,7 +1081,7 @@ pub mod trigger {
     }
 
     impl Query for FindTriggersByDomainId {
-        type Output = Vec<Trigger<FilterBox, OptimizedExecutable>>;
+        type Output = Vec<Trigger<FilterBox, Executable>>;
     }
 
     impl FindTriggerById {

--- a/data_model/src/trigger.rs
+++ b/data_model/src/trigger.rs
@@ -76,8 +76,6 @@ pub mod model {
     pub struct WasmInternalRepr {
         /// Serialized with `wasmtime::Module::serialize`
         pub serialized: Vec<u8>,
-        /// Hash of original WASM blob on blockchain
-        pub blob_hash: iroha_crypto::HashOf<crate::transaction::WasmSmartContract>,
     }
 
     /// Same as [`Executable`] but instead of [`Wasm`](Executable::Wasm) contains

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -2120,7 +2120,6 @@
   "HashOf<MerkleTree<VersionedSignedTransaction>>": "Hash",
   "HashOf<VersionedCommittedBlock>": "Hash",
   "HashOf<VersionedSignedTransaction>": "Hash",
-  "HashOf<WasmSmartContract>": "Hash",
   "HashValue": {
     "Enum": [
       {
@@ -4845,10 +4844,6 @@
       {
         "name": "serialized",
         "type": "Vec<u8>"
-      },
-      {
-        "name": "blob_hash",
-        "type": "HashOf<WasmSmartContract>"
       }
     ]
   },

--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -340,6 +340,15 @@ mod genesis {
                 "alice@wonderland".parse()?,
             )),
         );
+        let token = PermissionToken::new("allowed_to_do_stuff".parse()?);
+
+        let register_permission = RegisterBox::new(PermissionTokenDefinition::new(
+            token.definition_id().clone(),
+        ));
+        let role_id: RoleId = "staff_that_does_stuff_in_genesis".parse()?;
+        let register_role =
+            RegisterBox::new(Role::new(role_id.clone()).add_permission(token.clone()));
+
         let alice_id = <Account as Identifiable>::Id::from_str("alice@wonderland")?;
         let grant_permission_to_set_parameters = GrantBox::new(
             PermissionToken::new("can_set_parameters".parse()?),


### PR DESCRIPTION
## Description

Retain original WASM blobs in `TriggerSet`
Substitute internal representation for original when querying for Triggers

### Linked issue

Closes #3516 

### Benefits

No more leaking internal representation
`FindTrigger` queries return actually useful WASM

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
