### PR TITLE
[ci]: Update rustup toolchain & add musl-x86_64 component

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,10 +4,10 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 git docker docker-buildx docker-compose --noconfirm
+RUN pacman -Syu rustup mold musl rust-musl musl-x86_64 openssl libgit2 git docker docker-buildx docker-compose --noconfirm
 
-RUN rustup toolchain install nightly-2022-12-22-x86_64-unknown-linux-gnu
-RUN rustup default nightly-2022-12-22-x86_64-unknown-linux-gnu
+RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
+RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu
 RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt


### PR DESCRIPTION
## Description
1. Add rustup toolchain `nightly-2023-06-25`.
2. Add [musl-x86_64](https://aur.archlinux.org/packages/musl-x86_64) Arch package. Probably should help to fix ` error occurred: Failed to find tool. Is `musl-g++` installed?` error.

### Linked issue
[Broken iroha2-dev compilation](https://github.com/hyperledger/iroha/actions/runs/5346333962/jobs/9693207108).

### Benefits
Should help to fix `registry` job in `I2::Dev::Publish` workflow.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up