### PR TITLE
[refactor]: move instruction len from data_model into core

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -21,7 +21,7 @@ use http_default::{AsyncWebSocketStream, WebSocketStream};
 use iroha_config::{client::Configuration, torii::uri, GetConfiguration, PostConfiguration};
 use iroha_crypto::{HashOf, KeyPair};
 use iroha_data_model::{
-    block::VersionedCommittedBlock, predicate::PredicateBox, prelude::*,
+    block::VersionedCommittedBlock, isi::Instruction, predicate::PredicateBox, prelude::*,
     transaction::TransactionPayload, ValidationFail,
 };
 use iroha_logger::prelude::*;

--- a/client/tests/integration/burn_public_keys.rs
+++ b/client/tests/integration/burn_public_keys.rs
@@ -2,7 +2,7 @@
 
 use iroha_client::client::{account, transaction, Client};
 use iroha_crypto::{KeyPair, PublicKey};
-use iroha_data_model::prelude::*;
+use iroha_data_model::{isi::Instruction, prelude::*};
 use test_network::*;
 
 fn submit_and_get(

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -116,7 +116,14 @@ fn committed_block_must_be_available_in_kura() {
         .expect("Failed to submit transaction");
 
     let event = event_iter.next().expect("Block must be committed");
-    let Ok(Event::Pipeline(PipelineEvent { entity_kind: PipelineEntityKind::Block, status: PipelineStatus::Committed, hash })) = event else { panic!("Received unexpected event") };
+    let Ok(Event::Pipeline(PipelineEvent {
+        entity_kind: PipelineEntityKind::Block,
+        status: PipelineStatus::Committed,
+        hash,
+    })) = event
+    else {
+        panic!("Received unexpected event")
+    };
     let hash = HashOf::from_untyped_unchecked(hash);
 
     peer.iroha

--- a/client/tests/integration/query_errors.rs
+++ b/client/tests/integration/query_errors.rs
@@ -24,7 +24,7 @@ fn non_existent_account_is_specific_error() {
     match err {
         ClientQueryError::Validation(ValidationFail::QueryFailed(QueryExecutionFail::Find(
             err,
-        ))) => match *err {
+        ))) => match err {
             FindError::Domain(id) => assert_eq!(id.name.as_ref(), "regalia"),
             x => panic!("FindError::Domain expected, got {x:?}"),
         },

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -200,8 +200,7 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
             .chain()
             .last()
             .expect("At least two error causes expected")
-            .downcast_ref::<Box<FindError>>()
-            .map(std::ops::Deref::deref),
+            .downcast_ref::<FindError>(),
         Some(FindError::Trigger(id)) if *id == trigger_id
     ));
 

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -50,7 +50,7 @@ pub mod isi {
             match wsv.asset(&asset_id) {
                 Err(err) => match err {
                     QueryExecutionFail::Find(find_err)
-                        if matches!(*find_err, FindError::Asset(_)) =>
+                        if matches!(find_err, FindError::Asset(_)) =>
                     {
                         assert_can_register(&asset_id.definition_id, wsv, &self.object.value)?;
                         let asset = wsv

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -619,7 +619,7 @@ pub mod query {
                 .asset(&id)
                 .map_err(|asset_err| {
                     if let Err(definition_err) = wsv.asset_definition(&id.definition_id) {
-                        Error::Find(Box::new(definition_err))
+                        Error::Find(definition_err)
                     } else {
                         asset_err
                     }
@@ -657,7 +657,7 @@ pub mod query {
                 .map_err(|e| Error::Evaluate(e.to_string()))?;
             let asset = wsv.asset(&id).map_err(|asset_err| {
                 if let Err(definition_err) = wsv.asset_definition(&id.definition_id) {
-                    Error::Find(Box::new(definition_err))
+                    Error::Find(definition_err)
                 } else {
                     asset_err
                 }
@@ -670,7 +670,7 @@ pub mod query {
                 .map_err(|e| Error::Conversion(e.to_string()))?;
             Ok(store
                 .get(&key)
-                .ok_or_else(|| Error::Find(Box::new(FindError::MetadataKey(key))))?
+                .ok_or_else(|| Error::Find(FindError::MetadataKey(key)))?
                 .clone())
         }
     }

--- a/core/src/smartcontracts/isi/block.rs
+++ b/core/src/smartcontracts/isi/block.rs
@@ -47,7 +47,7 @@ impl ValidQuery for FindBlockHeaderByHash {
         let block = wsv
             .all_blocks()
             .find(|block| block.hash() == hash)
-            .ok_or_else(|| QueryExecutionFail::Find(Box::new(FindError::Block(hash))))?;
+            .ok_or_else(|| QueryExecutionFail::Find(FindError::Block(hash)))?;
 
         Ok(block.as_v1().header.clone())
     }

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -443,7 +443,7 @@ pub mod prelude {
 mod tests {
     #![allow(clippy::restriction)]
 
-    use core::str::FromStr;
+    use core::str::FromStr as _;
     use std::sync::Arc;
 
     use iroha_crypto::KeyPair;

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -100,7 +100,9 @@ mod tests {
     use std::str::FromStr as _;
 
     use iroha_crypto::{Hash, HashOf, KeyPair};
-    use iroha_data_model::{block::VersionedCommittedBlock, transaction::TransactionLimits};
+    use iroha_data_model::{
+        block::VersionedCommittedBlock, query::error::FindError, transaction::TransactionLimits,
+    };
     use once_cell::sync::Lazy;
 
     use super::*;
@@ -384,7 +386,10 @@ mod tests {
             .sign(ALICE_KEYS.clone())?;
         let wrong_hash = unapplied_tx.hash();
         let not_found = FindTransactionByHash::new(wrong_hash).execute(&wsv);
-        assert!(not_found.is_err());
+        assert!(matches!(
+            not_found,
+            Err(Error::Find(FindError::Transaction(_)))
+        ));
 
         let found_accepted = FindTransactionByHash::new(va_tx.hash()).execute(&wsv)?;
         if found_accepted.transaction.error.is_none() {

--- a/core/src/smartcontracts/isi/triggers/mod.rs
+++ b/core/src/smartcontracts/isi/triggers/mod.rs
@@ -225,7 +225,7 @@ pub mod query {
             } = wsv
                 .triggers()
                 .inspect_by_id(&id, |action| action.clone_and_box())
-                .ok_or_else(|| Error::Find(Box::new(FindError::Trigger(id.clone()))))?;
+                .ok_or_else(|| Error::Find(FindError::Trigger(id.clone())))?;
 
             let action =
                 Action::new(loaded_executable, repeats, authority, filter).with_metadata(metadata);
@@ -253,7 +253,7 @@ pub mod query {
                         .map(Clone::clone)
                         .ok_or_else(|| FindError::MetadataKey(key.clone()).into())
                 })
-                .ok_or_else(|| Error::Find(Box::new(FindError::Trigger(id))))?
+                .ok_or_else(|| Error::Find(FindError::Trigger(id)))?
         }
     }
 

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -448,7 +448,7 @@ pub mod query {
             iroha_logger::trace!(%role_id);
 
             wsv.world.roles.get(&role_id).map_or_else(
-                || Err(Error::Find(Box::new(FindError::Role(role_id)))),
+                || Err(Error::Find(FindError::Role(role_id))),
                 |role_ref| Ok(role_ref.clone()),
             )
         }

--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -474,7 +474,7 @@ impl WorldStateView {
                 account
                     .assets
                     .get(id)
-                    .ok_or_else(|| QueryExecutionFail::from(Box::new(FindError::Asset(id.clone()))))
+                    .ok_or_else(|| QueryExecutionFail::from(FindError::Asset(id.clone())))
                     .map(Clone::clone)
             },
         )?

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -21,7 +21,7 @@ use iroha_config::{
     torii::Configuration as ToriiConfiguration,
 };
 use iroha_core::prelude::*;
-use iroha_data_model::{peer::Peer as DataModelPeer, prelude::*};
+use iroha_data_model::{isi::Instruction, peer::Peer as DataModelPeer, prelude::*};
 use iroha_genesis::{GenesisNetwork, RawGenesisBlock};
 use iroha_logger::{Configuration as LoggerConfiguration, InstrumentFutures};
 use iroha_primitives::addr::{socket_addr, SocketAddr};

--- a/data_model/derive/src/model.rs
+++ b/data_model/derive/src/model.rs
@@ -15,7 +15,10 @@ pub fn impl_model(input: &syn::ItemMod) -> TokenStream {
     } = input;
 
     let syn::Visibility::Public(vis_public) = vis else {
-        abort!(input, "The `model` attribute can only be used on public modules");
+        abort!(
+            input,
+            "The `model` attribute can only be used on public modules"
+        );
     };
     if ident != "model" {
         abort!(

--- a/data_model/src/name.rs
+++ b/data_model/src/name.rs
@@ -55,7 +55,8 @@ impl Name {
             .chars()
             .count()
             .try_into()
-            .map(|len| range.contains(&len)) else {
+            .map(|len| range.contains(&len))
+        else {
             return Err(InvalidParameterError::NameLength);
         };
         Ok(())

--- a/data_model/src/query.rs
+++ b/data_model/src/query.rs
@@ -1460,7 +1460,7 @@ pub mod error {
                 String,
             ),
             /// Query found nothing
-            Find(#[cfg_attr(feature = "std", source)] Box<FindError>),
+            Find(#[cfg_attr(feature = "std", source)] FindError),
             /// Query found wrong type of asset: {0}
             Conversion(
                 #[skip_from]

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -22,8 +22,11 @@ use serde::{Deserialize, Serialize};
 
 pub use self::model::*;
 use crate::{
-    account::AccountId, isi::InstructionBox, metadata::UnlimitedMetadata, name::Name,
-    prelude::Instruction, Value,
+    account::AccountId,
+    isi::{Instruction, InstructionBox},
+    metadata::UnlimitedMetadata,
+    name::Name,
+    Value,
 };
 
 #[model]

--- a/data_model/src/visit.rs
+++ b/data_model/src/visit.rs
@@ -477,11 +477,11 @@ pub fn visit_transfer<V: Visit + ?Sized>(
     let object = evaluate_expr!(visitor, authority, <isi as Transfer>::object());
 
     let (IdBox::AssetId(source_id), IdBox::AccountId(destination_id)) = (
-            evaluate_expr!(visitor, authority, <isi as Transfer>::source_id()),
-            evaluate_expr!(visitor, authority, <isi as Transfer>::destination_id()),
-        ) else {
-            return visitor.visit_unsupported(authority, isi);
-        };
+        evaluate_expr!(visitor, authority, <isi as Transfer>::source_id()),
+        evaluate_expr!(visitor, authority, <isi as Transfer>::destination_id()),
+    ) else {
+        return visitor.visit_unsupported(authority, isi);
+    };
 
     match object {
         Value::Numeric(object) => visitor.visit_transfer_asset(

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeMap, format, vec::Vec};
 use core::ops::RangeFrom;
 
-use data_model::{prelude::*, query::QueryBox, validator::NeedsValidationBox};
+use data_model::{isi::Instruction, prelude::*, query::QueryBox, validator::NeedsValidationBox};
 use debug::DebugExpectExt as _;
 pub use iroha_data_model as data_model;
 pub use iroha_wasm_derive::main;

--- a/wasm_codec/derive/src/lib.rs
+++ b/wasm_codec/derive/src/lib.rs
@@ -373,8 +373,15 @@ fn classify_fn(fn_sig: &syn::Signature) -> FnClass {
         };
     }
 
-    let syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments { args: generics, ..}) = &output_last_segment.arguments else {
-        abort!(output_last_segment.arguments, "`Result` return type should have generic arguments");
+    let syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+        args: generics,
+        ..
+    }) = &output_last_segment.arguments
+    else {
+        abort!(
+            output_last_segment.arguments,
+            "`Result` return type should have generic arguments"
+        );
     };
 
     let ok_type = classify_ok_type(generics);
@@ -434,7 +441,11 @@ fn classify_params_and_state(
 
 fn parse_state_param(param: &syn::PatType) -> Result<&syn::Type, Diagnostic> {
     let syn::Pat::Ident(pat_ident) = &*param.pat else {
-        return Err(diagnostic!(param, Level::Error, "State parameter should be an ident"));
+        return Err(diagnostic!(
+            param,
+            Level::Error,
+            "State parameter should be an ident"
+        ));
     };
     if !["state", "_state"].contains(&&*pat_ident.ident.to_string()) {
         return Err(diagnostic!(
@@ -445,7 +456,11 @@ fn parse_state_param(param: &syn::PatType) -> Result<&syn::Type, Diagnostic> {
     }
 
     let syn::Type::Reference(ty_ref) = &*param.ty else {
-        return Err(diagnostic!(param.ty, Level::Error, "State parameter should be either reference or mutable reference"));
+        return Err(diagnostic!(
+            param.ty,
+            Level::Error,
+            "State parameter should be either reference or mutable reference"
+        ));
     };
 
     Ok(&*ty_ref.elem)
@@ -458,7 +473,10 @@ fn classify_ok_type(
         .first()
         .expect_or_abort("First generic argument expected in `Result` return type");
     let syn::GenericArgument::Type(ok_type) = ok_generic else {
-        abort!(ok_generic, "First generic of `Result` return type expected to be a type");
+        abort!(
+            ok_generic,
+            "First generic of `Result` return type expected to be a type"
+        );
     };
 
     if let syn::Type::Tuple(syn::TypeTuple { elems, .. }) = ok_type {
@@ -473,15 +491,17 @@ fn extract_err_type(generics: &Punctuated<syn::GenericArgument, syn::Token![,]>)
         .iter()
         .nth(1)
         .expect_or_abort("Second generic argument expected in `Result` return type");
-    let syn::GenericArgument::Type(err_type) = err_generic else
-    {
-        abort!(err_generic, "Second generic of `Result` return type expected to be a type");
+    let syn::GenericArgument::Type(err_type) = err_generic else {
+        abort!(
+            err_generic,
+            "Second generic of `Result` return type expected to be a type"
+        );
     };
     err_type
 }
 
 fn unwrap_path(ty: &syn::Type) -> &syn::Path {
-    let syn::Type::Path(syn::TypePath {ref path, ..}) = *ty else {
+    let syn::Type::Path(syn::TypePath { ref path, .. }) = *ty else {
         abort!(ty, "Expected path");
     };
 


### PR DESCRIPTION
## Description

the less functionality we expose in public API the better

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
