### PR TITLE
[refactor] #3289: Use workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,15 +169,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.2"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.2",
@@ -674,14 +674,14 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.1"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex 0.5.0",
+ "once_cell",
  "strsim",
 ]
 
@@ -839,12 +839,6 @@ name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1311,10 +1305,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn 1.0.109",
 ]
 
@@ -3469,7 +3461,7 @@ dependencies = [
 name = "kagami"
 version = "2.0.0-pre-rc.16"
 dependencies = [
- "clap 4.3.2",
+ "clap 4.3.11",
  "color-eyre",
  "derive_more",
  "duct",
@@ -3517,7 +3509,7 @@ dependencies = [
 name = "kura_inspector"
 version = "2.0.0-pre-rc.16"
 dependencies = [
- "clap 3.2.25",
+ "clap 4.3.11",
  "iroha_core",
  "iroha_data_model",
  "iroha_version",
@@ -3968,7 +3960,7 @@ dependencies = [
 name = "parity_scale_decoder"
 version = "2.0.0-pre-rc.16"
 dependencies = [
- "clap 3.2.25",
+ "clap 4.3.11",
  "colored",
  "eyre",
  "iroha_crypto",
@@ -4638,15 +4630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,12 +4780,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,117 @@ license = "Apache-2.0"
 keywords = ["blockchain", "crypto", "iroha", "ledger"]
 categories = ["cryptography::cryptocurrencies"]
 
+[workspace.dependencies]
+iroha = { path = "cli" }
+iroha_cli_derive = { version = "=2.0.0-pre-rc.16", path = "cli/derive" }
+iroha_macro_utils = { version = "=2.0.0-pre-rc.16", path = "macro/utils" }
+iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "wasm_builder" }
+iroha_telemetry = { version = "=2.0.0-pre-rc.16", path = "telemetry" }
+iroha_telemetry_derive = { version = "=2.0.0-pre-rc.16", path = "telemetry/derive" }
+iroha_p2p = { version = "=2.0.0-pre-rc.16", path = "p2p" }
+iroha_data_model_derive = { version = "=2.0.0-pre-rc.16", path = "data_model/derive" }
+iroha_core = { version = "=2.0.0-pre-rc.16", path = "core" }
+iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "primitives", default-features = false }
+iroha_primitives_derive = { version = "=2.0.0-pre-rc.16", path = "primitives/derive" }
+iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "data_model" }
+iroha_client = { version = "=2.0.0-pre-rc.16", path = "client" }
+iroha_config = { version = "=2.0.0-pre-rc.16", path = "config" }
+iroha_config_base = { version = "=2.0.0-pre-rc.16", path = "config/base" }
+iroha_config_derive = { version = "=2.0.0-pre-rc.16", path = "config/base/derive" }
+iroha_schema_gen = { version = "=2.0.0-pre-rc.16", path = "schema/gen" }
+iroha_schema = { version = "=2.0.0-pre-rc.16", path = "schema", default-features = false }
+iroha_schema_derive = { version = "=2.0.0-pre-rc.16", path = "schema/derive" }
+iroha_logger = { version = "=2.0.0-pre-rc.16", path = "logger" }
+iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "crypto", default-features = false }
+iroha_macro = { version = "=2.0.0-pre-rc.16", path = "macro", default-features = false }
+iroha_derive = { version = "=2.0.0-pre-rc.16", path = "macro/derive" }
+iroha_futures = { version = "=2.0.0-pre-rc.16", path = "futures" }
+iroha_futures_derive = { version = "=2.0.0-pre-rc.16", path = "futures/derive" }
+iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "genesis" }
+iroha_ffi = { version = "=2.0.0-pre-rc.16", path = "ffi" }
+iroha_ffi_derive = { version = "=2.0.0-pre-rc.16", path = "ffi/derive" }
+iroha_version = { version = "=2.0.0-pre-rc.16", path = "version", default-features = false }
+iroha_version_derive = { version = "=2.0.0-pre-rc.16", path = "version/derive", default-features = false }
+iroha_wasm_codec = { version = "=2.0.0-pre-rc.16", path = "wasm_codec" }
+test_network = { version = "=2.0.0-pre-rc.16", path = "core/test_network" }
+
+proc-macro-error = "1.0.4"
+proc-macro2 = "1.0.49"
+syn = { version = "1.0.107", default-features = false }
+quote = "1.0.23"
+
+futures = { version = "0.3.25", default-features = false }
+async-stream = "0.3.3"
+tokio = "1.23.0"
+tokio-stream = "0.1.11"
+tokio-tungstenite = "0.17.2"
+
+crossbeam = "0.8.2"
+crossbeam-queue = "0.3.8"
+parking_lot = { version = "0.12.1" }
+
+once_cell = "1.16.0"
+tempfile = "3.3.0"
+path-absolutize = "3.1.0"
+pathdiff = "0.2.1"
+itertools = "0.10.5"
+bytes = "1.4.0"
+
+vergen = { version = "8.1.1", default-features = false }
+trybuild = "1.0.73"
+
+base64 = { version = "0.13.1", default-features = false }
+hex = { version = "0.4.3", default-features = false }
+
+fixnum = { version = "0.9.1", default-features = false }
+url = "2.3.1"
+prometheus = { version = "0.13.3", default-features = false }
+
+clap = "4.2.1"
+owo-colors = "3.5.0"
+supports-color = "2.0.0"
+inquire = "0.6.2"
+spinoff = "0.7.0"
+duct = "0.13.6"
+
+criterion = "0.3.6"
+proptest = "1.0.0"
+expect-test = "1.4.1"
+
+eyre = "0.6.8"
+color-eyre = "0.6.2"
+thiserror = { version = "1.0.38", default-features = false }
+
+cfg-if = "1.0.0"
+derive_more = { version = "0.99.17", default-features = false }
+async-trait = "0.1.60"
+strum = { version = "0.24.1", default-features = false }
+getset = "0.1.2"
+hex-literal = "0.3.4"
+
+ursa = "0.3.7"
+aead = "0.3.2"
+
+rand = "0.8.5"
+warp = { version = "0.3.3", default-features = false }
+wasmtime = "0.39.1"
+
+tracing = "0.1.37"
+tracing-core = "0.1.30"
+tracing-subscriber = { version = "0.3.16", default-features = false }
+tracing-futures = { version = "0.2.5", default-features = false }
+tracing-bunyan-formatter = { version = "0.3.4", default-features = false }
+
+dashmap = "5.4.0"
+rustc-hash = "1.1.0"
+
+serde = { version = "1.0.151", default-features = false }
+serde_json = { version = "1.0.91", default-features = false }
+serde_yaml = "0.9.21"
+serde_with = { version = "2.2.0", default-features = false }
+parity-scale-codec = { version = "3.2.1", default-features = false }
+json5 = "0.4.1"
+
 [workspace]
 resolver = "2"
 members = [
@@ -54,6 +165,7 @@ members = [
   "wasm_codec/derive",
   "wasm_builder",
 ]
+
 
 [profile.deploy]
 inherits = "release"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,45 +39,45 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_core = { version = "=2.0.0-pre-rc.16", path = "../core" }
-iroha_macro = { version = "=2.0.0-pre-rc.16", path = "../macro" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
-iroha_futures = { version = "=2.0.0-pre-rc.16", path = "../futures" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model", features = ["http"] }
-iroha_telemetry = { version = "=2.0.0-pre-rc.16", path = "../telemetry", optional = true }
-iroha_version = { version = "=2.0.0-pre-rc.16", path = "../version", features = ["http"] }
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
-iroha_p2p = { version = "=2.0.0-pre-rc.16", path = "../p2p" }
-iroha_schema_gen = { version = "=2.0.0-pre-rc.16", path = "../schema/gen", optional = true }
-iroha_cli_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../genesis" }
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "../wasm_builder" }
+iroha_core = { workspace = true }
+iroha_macro = { workspace = true }
+iroha_logger = { workspace = true }
+iroha_futures = { workspace = true }
+iroha_data_model = { workspace = true, features = ["http"] }
+iroha_telemetry = { workspace = true, optional = true }
+iroha_version = { workspace = true, features = ["http"] }
+iroha_config = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_p2p = { workspace = true }
+iroha_schema_gen = { workspace = true, optional = true }
+iroha_cli_derive = { workspace = true }
+iroha_genesis = { workspace = true }
+iroha_wasm_builder = { workspace = true }
 
 
-async-trait = "0.1.60"
-color-eyre = "0.6.2"
-eyre = "0.6.8"
-tracing = "0.1.37"
-futures = { version = "0.3.25", default-features = false, features = ["std", "async-await"] }
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.151", features = ["derive"] }
-serde_json = "1.0.91"
-thiserror = "1.0.38"
-tokio = { version = "1.23.0", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs", "signal"] }
-warp = "0.3.3"
+async-trait = { workspace = true }
+color-eyre = { workspace = true }
+eyre = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs", "signal"] }
+warp = { workspace = true, features = ["multipart", "websocket"] }
 serial_test = "0.8.0"
-once_cell = "1.16.0"
-owo-colors = { version = "3.5.0", features = ["supports-colors"] }
-supports-color = "2.0.0"
+once_cell = { workspace = true }
+owo-colors = { workspace = true, features = ["supports-colors"] }
+supports-color = { workspace = true }
 thread-local-panic-hook = { version = "0.1.0", optional = true }
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 
 [build-dependencies]
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "../wasm_builder" }
-eyre = "0.6.8"
+iroha_wasm_builder = { workspace = true }
+eyre = { workspace = true }
 
-vergen = { version = "8.1.1", default-features = false, features = ["cargo"] }
+vergen = { workspace = true, features = ["cargo"] }
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,53 +20,54 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto"}
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model", features = ["http"] }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger"}
-iroha_telemetry = { version ="=2.0.0-pre-rc.16", path = "../telemetry" }
-iroha_version = { version = "=2.0.0-pre-rc.16", path = "../version", features = ["http"] }
+iroha_config = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_data_model = { workspace = true, features = ["http"] }
+iroha_primitives = { workspace = true }
+iroha_logger = { workspace = true }
+iroha_telemetry = { workspace = true }
+iroha_version = { workspace = true, features = ["http"] }
 
 attohttpc = "0.18.0"
-eyre = "0.6.8"
+eyre = { workspace = true }
 http = "0.2.8"
-url = "2.3.1"
-rand = "0.8.5"
-serde = { version = "1.0.151", features = ["derive"] }
-serde_json = "1.0.91"
-base64 = "0.13.1"
-thiserror = "1.0.38"
-derive_more = "0.99.17"
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-tokio = { version = "1.23.0", features = ["rt"] }
-tokio-tungstenite = { version = "0.16", features = ["native-tls"] }
+url = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+thiserror = { workspace = true }
+derive_more = { workspace = true }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
+tokio = { workspace = true, features = ["rt"] }
+# TODO: migrate to tokio-tungstenite 0.17 (or newer) and use the workspace dependency
+tokio-tungstenite = { version = "0.16.1", features = ["native-tls"] }
 tungstenite = { version = "0.16", features = ["native-tls"] }
 futures-util = "0.3.25"
 
 [dev-dependencies]
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "../wasm_builder" }
+iroha_wasm_builder = { workspace = true }
 
 # TODO: These three activate `transparent_api` but client should never activate this feature.
 # Additionally there is a dependency on iroha_core in dev-dependencies in telemetry/derive
 # Hopefully, once the integration tests migration is finished these can be removed
-iroha = { path = "../cli", features = ["dev-telemetry", "telemetry"] }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../genesis"}
-test_network = { version = "=2.0.0-pre-rc.16", path = "../core/test_network" }
+iroha = { workspace = true, features = ["dev-telemetry", "telemetry"] }
+iroha_genesis = { workspace = true }
+test_network = { workspace = true }
 
-tokio = { version = "1.23.0", features = ["rt-multi-thread"] }
-criterion = { version = "0.3.6", features = ["html_reports"] }
-color-eyre = "0.6.2"
-tempfile = "3.3.0"
-hex = "0.4.3"
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+criterion = { workspace = true, features = ["html_reports"] }
+color-eyre = { workspace = true }
+tempfile = { workspace = true }
+hex = { workspace = true }
 
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["fmt", "ansi"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
 tracing-flame = "0.2.0"
-once_cell = "1.16.0"
+once_cell = { workspace = true }
 
 [build-dependencies]
-eyre = "0.6.8"
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "../wasm_builder" }
+eyre = { workspace = true }
+iroha_wasm_builder = { workspace = true }
 
 [[bench]]
 name = "torii"

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -20,18 +20,19 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_client = { version = "=2.0.0-pre-rc.16", path = "../client" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
+iroha_client = { workspace = true }
+iroha_data_model = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_config = { workspace = true }
 
-color-eyre = "0.6.2"
+color-eyre = { workspace = true }
+# TODO: migrate to clap v4 (and use the workspace dependency)
 clap = { version = "3.2.23", features = ["derive"] }
 dialoguer = { version = "0.10.2", default-features = false }
-json5 = "0.4.1"
-once_cell = "1.16.0"
-serde_json = "1.0.93"
+json5 = { workspace = true }
+once_cell = { workspace = true }
+serde_json = { workspace = true }
 erased-serde = "0.3.24"
 
 [build-dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -8,27 +8,27 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_config_base = { path = "base" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
+iroha_config_base = { workspace = true }
+iroha_data_model = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_crypto = { workspace = true }
 
-eyre = "0.6.8"
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["fmt", "ansi"] }
-url = { version = "2.3.1", features = ["serde"] }
+eyre = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
+url = { workspace = true, features = ["serde"] }
 
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-strum = { version = "0.24.1", default-features = false, features = ["derive"] }
-serde_json = "1.0.91"
-json5 = "0.4.1"
-thiserror = "1.0.38"
-derive_more = "0.99.17"
-cfg-if = "1.0.0"
-path-absolutize = "3.0.14"
+serde = { workspace = true, features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+json5 = { workspace = true }
+thiserror = { workspace = true }
+derive_more = { workspace = true }
+cfg-if = { workspace = true }
+path-absolutize = { workspace = true }
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = { workspace = true }
 
 [features]
 default = []

--- a/config/base/Cargo.toml
+++ b/config/base/Cargo.toml
@@ -8,13 +8,13 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_config_derive = { path = "derive" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../../crypto" }
+iroha_config_derive = { workspace = true }
+iroha_crypto = { workspace = true }
 
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_json = "1.0.91"
-json5 = "0.4.1"
-thiserror = "1.0.38"
-crossbeam = "0.8.2"
-eyre = "0.6.8"
+serde = { workspace = true, default-features = false, features = ["derive"] }
+serde_json = { workspace = true }
+json5 = { workspace = true }
+thiserror = { workspace = true }
+crossbeam = { workspace = true }
+eyre = { workspace = true }
 

--- a/config/base/derive/Cargo.toml
+++ b/config/base/derive/Cargo.toml
@@ -11,10 +11,11 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", default-features = false, features = ["derive", "parsing", "proc-macro", "clone-impls", "printing"] }
-# This is the maximally compressed set of features. Yes we also need "printing".
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
+iroha_macro_utils = { workspace = true }
 
-iroha_macro_utils = { version = "=2.0.0-pre-rc.16", path = "../../../macro/utils" }
+syn = { workspace = true, features = ["derive", "parsing", "proc-macro", "clone-impls", "printing"] }
+# This is the maximally compressed set of features. Yes we also need "printing".
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
+

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,42 +37,42 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model", features = ["transparent_api"] }
-iroha_macro = { version = "=2.0.0-pre-rc.16", path = "../macro" }
-iroha_p2p = { version = "=2.0.0-pre-rc.16", path = "../p2p" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger"}
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
-iroha_version = { version = "=2.0.0-pre-rc.16", path = "../version" }
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_futures = { version = "=2.0.0-pre-rc.16", path = "../futures" }
-iroha_telemetry = { version = "=2.0.0-pre-rc.16", path = "../telemetry" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../genesis" }
-iroha_wasm_codec = { version = "=2.0.0-pre-rc.16", path = "../wasm_codec" }
+iroha_data_model = { workspace = true, features = ["transparent_api"] }
+iroha_macro = { workspace = true }
+iroha_p2p = { workspace = true }
+iroha_logger = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_version = { workspace = true }
+iroha_config = { workspace = true }
+iroha_futures = { workspace = true }
+iroha_telemetry = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_genesis = { workspace = true }
+iroha_wasm_codec = { workspace = true }
 
-async-trait = "0.1.60"
-dashmap = "5.4.0"
-eyre = "0.6.8"
-futures = { version = "0.3.25", default-features = false, features = ["std", "async-await"] }
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-rand = "0.8.5"
-serde = { version = "1.0.151", features = ["derive"] }
-serde_json = "1.0.91"
-tokio = { version = "1.23.0", features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"] }
-crossbeam-queue = "0.3.8"
-thiserror = "1.0.38"
-wasmtime = "0.39.1"
-parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
-derive_more = "0.99.17"
-itertools = "0.10.5"
+async-trait = { workspace = true }
+dashmap = { workspace = true }
+eyre = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"] }
+crossbeam-queue = { workspace = true }
+thiserror = { workspace = true }
+wasmtime = { workspace = true }
+parking_lot = { workspace = true, features = ["deadlock_detection"] }
+derive_more = { workspace = true }
+itertools = { workspace = true }
 sealed = "0.5.0"
 
 [dev-dependencies]
-criterion = "0.3.6"
-hex = "0.4.3"
+criterion = { workspace = true }
+hex = { workspace = true }
 byte-unit = "4.0.18"
-once_cell = "1.16.0"
-tempfile = "3.3.0"
+once_cell = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "validation"

--- a/core/test_network/Cargo.toml
+++ b/core/test_network/Cargo.toml
@@ -8,19 +8,19 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha = { path = "../../cli", features = ["test-network"] }
-iroha_client = { version = "=2.0.0-pre-rc.16", path = "../../client" }
-iroha_core = { version = "=2.0.0-pre-rc.16", path = "../../core" }
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../../config" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../../data_model" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../../primitives" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../../logger" }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../../genesis" }
+iroha = { workspace = true, features = ["test-network"] }
+iroha_client = { workspace = true }
+iroha_core = { workspace = true }
+iroha_config = { workspace = true }
+iroha_data_model = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_logger = { workspace = true }
+iroha_genesis = { workspace = true }
 
 
-eyre = "0.6.8"
-futures = { version = "0.3.25", default-features = false, features = ["std", "async-await"] }
-rand = "0.8.5"
-tempfile = "3.3.0"
-tokio = { version = "1.23.0", features = ["rt", "rt-multi-thread", "macros"] }
+eyre = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
+rand = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 unique_port = "0.2.1"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,20 +21,20 @@ vendored = ["openssl-sys"]
 ffi_export = ["std", "iroha_ffi", "iroha_primitives/ffi_export"]
 
 [dependencies]
-iroha_primitives = { path = "../primitives", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_ffi = { path = "../ffi", version = "=2.0.0-pre-rc.16", optional = true }
-iroha_schema = { path = "../schema" }
+iroha_primitives = { workspace = true }
+iroha_macro = { workspace = true }
+iroha_ffi = { workspace = true, optional = true }
+iroha_schema = { workspace = true }
 
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "deref_mut", "display"] }
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive", "full"] }
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_with = { version = "2.2.0", default-features = false, features = ["macros"] }
-hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
+derive_more = { workspace = true, features = ["deref", "deref_mut", "display"] }
+parity-scale-codec = { workspace = true, features = ["derive", "full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["macros"] }
+hex = { workspace = true, features = ["alloc", "serde"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"], optional = true }
-ursa = { version = "0.3.7", optional = true }
-getset = "0.1.2"
+ursa = { workspace = true, optional = true }
+getset = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.3.4"
-serde_json = "1.0.91"
+hex-literal = { workspace = true }
+serde_json = { workspace = true }

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -30,32 +30,32 @@ ffi_export = ["std", "iroha_ffi", "iroha_primitives/ffi_export", "iroha_crypto/f
 transparent_api = []
 
 [dependencies]
-iroha_primitives = { path = "../primitives", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_data_model_derive = { path = "derive", version = "=2.0.0-pre-rc.16" }
-iroha_crypto = { path = "../crypto", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_version = { path = "../version", version = "=2.0.0-pre-rc.16", default-features = false, features = ["derive", "json", "scale"] }
-iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.16" }
-iroha_ffi = { path = "../ffi", version = "=2.0.0-pre-rc.16", optional = true }
+iroha_primitives = { workspace = true }
+iroha_data_model_derive = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_macro = { workspace = true }
+iroha_version = { workspace = true, features = ["derive", "json", "scale"] }
+iroha_schema = { workspace = true }
+iroha_ffi = { workspace = true, optional = true }
 
-dashmap = { version = "5.4.0", optional = true }
-tokio = { version = "1.23.0", features = ["sync", "rt-multi-thread"], optional = true }
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["as_ref", "display", "constructor", "from_str", "from", "into"] }
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_with = {version = "2.2.0", default-features = false, features = ["macros"]}
-serde_json = { version = "1.0.91", default-features = false, features = ["arbitrary_precision"] }
-warp = { version = "0.3.3", default-features = false, optional = true }
-thiserror = { version = "1.0.38", optional = true }
-getset = "0.1.2"
-strum = { version = "0.24.1", default-features = false, features = ["derive"] }
-base64 = { version = "0.13.1", default-features = false, features = ["alloc"]}
+dashmap = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["sync", "rt-multi-thread"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+derive_more = { workspace = true, features = ["as_ref", "display", "constructor", "from_str", "from", "into"] }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["macros"] }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
+warp = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+getset = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
+base64 = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
-iroha_client = { path = "../client", version = "=2.0.0-pre-rc.16" }
+iroha_client = { workspace = true }
 
-trybuild = "1.0.73"
-criterion = "0.3.6"
+trybuild = { workspace = true }
+criterion = { workspace = true }
 
 [[bench]]
 name = "time_event_filter"

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -11,16 +11,16 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full", "extra-traits"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
-iroha_macro_utils = { version = "2.0.0-pre-rc.16", path = "../../macro/utils" }
-serde_json = "1.0.91"
+syn = { workspace = true, features = ["full", "extra-traits"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
+iroha_macro_utils = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../", features = ["http"] }
+iroha_data_model = { workspace = true }
 
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_json = "1.0.91"
-trybuild = "1.0.73"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+trybuild = { workspace = true }

--- a/derive_primitives/Cargo.toml
+++ b/derive_primitives/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.0.0-pre-rc.16"
 edition = "2021"
 
 [dependencies]
-syn = { version = "1", default-features = false, features = ["full", "extra-traits", "derive", "parsing"] }
-quote = "1.0"
-proc-macro2 = "1.0.49"
+syn = { workspace = true, features = ["full", "extra-traits", "derive", "parsing"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 heck = "0.4.1"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["development-tools::ffi"]
 non_robust_ref_mut = []
 
 [dependencies]
-iroha_ffi_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
+iroha_ffi_derive = { workspace = true }
 
-derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
+derive_more = { workspace = true, features = ["display"] }
 
 [dev-dependencies]
 webassembly-test = "0.1.0"
-getset = "0.1.2"
+getset = { workspace = true }

--- a/ffi/derive/Cargo.toml
+++ b/ffi/derive/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["development-tools::ffi"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full", "visit", "visit-mut", "extra-traits"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
-derive_more = "0.99.17"
-rustc-hash = "1.1.0"
+syn = { workspace = true, features = ["full", "visit", "visit-mut", "extra-traits"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
+derive_more = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
-iroha_ffi = { version = "=2.0.0-pre-rc.16", path = "../" }
+iroha_ffi = { workspace = true }
 
-getset = "0.1.2"
-trybuild = "1.0.73"
+getset = { workspace = true }
+trybuild = { workspace = true }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -13,14 +13,14 @@ default = []
 telemetry = ["iroha_futures_derive/telemetry"]
 
 [dependencies]
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_futures_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
+iroha_config = { workspace = true }
+iroha_futures_derive = { workspace = true }
+iroha_logger = { workspace = true }
 
-rand = "0.8.5"
-serde_json = "1.0.91"
-serde = { version = "1.0.151", features = ["derive"] }
-tokio = { version = "1.23.0", features = ["rt", "rt-multi-thread", "macros"] }
+rand = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 tokio-stream = "0.1.11"

--- a/futures/derive/Cargo.toml
+++ b/futures/derive/Cargo.toml
@@ -16,7 +16,7 @@ telemetry = []
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 edition = "2021"
 
 [dependencies]
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model", features = ["http"] }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_schema = { version = "=2.0.0-pre-rc.16", path = "../schema" }
+iroha_config = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_data_model = { workspace = true, features = ["http"] }
+iroha_logger = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_schema = { workspace = true }
 
-derive_more = { version = "0.99.17", default-features = false, features = ["deref"]}
-serde = { version = "1.0.151", features = ["derive"] }
-serde_json = "1.0.91"
-once_cell = "1.16.0"
-tracing = "0.1.37"
-eyre = "0.6.8"
+derive_more = { workspace = true, features = ["deref"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+once_cell = { workspace = true }
+tracing = { workspace = true }
+eyre = { workspace = true }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -8,23 +8,23 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
+iroha_config = { workspace = true }
 
-color-eyre = "0.6.2"
-serde_json = "1.0.91"
-tracing = "0.1.37"
-tracing-core = "0.1.30"
-tracing-futures = { version = "0.2.5", default-features = false, features = ["std-future", "std"] }
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["fmt", "ansi"] }
-tracing-bunyan-formatter = { version = "0.3.4", default-features = false }
-tokio = { version = "1.23.0", features = ["sync"] }
+color-eyre = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-core = { workspace = true }
+tracing-futures = { workspace = true, features = ["std-future", "std"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
+tracing-bunyan-formatter = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 console-subscriber =  { version = "0.1.8", optional = true }
-once_cell = "1.16.0"
-derive_more = "0.99.17"
+once_cell = { workspace = true }
+derive_more = { workspace = true }
 tracing-error = "0.2.0"
 
 [dev-dependencies]
-tokio = { version = "1.23.0", features = ["macros", "time", "rt"] }
+tokio = { workspace = true, features = ["macros", "time", "rt"] }
 
 
 [features]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -19,4 +19,4 @@ default = ["std"]
 std = []
 
 [dependencies]
-iroha_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
+iroha_derive = { workspace = true }

--- a/macro/derive/Cargo.toml
+++ b/macro/derive/Cargo.toml
@@ -11,11 +11,11 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = {version = "1.0.107", features = ["full"]}
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
-iroha_macro = { version = "2.0.0-pre-rc.16", path = ".." }
+iroha_macro = { workspace = true }
 
-trybuild = "1.0.73"
+trybuild = { workspace = true }

--- a/macro/utils/Cargo.toml
+++ b/macro/utils/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 [features]
 
 [dependencies]
-syn = "1.0.107"
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -9,23 +9,23 @@ license.workspace = true
 categories = ["network-programming"]
 
 [dependencies]
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../crypto" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model" }
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../primitives" }
-iroha_config_base = { version = "=2.0.0-pre-rc.16", path = "../config/base" }
-iroha_data_model_derive = { version = "=2.0.0-pre-rc.16", path = "../data_model/derive" }
+iroha_logger = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_data_model = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_config_base = { workspace = true }
+iroha_data_model_derive = { workspace = true }
 
-rand = "0.8.5"
-tokio = { version = "1.23.0", features = ["rt-multi-thread", "macros", "io-util", "net"] }
-async-stream = "0.3.3"
-futures = { version = "0.3.25", default-features = false, features = ["alloc"] }
-async-trait = "0.1.60"
-parity-scale-codec = { version = "3.2.1", features = ["derive"] }
-aead = "0.3.2"
-thiserror = "1.0.38"
-derive_more = "0.99.17"
-bytes = "1.4.0"
+rand = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "io-util", "net"] }
+async-stream = { workspace = true }
+futures = { workspace = true, features = ["alloc"] }
+async-trait = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+aead = { workspace = true }
+thiserror = { workspace = true }
+derive_more = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
-test_network = { version = "=2.0.0-pre-rc.16", path = "../core/test_network" }
+test_network = { workspace = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -24,21 +24,21 @@ std = ["iroha_macro/std", "fixnum/std", "thiserror"]
 ffi_export = ["std", "iroha_ffi"]
 
 [dependencies]
-iroha_macro = { path = "../macro", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_schema = { path = "../schema", version = "=2.0.0-pre-rc.16", default-features = false }
-iroha_ffi = { path = "../ffi", version = "=2.0.0-pre-rc.16", optional = true }
-iroha_primitives_derive = { path = "derive" }
+iroha_macro = { workspace = true }
+iroha_schema = { workspace = true }
+iroha_ffi = { workspace = true, optional = true }
+iroha_primitives_derive = { workspace = true }
 
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-fixnum = { version = "0.9.1", default-features = false, features = ["serde", "parity", "i64"] }
-derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "as_ref", "as_mut", "deref", "constructor", "into_iterator"] }
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_with = {version = "2.2.0", default-features = false, features = ["macros"]}
+parity-scale-codec = { workspace = true, features = ["derive"] }
+fixnum = { workspace = true, features = ["serde", "parity", "i64"] }
+derive_more = { workspace = true, features = ["display", "from", "as_ref", "as_mut", "deref", "constructor", "into_iterator"] }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["macros"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["serde", "union"] }
 smallstr = { version = "0.3.0", default-features = false, features = ["serde", "union"] }
-thiserror = { version = "1.0.38", optional = true }
+thiserror = { workspace = true, optional = true }
 
 
 [dev-dependencies]
-serde_json = { version = "1.0.91", default-features = false, features = ["alloc"] }
-trybuild = "1.0.73"
+serde_json = { workspace = true, features = ["alloc"] }
+trybuild = { workspace = true }

--- a/primitives/derive/Cargo.toml
+++ b/primitives/derive/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-quote = "1.0.23"
-syn = "1.0.107"
-proc-macro2 = "1.0.49"
+quote = { workspace = true }
+syn = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 # needed for doc-tests to pass

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -8,10 +8,10 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_schema_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
+iroha_schema_derive = { workspace = true }
 
-serde = { version = "1.0.151", default-features = false, features = ["derive", "alloc"] }
-fixnum = { version = "0.9.1", default-features = false, features = ["i64"] }
+serde = { workspace = true, features = ["derive", "alloc"] }
+fixnum = { workspace = true, features = ["i64"] }
 
 [dev-dependencies]
 parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive", "full"] }

--- a/schema/derive/Cargo.toml
+++ b/schema/derive/Cargo.toml
@@ -11,11 +11,11 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full"] }
-proc-macro2 = "1.0.49"
-quote = "1.0.23"
+syn = { workspace = true, features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 
 [dev-dependencies]
-iroha_schema = { version = "=2.0.0-pre-rc.16", path = "../"}
+iroha_schema = { workspace = true}
 
-trybuild = "1.0.73"
+trybuild = { workspace = true }

--- a/schema/gen/Cargo.toml
+++ b/schema/gen/Cargo.toml
@@ -8,8 +8,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../../genesis"}
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../../primitives" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../../data_model", features = ["http"] }
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../../crypto" }
-iroha_schema = { version = "=2.0.0-pre-rc.16", path = "../../schema" }
+iroha_genesis = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_data_model = { workspace = true, features = ["http"] }
+iroha_crypto = { workspace = true }
+iroha_schema = { workspace = true }

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -15,26 +15,26 @@ dev-telemetry = []
 metric-instrumentation = []
 
 [dependencies]
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../config" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
-iroha_futures = { version = "=2.0.0-pre-rc.16", path = "../futures", features = ["telemetry"] }
-iroha_telemetry_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
+iroha_config = { workspace = true }
+iroha_logger = { workspace = true }
+iroha_futures = { workspace = true, features = ["telemetry"] }
+iroha_telemetry_derive = { workspace = true }
 
-async-trait = "0.1.60"
+async-trait = { workspace = true }
 chrono = "0.4.23"
-eyre = "0.6.8"
-futures = { version = "0.3.25", default-features = false, features = ["std", "async-await"] }
-serde_json = "1.0.91"
+eyre = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
+serde_json = { workspace = true }
 streaming-stats = "0.2.3"
-serde = { version = "1.0.151", features = ["derive"] }
-tokio = { version = "1.23.0", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-stream = { version = "0.1.11", features = ["fs"] }
-tokio-tungstenite = "0.17.2"
-url = { version = "2.3.1", features = ["serde"] }
-prometheus = { version = "0.13.3", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio-stream = { workspace = true, features = ["fs"] }
+tokio-tungstenite = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+prometheus = { workspace = true }
 
 
 [build-dependencies]
-eyre = "0.6.8"
-vergen = { version = "8.1.1", default-features = false, features = ["cargo", "git", "gitoxide"] }
+eyre = { workspace = true }
+vergen = { workspace = true, features = ["cargo", "git", "gitoxide"] }
 

--- a/telemetry/derive/Cargo.toml
+++ b/telemetry/derive/Cargo.toml
@@ -16,12 +16,12 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
 
 [dev-dependencies]
-iroha_core = { version = "=2.0.0-pre-rc.16", path = "../../core" }
+iroha_core = { workspace = true }
 
-trybuild = "1.0.73"
+trybuild = { workspace = true }

--- a/tools/kagami/Cargo.toml
+++ b/tools/kagami/Cargo.toml
@@ -10,30 +10,30 @@ description = "A tool used to generate cryptographic keys, docs, the schema and 
 license.workspace = true
 
 [dependencies]
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../../crypto" }
-iroha_config = { version = "=2.0.0-pre-rc.16", path = "../../config" }
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../../data_model" }
-iroha_schema_gen = { version = "=2.0.0-pre-rc.16", path = "../../schema/gen" }
-iroha_primitives = { version = "2.0.0-pre-rc.16", path = "../../primitives" }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../../genesis" }
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.16", path = "../../wasm_builder" }
+iroha_crypto = { workspace = true }
+iroha_config = { workspace = true }
+iroha_data_model = { workspace = true }
+iroha_schema_gen = { workspace = true }
+iroha_primitives = { workspace = true }
+iroha_genesis = { workspace = true }
+iroha_wasm_builder = { workspace = true }
 
-color-eyre = "0.6.2"
-clap = { version = "4.2.1", features = ["derive"] }
-serde_json = "1.0.91"
-derive_more = "0.99.17"
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
-serde_yaml = "0.9.21"
-expect-test = "1.4.1"
-pathdiff = "0.2.1"
-path-absolutize = "3.1.0"
-spinoff = { version = "0.7.0", features = ["aesthetic"] }
-owo-colors = { version = "3.5.0", features = ["supports-colors"] }
-supports-color = "2.0.0"
-inquire = "0.6.2"
-duct = "0.13.6"
-tempfile = "3.6.0"
+color-eyre = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+derive_more = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_yaml = { workspace = true }
+expect-test = { workspace = true }
+pathdiff = { workspace = true }
+path-absolutize = { workspace = true }
+spinoff = { workspace = true, features = ["aesthetic"] }
+owo-colors = { workspace = true, features = ["supports-colors"] }
+supports-color = { workspace = true }
+inquire = { workspace = true }
+duct = { workspace = true }
+tempfile = { workspace = true }
 
 [build-dependencies]
-eyre = "0.6.8"
-vergen = { version = "8.1.1", default-features = false, features = ["git", "gitoxide"] }
+eyre = { workspace = true }
+vergen = { workspace = true, features = ["git", "gitoxide"] }

--- a/tools/kura_inspector/Cargo.toml
+++ b/tools/kura_inspector/Cargo.toml
@@ -8,8 +8,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-iroha_core = { path = "../../core" }
-iroha_version = { path = "../../version" }
-iroha_data_model = { path = "../../data_model" }
+iroha_core = { workspace = true }
+iroha_version = { workspace = true }
+iroha_data_model = { workspace = true }
 
-clap = { version = "3.2.23", features = ["derive", "cargo"] }
+clap = { workspace = true, features = ["derive", "cargo"] }

--- a/tools/parity_scale_decoder/Cargo.toml
+++ b/tools/parity_scale_decoder/Cargo.toml
@@ -13,20 +13,22 @@ license.workspace = true
 no-color = ["colored/no-color"]
 
 [dependencies]
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../../data_model", features = ["http"]}
-iroha_primitives = { version = "=2.0.0-pre-rc.16", path = "../../primitives", default-features = false }
-iroha_schema = { version = "=2.0.0-pre-rc.16", path = "../../schema"}
-iroha_schema_gen = { version = "=2.0.0-pre-rc.16", path = "../../schema/gen"}
-iroha_crypto = { version = "=2.0.0-pre-rc.16", path = "../../crypto", default-features = false }
-iroha_version = { version = "=2.0.0-pre-rc.16", path = "../../version", default-features = false }
-iroha_genesis = { version = "=2.0.0-pre-rc.16", path = "../../genesis"}
-clap = { version = "3.2.23", features = ["derive", "cargo"] }
-eyre = "0.6.8"
-parity-scale-codec = { version = "3.2.1", default-features = false }
+iroha_data_model = { workspace = true, features = ["http"] }
+iroha_primitives = { workspace = true }
+iroha_schema = { workspace = true }
+iroha_schema_gen = { workspace = true }
+iroha_crypto = { workspace = true }
+iroha_version = { workspace = true }
+iroha_genesis = { workspace = true }
+
+clap = { workspace = true, features = ["derive", "cargo"] }
+eyre = { workspace = true }
+parity-scale-codec = { workspace = true }
 colored = "2.0.0"
 
 [build-dependencies]
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../../data_model"}
-parity-scale-codec = { version = "3.2.1", default-features = false }
-serde_json = "1.0.91"
-serde = "1.0.151"
+iroha_data_model = { workspace = true }
+
+parity-scale-codec = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -22,15 +22,15 @@ json = ["serde", "serde_json"]
 http = ["std", "warp"]
 
 [dependencies]
-iroha_version_derive = { version = "=2.0.0-pre-rc.16", path = "derive", default-features = false, optional = true }
-iroha_macro = { version = "=2.0.0-pre-rc.16", path = "../macro", default-features = false }
+iroha_version_derive = { workspace = true, optional = true }
+iroha_macro = { workspace = true }
 
-parity-scale-codec = { version = "3.2.1", default-features = false, optional = true, features = ["derive"] }
-serde_json = { version = "1.0.91", default-features = false, optional = true, features = ["alloc"] }
-serde = { version = "1.0.151", default-features = false, optional = true, features = ["derive"] }
-thiserror = { version = "1.0.38", default-features = false, optional = true }
-warp = { version = "0.3.3", default-features = false, optional = true }
+parity-scale-codec = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true, features = ["alloc"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
+thiserror = { workspace = true, optional = true }
+warp = { workspace = true, optional = true }
 
 [dev-dependencies]
-iroha_data_model = { version = "=2.0.0-pre-rc.16", path = "../data_model" }
-iroha_logger = { version = "=2.0.0-pre-rc.16", path = "../logger" }
+iroha_data_model = { workspace = true }
+iroha_logger = { workspace = true }

--- a/version/derive/Cargo.toml
+++ b/version/derive/Cargo.toml
@@ -11,18 +11,18 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
-rustc-hash = "1.1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
+rustc-hash = { workspace = true }
 
 [dev-dependencies]
-iroha_version = { version = "=2.0.0-pre-rc.16", path = "..", features = ["scale", "json"]}
-iroha_macro = { version = "=2.0.0-pre-rc.16", path = "../../macro" }
+iroha_version = { workspace = true, features = ["scale", "json"] }
+iroha_macro = { workspace = true }
 
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.91", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.151", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["alloc"] }
+serde = { workspace = true, features = ["derive"] }
 
-trybuild = "1.0.73"
+trybuild = { workspace = true }

--- a/wasm_builder/Cargo.toml
+++ b/wasm_builder/Cargo.toml
@@ -9,8 +9,8 @@ license.workspace = true
 categories = ["development-tools::build-utils"]
 
 [dependencies]
-eyre = "0.6.8"
-serde_json = "1.0.99"
+eyre = { workspace = true }
+serde_json = { workspace = true }
 sha256 = "1.1.4"
-path-absolutize = "3.1.0"
+path-absolutize = { workspace = true }
 wasm-opt = "0.113.0"

--- a/wasm_codec/Cargo.toml
+++ b/wasm_codec/Cargo.toml
@@ -10,5 +10,5 @@ license.workspace = true
 [dependencies]
 iroha_core_wasm_codec_derive = { version = "=2.0.0-pre-rc.16", path = "derive" }
 
-wasmtime = "0.39.1"
-parity-scale-codec = { version = "3.2.1", default-features = false, features = ["derive"] }
+wasmtime = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["derive"] }

--- a/wasm_codec/derive/Cargo.toml
+++ b/wasm_codec/derive/Cargo.toml
@@ -10,8 +10,8 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full", "extra-traits"] }
-quote = "1.0.23"
-proc-macro2 = "1.0.49"
-proc-macro-error = "1.0.4"
-once_cell = "1.16.0"
+syn = { workspace = true, features = ["full", "extra-traits"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+proc-macro-error = { workspace = true }
+once_cell = { workspace = true }


### PR DESCRIPTION
## Description

This PR extracts all common dependencies (2 usages or more) into a workspace level, so that it is easier to update them in lockstep.

Also, all iroha crates besides except inner `_derive` crates are also specified at workspace level.

### Issues

There are two places where I couldn't unify the dependencies:

1. `tokio-tungstenite` of versions 0.16 and 0.17 is used
https://github.com/hyperledger/iroha/blob/39504a5a8029080e0a7fe93b0f06a74710dba347/client/Cargo.toml#L44-L43

2. `clap` v3 and v4 is used:
https://github.com/hyperledger/iroha/blob/39504a5a8029080e0a7fe93b0f06a74710dba347/client_cli/Cargo.toml#L31-L30

I haven't tried too hard, but it seems that it would require some code changes to update these places. 

### Linked issue

Closes #3289 

