### PR TITLE
[ci]: Trigger iroha2 PR-build only for PR-generator case

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -104,3 +104,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: mold --run cargo test -p iroha_client --tests --no-default-features unstable_network --quiet
+
+  # Run the job to check that the docker containers are properly buildable
+  pr-generator-build:
+    # Job will only execute if the head of the pull request is a branch for PR-generator case
+    if: startsWith(github.head_ref, 'iroha2-pr-deploy/')
+    runs-on: [self-hosted, Linux, iroha2-dev-push]
+    container:
+      image: hyperledger/iroha2-ci:nightly-2023-06-25
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Soramitsu Harbor
+        uses: docker/login-action@v2
+        with:
+          registry: docker.soramitsu.co.jp
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        if: always()
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+      - name: Build and push iroha2:dev image
+        uses: docker/build-push-action@v4
+        if: always()
+        with:
+          push: true
+          tags: docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
+          labels: commit=${{ github.sha }}
+          build-args: TAG=dev
+          file: Dockerfile
+          # This context specification is required
+          context: .

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -38,11 +38,9 @@ jobs:
         if: always()
         with:
           push: true
-          # include the tag for PR-generator image specifically
           tags: |
             hyperledger/iroha2:dev
             docker.soramitsu.co.jp/iroha2/iroha2:dev
-            docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
           labels: commit=${{ github.sha }}
           build-args: TAG=dev
           file: Dockerfile


### PR DESCRIPTION
## Description

1. Add the trigger to build iroha2 PR-image from INTERNAL repository `hyperledger/iroha` branch if it's a PR-generator case.

## Requirements
1. INTERNAL branch should start from `iroha2-pr-deploy/`
2. PR should has `experimental_environment` label

### Benefits

Check if iroha2 PR-image is properly buildable when it's necessary.


### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

