### PR TITLE
[fix] #3613: Do not tolerate invalid signatures on transactions

### DIFF
--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -377,12 +377,8 @@ mod candidate {
 
     impl SignedTransactionCandidate {
         #[cfg(feature = "std")]
-        fn validate(mut self) -> Result<SignedTransaction, &'static str> {
-            // TODO: Should we tolerate invalid signatures?
-            if self.retain_verified_signatures().is_empty() {
-                return Err("Transaction contains no valid signatures");
-            }
-
+        fn validate(self) -> Result<SignedTransaction, &'static str> {
+            self.validate_signatures()?;
             self.validate_instructions()
         }
 
@@ -405,12 +401,10 @@ mod candidate {
         }
 
         #[cfg(feature = "std")]
-        fn retain_verified_signatures(
-            &mut self,
-        ) -> Vec<&iroha_crypto::SignatureOf<TransactionPayload>> {
+        fn validate_signatures(&self) -> Result<(), &'static str> {
             self.signatures
-                .retain_verified_by_hash(self.payload.hash())
-                .collect()
+                .verify_hash(self.payload.hash())
+                .map_err(|_| "Transaction contains invalid signatures")
         }
     }
 


### PR DESCRIPTION
## Description

Fail deserializing/decoding transactions with invalid signatures 

Closes #3613 

## Unsolved questions

1. There are other places where the "retain valid signatures" logic is used: https://github.com/hyperledger/iroha/blob/c0a59c002b822a9dbca9bba376651d0e7457547a/core/src/sumeragi/network_topology.rs#L233 and https://github.com/hyperledger/iroha/blob/c0a59c002b822a9dbca9bba376651d0e7457547a/core/src/sumeragi/main_loop.rs#L1042 Maybe the logic in these places should be changed too? Or would it break some assumptions?

2. Error handling here is a bit funky. It returns an ad-hoc `&'static str` as an error type, potentially losing some context. It _could_ make sense to defined another error type just for this.