### PR TITLE
[ci] #3654: Add Dockerfiles to build iroha2 on GNU libc

### DIFF
--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -1,0 +1,20 @@
+FROM archlinux:base-devel
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN pacman -Syu rustup mold openssl libgit2 git docker docker-buildx docker-compose --noconfirm
+
+RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
+RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu
+RUN rustup component add llvm-tools-preview clippy
+RUN rustup component add rust-src
+RUN rustup component add rustfmt
+RUN rustup target add wasm32-unknown-unknown
+RUN cargo install cargo-lints
+RUN cargo install webassembly-test-runner
+RUN cargo install cargo-llvm-cov
+
+# TODO: Figure out a way to pull in libgit2, which doesn't crash if this useless variable is gone.
+RUN git config --global --add safe.directory .

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -1,0 +1,46 @@
+#base stage
+FROM archlinux:base-devel AS builder
+
+# Force-sync packages, install archlinux-keyring, repopulate keys
+RUN pacman -Syy
+RUN pacman -S archlinux-keyring --noconfirm --disable-download-timeout
+RUN rm -rf /etc/pacman.d/gnupg/* && pacman-key --init && pacman-key --populate archlinux
+
+# Install updates
+RUN pacman -Syu --noconfirm --disable-download-timeout
+
+# Set up Rust toolchain
+RUN pacman -S rustup mold wget --noconfirm --disable-download-timeout
+RUN rustup toolchain install nightly-2023-06-25
+RUN rustup default nightly-2023-06-25
+RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add rust-src
+
+# builder stage
+WORKDIR /iroha
+COPY . .
+RUN mold --run cargo build --target x86_64-unknown-linux-gnu --profile deploy
+
+# final image
+FROM alpine:3.18
+
+ARG  STORAGE=/storage
+ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-gnu/deploy
+ENV  BIN_PATH=/usr/local/bin/
+ENV  CONFIG_DIR=/config
+ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
+ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
+ENV  KURA_BLOCK_STORE_PATH=$STORAGE
+
+RUN  set -ex && \
+     apk --update add curl ca-certificates && \
+     adduser --disabled-password iroha --shell /bin/bash --home /app && \
+     mkdir -p $CONFIG_DIR && \
+     mkdir $STORAGE && \
+     chown iroha:iroha $STORAGE
+
+COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
+COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH
+COPY --from=builder $TARGET_DIR/kagami $BIN_PATH
+USER iroha
+CMD  iroha


### PR DESCRIPTION
## Description
Add `Dockerfile.build.glibc` and `Dockerfile.glibc` files to build `iroha2-ci` and `iroha2` images on GNU libc library and without `musl`.

### Linked issue
#3654 

### Benefits
1. To have a `iroha2` CI on GNU libc and without `musl`.
2. To reduce the sizes of `iroha2-ci` and `iroha2` final images.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up