### PR TITLE
[ci]: Remove i2 PR-build trigger

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -3,11 +3,6 @@ name: I2::Dev::Publish
 on:
   push:
     branches: [iroha2-dev]
-  # Run the workflow to check that the docker containers are properly buildable
-  pull_request_target:
-    branches: [iroha2-dev]
-    paths:
-      - '.github/workflows/**.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,7 +4,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN pacman -Syu rustup mold musl rust-musl musl openssl libgit2 git docker docker-buildx docker-compose --noconfirm
+RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 git docker docker-buildx docker-compose --noconfirm
 
 RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
 RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu


### PR DESCRIPTION
[ci]: Remove i2 PR-build & Update rust nightly toolchain

## Description
1. Remove PR-trigger from `I2::Dev::Publish` workflow. It doesn't make sense it is always executed in base branch context. `pull_request` trigger makes sense only if PR is coming from internal repo PR branch. But it fails while PR from fork. Increasing workflow permission doesn't help as well. Instead of this, to check if PR-image is buildable, we can try PR-generator feature soon with the whole k8s CI/CD process when it's really necessary. Or to invent an another approach like keeping Actions secrets in an external place.

### Linked issue
[Failed Actions](https://github.com/hyperledger/iroha/actions/runs/5517090208)

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
