### PR TITLE
[ci]: Update rust toolchain in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN rm -rf /etc/pacman.d/gnupg/* && pacman-key --init && pacman-key --populate a
 RUN pacman -Syu --noconfirm --disable-download-timeout
 
 # Set up Rust toolchain
-RUN pacman -S rustup mold musl rust-musl --noconfirm --disable-download-timeout
-RUN rustup toolchain install nightly-2022-12-22
-RUN rustup default nightly-2022-12-22
+RUN pacman -S rustup mold musl rust-musl musl-x86_64 --noconfirm --disable-download-timeout
+RUN rustup toolchain install nightly-2023-06-25
+RUN rustup default nightly-2023-06-25
 RUN rustup target add x86_64-unknown-linux-musl wasm32-unknown-unknown
 RUN rustup component add rust-src
 


### PR DESCRIPTION
## Description
Update rustup toolchain iroha2 `Dockerfile`.

### Linked issue
[Failed CI after updating Dockerfile.build](https://github.com/hyperledger/iroha/actions/runs/5388372729).

### Benefits
Should help to fix `registry` jon in `I2::Dev::Publish` workflow.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
