### PR TITLE
[ci] #3700: CI check for `kagami validator`

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -49,6 +49,9 @@ jobs:
         if: always()
         working-directory: wasm
         run: mold --run cargo build --target wasm32-unknown-unknown --quiet
+      - name: Check validator generation as standalone
+        if: always()
+        run: ./scripts/check.sh validator
 
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2ci]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bytesize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,37 +1899,85 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf41b61f7df395284f7a579c0fa1a7e012c5aede655174d4e91299ef1cac643"
 dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-features",
- "gix-fs",
- "gix-glob",
+ "gix-actor 0.20.0",
+ "gix-attributes 0.12.0",
+ "gix-config 0.22.0",
+ "gix-credentials 0.14.0",
+ "gix-date 0.5.1",
+ "gix-diff 0.29.0",
+ "gix-discover 0.18.1",
+ "gix-features 0.29.0",
+ "gix-fs 0.1.1",
+ "gix-glob 0.7.0",
  "gix-hash",
  "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-mailmap",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-ignore 0.2.0",
+ "gix-index 0.16.1",
+ "gix-lock 5.0.1",
+ "gix-mailmap 0.12.0",
+ "gix-object 0.29.2",
+ "gix-odb 0.45.0",
+ "gix-pack 0.35.0",
  "gix-path",
  "gix-prompt",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
+ "gix-ref 0.29.1",
+ "gix-refspec 0.10.1",
+ "gix-revision 0.13.0",
  "gix-sec",
- "gix-tempfile",
- "gix-traverse",
- "gix-url",
+ "gix-tempfile 5.0.3",
+ "gix-traverse 0.25.0",
+ "gix-url 0.18.0",
  "gix-utils",
  "gix-validate",
- "gix-worktree",
+ "gix-worktree 0.17.1",
+ "log",
+ "once_cell",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e74cea676de7f53a79f3c0365812b11f6814b81e671b8ee4abae6ca09c7881"
+dependencies = [
+ "gix-actor 0.23.0",
+ "gix-attributes 0.14.1",
+ "gix-commitgraph",
+ "gix-config 0.25.1",
+ "gix-credentials 0.16.1",
+ "gix-date 0.7.0",
+ "gix-diff 0.32.0",
+ "gix-discover 0.21.1",
+ "gix-features 0.31.1",
+ "gix-fs 0.3.0",
+ "gix-glob 0.9.1",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore 0.4.1",
+ "gix-index 0.20.0",
+ "gix-lock 7.0.1",
+ "gix-mailmap 0.15.0",
+ "gix-negotiate",
+ "gix-object 0.32.0",
+ "gix-odb 0.49.1",
+ "gix-pack 0.39.1",
+ "gix-path",
+ "gix-prompt",
+ "gix-ref 0.32.1",
+ "gix-refspec 0.13.0",
+ "gix-revision 0.17.0",
+ "gix-sec",
+ "gix-tempfile 7.0.0",
+ "gix-trace",
+ "gix-traverse 0.29.0",
+ "gix-url 0.20.1",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.21.1",
  "log",
  "once_cell",
  "signal-hook",
@@ -1934,7 +1994,21 @@ checksum = "848efa0f1210cea8638f95691c82a46f98a74b9e3524f01d4955ebc25a8f84f3"
 dependencies = [
  "bstr",
  "btoi",
- "gix-date",
+ "gix-date 0.5.1",
+ "itoa",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1969b77b9ee4cc1755c841987ec6f7622aaca95e952bcafb76973ae59d1b8716"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date 0.7.0",
  "itoa",
  "nom",
  "thiserror",
@@ -1947,7 +2021,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3015baa01ad2122fbcaab7863c857a603eb7b7ec12ac8141207c42c6439805e2"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.7.0",
+ "gix-path",
+ "gix-quote",
+ "kstring",
+ "log",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3772b0129dcd1fc73e985bbd08a1482d082097d2915cb1ee31ce8092b8e4434"
+dependencies = [
+ "bstr",
+ "gix-glob 0.9.1",
  "gix-path",
  "gix-quote",
  "kstring",
@@ -1959,29 +2050,43 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc02feb20ad313d52a450852f2005c2205d24f851e74d82b7807cbe12c371667"
+checksum = "311e2fa997be6560c564b070c5da2d56d038b645a94e1e5796d5d85a350da33c"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7acf3bc6c4b91e8fb260086daf5e105ea3a6d913f5fd3318137f7e309d6e540"
+checksum = "39db5ed0fc0a2e9b1b8265993f7efdbc30379dec268f3b91b7af0c2de4672fdd"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6141b70cfb21255223e42f3379855037cbbe8673b58dd8318d2f09b516fad1"
+checksum = "bb49ab557a37b0abb2415bca2b10e541277dff0565deb5bd5e99fd95f93f51eb"
 dependencies = [
  "bstr",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed42baa50075d41c1a0931074ce1a97c5797c7c6fe7591d9f1f2dcd448532c26"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features 0.31.1",
+ "gix-hash",
+ "memmap2 0.7.1",
+ "thiserror",
 ]
 
 [[package]]
@@ -1992,10 +2097,32 @@ checksum = "1d252a0eddb6df74600d3d8872dc9fe98835a7da43110411d705b682f49d4ac1"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features",
- "gix-glob",
+ "gix-features 0.29.0",
+ "gix-glob 0.7.0",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.29.1",
+ "gix-sec",
+ "log",
+ "memchr",
+ "nom",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817688c7005a716d9363e267913526adea402dabd947f4ba63842d10cc5132af"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features 0.31.1",
+ "gix-glob 0.9.1",
+ "gix-path",
+ "gix-ref 0.32.1",
  "gix-sec",
  "log",
  "memchr",
@@ -2008,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f216df1c33e6e1555923eff0096858a879e8aaadd35b5d788641e4e8064c892"
+checksum = "83960be5e99266bcf55dae5a24731bbd39f643bfb68f27e939d6b06836b5b87d"
 dependencies = [
  "bitflags 2.3.1",
  "bstr",
@@ -2031,7 +2158,23 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-url",
+ "gix-url 0.18.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a75565e0e6e7f80cfa4eb1b05cc448c6846ddd48dcf413a28875fbc11ee9af"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-url 0.20.1",
  "thiserror",
 ]
 
@@ -2048,13 +2191,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-date"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9a04a1d2387c955ec91059d56b673000dd24f3c07cad08ed253e36381782bf"
+dependencies = [
+ "bstr",
+ "itoa",
+ "thiserror",
+ "time 0.3.22",
+]
+
+[[package]]
 name = "gix-diff"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644a0f2768bc42d7a69289ada80c9e15c589caefc6a315d2307202df83ed1186"
 dependencies = [
  "gix-hash",
- "gix-object",
+ "gix-object 0.29.2",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf5d9b9b521b284ebe53ee69eee33341835ec70edc314f36b2100ea81396121"
+dependencies = [
+ "gix-hash",
+ "gix-object 0.32.0",
  "imara-diff",
  "thiserror",
 ]
@@ -2069,7 +2236,22 @@ dependencies = [
  "dunce",
  "gix-hash",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.29.1",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272aad20dc63dedba76615373dd8885fb5aebe4795e5b5b0aa2a24e63c82085c"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.32.1",
  "gix-sec",
  "thiserror",
 ]
@@ -2085,7 +2267,29 @@ dependencies = [
  "gix-hash",
  "libc",
  "once_cell",
- "prodash",
+ "prodash 23.1.2",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06142d8cff5d17509399b04052b64d2f9b3a311d5cff0b1a32b220f62cd0d595"
+dependencies = [
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "flate2",
+ "gix-hash",
+ "gix-trace",
+ "jwalk",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash 25.0.1",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -2097,7 +2301,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b37a1832f691fdc09910bd267f9a2e413737c1f9ec68c6e31f9e802616278a9"
 dependencies = [
- "gix-features",
+ "gix-features 0.29.0",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb15956bc0256594c62a2399fcf6958a02a11724217eddfdc2b49b21b6292496"
+dependencies = [
+ "gix-features 0.31.1",
 ]
 
 [[package]]
@@ -2108,15 +2321,27 @@ checksum = "c07c98204529ac3f24b34754540a852593d2a4c7349008df389240266627a72a"
 dependencies = [
  "bitflags 2.3.1",
  "bstr",
- "gix-features",
+ "gix-features 0.29.0",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c18bdff83143d61e7d60da6183b87542a870d026b2a2d0b30170b8e9c0cd321a"
+dependencies = [
+ "bitflags 2.3.1",
+ "bstr",
+ "gix-features 0.31.1",
  "gix-path",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee181c85d3955f54c4426e6bfaeeada4428692e1a39b8788c2ac7785fc301dd8"
+checksum = "a0dd58cdbe7ffa4032fc111864c80d5f8cecd9a2c9736c97ae7e5be834188272"
 dependencies = [
  "hex",
  "thiserror",
@@ -2124,12 +2349,12 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd259bd0d96e6153e357a8cdaca76c48e103fd34208b6c0ce77b1ad995834bd2"
+checksum = "9e133bc56d938eaec1c675af7c681a51de9662b0ada779f45607b967a10da77a"
 dependencies = [
  "gix-hash",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "parking_lot",
 ]
 
@@ -2140,7 +2365,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba205b6df563e2906768bb22834c82eb46c5fdfcd86ba2c347270bc8309a05b2"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.7.0",
+ "gix-path",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca801f2d0535210f77b33e2c067d565aedecacc82f1b3dbce26da1388ebc4634"
+dependencies = [
+ "bstr",
+ "gix-glob 0.9.1",
  "gix-path",
  "unicode-bom",
 ]
@@ -2156,13 +2393,35 @@ dependencies = [
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features",
+ "gix-features 0.29.0",
  "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-lock 5.0.1",
+ "gix-object 0.29.2",
+ "gix-traverse 0.25.0",
  "itoa",
- "memmap2",
+ "memmap2 0.5.10",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68099abdf6ee50ae3c897e8b05de96871cbe54d52a37cdf559101f911b883562"
+dependencies = [
+ "bitflags 2.3.1",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features 0.31.1",
+ "gix-hash",
+ "gix-lock 7.0.1",
+ "gix-object 0.32.0",
+ "gix-traverse 0.29.0",
+ "itoa",
+ "memmap2 0.7.1",
  "smallvec",
  "thiserror",
 ]
@@ -2173,7 +2432,18 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c693d7f05730fa74a7c467150adc7cea393518410c65f0672f80226b8111555"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 5.0.3",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714bcb13627995ac33716e9c5e4d25612b19947845395f64d2a9cbe6007728e4"
+dependencies = [
+ "gix-tempfile 7.0.0",
  "gix-utils",
  "thiserror",
 ]
@@ -2185,7 +2455,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8856cec3bdc3610c06970d28b6cb20a0c6621621cf9a8ec48cbd23f2630f362"
 dependencies = [
  "bstr",
- "gix-actor",
+ "gix-actor 0.20.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1787e3c37fc43b1f7c0e3be6196c6837b3ba5f869190dfeaa444b816f0a7f34b"
+dependencies = [
+ "bstr",
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7bce64d4452dd609f44d04b14b29da2e0ad2c45fcdf4ce1472a5f5f8ec21c2"
+dependencies = [
+ "bitflags 2.3.1",
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-object 0.32.0",
+ "gix-revwalk",
+ "smallvec",
  "thiserror",
 ]
 
@@ -2197,8 +2495,28 @@ checksum = "2d96bd620fd08accdd37f70b2183cfa0b001b4f1c6ade8b7f6e15cb3d9e261ce"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor",
- "gix-features",
+ "gix-actor 0.20.0",
+ "gix-features 0.29.0",
+ "gix-hash",
+ "gix-validate",
+ "hex",
+ "itoa",
+ "nom",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953f3d7ffad16734aa3ab1d05807972c80e339d1bd9dde03e0198716b99e2a6"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
+ "gix-features 0.31.1",
  "gix-hash",
  "gix-validate",
  "hex",
@@ -2215,10 +2533,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca2f324aa67672b6d0f2c0fa93f96eb6a7029d260e4c1df5dce3c015f5e5add"
 dependencies = [
  "arc-swap",
- "gix-features",
+ "gix-features 0.29.0",
  "gix-hash",
- "gix-object",
- "gix-pack",
+ "gix-object 0.29.2",
+ "gix-pack 0.35.0",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6418cff00ecc2713b58c8e04bff30dda808fbba1a080e7248b299d069894a01"
+dependencies = [
+ "arc-swap",
+ "gix-date 0.7.0",
+ "gix-features 0.31.1",
+ "gix-hash",
+ "gix-object 0.32.0",
+ "gix-pack 0.39.1",
  "gix-path",
  "gix-quote",
  "parking_lot",
@@ -2234,27 +2571,51 @@ checksum = "164a515900a83257ae4aa80e741655bee7a2e39113fb535d7a5ac623b445ff20"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-diff",
- "gix-features",
+ "gix-diff 0.29.0",
+ "gix-features 0.29.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.29.2",
  "gix-path",
- "gix-tempfile",
- "gix-traverse",
- "memmap2",
+ "gix-tempfile 5.0.3",
+ "gix-traverse 0.25.0",
+ "memmap2 0.5.10",
  "parking_lot",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-path"
-version = "0.8.1"
+name = "gix-pack"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1226f2e50adeb4d76c754c1856c06f13a24cad1624801653fbf09b869e5b808"
+checksum = "414935138d90043ea5898de7a93f02c2558e52652492719470e203ef26a8fd0a"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-diff 0.32.0",
+ "gix-features 0.31.1",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-path",
+ "gix-tempfile 7.0.0",
+ "gix-traverse 0.29.0",
+ "memmap2 0.7.1",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfca182d2575ded2ed38280f1ebf75cd5d3790b77e0872de07854cf085821fbe"
 dependencies = [
  "bstr",
+ "gix-trace",
  "home",
  "once_cell",
  "thiserror",
@@ -2262,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15fe57fa48572b7d3bf465d6a2a0351cd3c55cba74fd5f0b9c23689f9c1a31e"
+checksum = "8dfd363fd89a40c1e7bff9c9c1b136cd2002480f724b0c627c1bc771cd5480ec"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2275,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d59489bff95b06dcdabe763b7266d3dc0a628cac1ac1caf65a7ca0a43eeae0"
+checksum = "3874de636c2526de26a3405b8024b23ef1a327bebf4845d770d00d48700b6a40"
 dependencies = [
  "bstr",
  "btoi",
@@ -2290,16 +2651,37 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e03989e9d49954368e1b526578230fc7189d1634acdfbe79e9ba1de717e15d5"
 dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
+ "gix-actor 0.20.0",
+ "gix-features 0.29.0",
+ "gix-fs 0.1.1",
  "gix-hash",
- "gix-lock",
- "gix-object",
+ "gix-lock 5.0.1",
+ "gix-object 0.29.2",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 5.0.3",
  "gix-validate",
- "memmap2",
+ "memmap2 0.5.10",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39453f4e5f23cddc2e6e4cca2ba20adfdbec29379e3ca829714dfe98ae068ccd"
+dependencies = [
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
+ "gix-features 0.31.1",
+ "gix-fs 0.3.0",
+ "gix-hash",
+ "gix-lock 7.0.1",
+ "gix-object 0.32.0",
+ "gix-path",
+ "gix-tempfile 7.0.0",
+ "gix-validate",
+ "memmap2 0.7.1",
  "nom",
  "thiserror",
 ]
@@ -2312,7 +2694,21 @@ checksum = "0a6ea733820df67e4cd7797deb12727905824d8f5b7c59d943c456d314475892"
 dependencies = [
  "bstr",
  "gix-hash",
- "gix-revision",
+ "gix-revision 0.13.0",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e76ff1f82fba295a121e31ab02f69642994e532c45c0c899aa393f4b740302"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision 0.17.0",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -2325,18 +2721,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "810f35e9afeccca999d5d348b239f9c162353127d2e13ff3240e31b919e35476"
 dependencies = [
  "bstr",
- "gix-date",
+ "gix-date 0.5.1",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.29.2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237428a7d3978e8572964e1e45d984027c2acc94df47e594baa6c4b0da7c9922"
+dependencies = [
+ "bstr",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-revwalk",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028d50fcaf8326a8f79a359490d9ca9fb4e2b51ac9ac86503560d0bcc888d2eb"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b7b38b766eb95dcc5350a9c450030b69892c0902fa35f4a6d0809273bd9dae"
+checksum = "ede298863db2a0574a14070991710551e76d1f47c9783b62d4fcbca17f56371c"
 dependencies = [
  "bitflags 2.3.1",
  "gix-path",
@@ -2350,7 +2776,7 @@ version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71a0d32f34e71e86586124225caefd78dabc605d0486de580d717653addf182"
 dependencies = [
- "gix-fs",
+ "gix-fs 0.1.1",
  "libc",
  "once_cell",
  "parking_lot",
@@ -2360,6 +2786,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-tempfile"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fac8310c17406ea619af72f42ee46dac795110f68f41b4f4fa231b69889c6a2"
+dependencies = [
+ "gix-fs 0.3.0",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103eac621617be3ebe0605c9065ca51a223279a23218aaf67d10daa6e452f663"
+
+[[package]]
 name = "gix-traverse"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,7 +2814,23 @@ checksum = "a5be1e807f288c33bb005075111886cceb43ed8a167b3182a0f62c186e2a0dd1"
 dependencies = [
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.29.2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3cdfd54598db4fae57d5ae6f52958422b2d13382d2745796bfe5c8015ffa86e"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-revwalk",
+ "smallvec",
  "thiserror",
 ]
 
@@ -2378,7 +2841,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc77f89054297cc81491e31f1bab4027e554b5ef742a44bd7035db9a0f78b76"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.29.0",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beaede6dbc83f408b19adfd95bb52f1dbf01fb8862c3faf6c6243e2e67fcdfa1"
+dependencies = [
+ "bstr",
+ "gix-features 0.31.1",
  "gix-path",
  "home",
  "thiserror",
@@ -2387,18 +2864,18 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcfcb150c7ef553d76988467d223254045bdcad0dc6724890f32fbe96415da5"
+checksum = "7058c94f4164fcf5b8457d35f6d8f6e1007f9f7f938c9c7684a7e01d23c6ddde"
 dependencies = [
- "fastrand",
+ "fastrand 2.0.0",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ea5845b506c7728b9d89f4227cc369a5fc5a1d5b26c3add0f0d323413a3a60"
+checksum = "8d092b594c8af00a3a31fe526d363ee8a51a6f29d8496cdb991ed2f01ec0ec13"
 dependencies = [
  "bstr",
  "thiserror",
@@ -2412,14 +2889,35 @@ checksum = "a69eaff0ae973a9d37c40f02ae5ae50fa726c8fc2fd3ab79d0a19eb61975aafa"
 dependencies = [
  "bstr",
  "filetime",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
+ "gix-attributes 0.12.0",
+ "gix-features 0.29.0",
+ "gix-fs 0.1.1",
+ "gix-glob 0.7.0",
  "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-ignore 0.2.0",
+ "gix-index 0.16.1",
+ "gix-object 0.29.2",
+ "gix-path",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1363b9aa66b9e14412ac04e1f759827203f491729d92172535a8ce6cde02efa"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-attributes 0.14.1",
+ "gix-features 0.31.1",
+ "gix-fs 0.3.0",
+ "gix-glob 0.9.1",
+ "gix-hash",
+ "gix-ignore 0.4.1",
+ "gix-index 0.20.0",
+ "gix-object 0.32.0",
  "gix-path",
  "io-close",
  "thiserror",
@@ -2484,9 +2982,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hdrhistogram"
@@ -2633,6 +3131,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "human_format"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
 
 [[package]]
 name = "humantime"
@@ -3465,6 +3969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "k256"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,6 +4000,7 @@ dependencies = [
  "duct",
  "expect-test",
  "eyre",
+ "gix 0.48.0",
  "inquire",
  "iroha_config",
  "iroha_crypto",
@@ -3639,6 +4154,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -4261,6 +4785,16 @@ name = "prodash"
 version = "23.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9516b775656bc3e8985e19cd4b8c0c0de045095074e453d2c0a513b5f978392d"
+
+[[package]]
+name = "prodash"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c236e70b7f9b9ea00d33c69f63ec1ae6e9ae96118923cd37bd4e9c7396f0b107"
+dependencies = [
+ "bytesize",
+ "human_format",
+]
 
 [[package]]
 name = "prometheus"
@@ -5302,7 +5836,7 @@ checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if",
- "fastrand",
+ "fastrand 1.9.0",
  "redox_syscall 0.3.5",
  "rustix 0.37.19",
  "windows-sys 0.48.0",
@@ -5866,6 +6400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6038,7 +6581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
 dependencies = [
  "anyhow",
- "gix",
+ "gix 0.44.1",
  "rustversion",
  "time 0.3.22",
 ]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+KAGAMI_BIN_PATH=${2:-"./target/release/kagami"}
+
 case $1 in
     "docs")
         cargo run --release --bin kagami -- docs | diff - docs/source/references/config.md || {
@@ -25,6 +27,15 @@ case $1 in
     "schema")
         cargo run --release --bin kagami -- schema | diff - docs/source/references/schema.json || {
             echo 'Please re-generate schema with `cargo run --release --bin kagami -- schema > docs/source/references/schema.json`'
+            exit 1
+        };;
+    "validator")
+        if [ ! -e "$KAGAMI_BIN_PATH" ]; then
+            echo 'Please run this check from Iroha root dir after compiling with `--release` flag or provide a valid path to `kagami` binary as a second argument'
+            exit 1
+        fi
+        $KAGAMI_BIN_PATH validator > /dev/null || {
+            echo 'Failed to run `kagami validator` as a standalone binary without invoking `cargo`'
             exit 1
         };;
     "docker-compose")

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -36,5 +36,5 @@ prometheus = { workspace = true }
 
 [build-dependencies]
 eyre = { workspace = true }
-vergen = { workspace = true, features = ["cargo", "git", "gitoxide"] }
+vergen = { workspace = true, features = ["cargo", "git", "git2"] }
 

--- a/tools/kagami/Cargo.toml
+++ b/tools/kagami/Cargo.toml
@@ -36,4 +36,5 @@ tempfile = { workspace = true }
 
 [build-dependencies]
 eyre = { workspace = true }
-vergen = { workspace = true, features = ["git", "gitoxide"] }
+vergen = { workspace = true, features = ["git", "git2"] }
+git2 = "0.17.2"

--- a/tools/kagami/build.rs
+++ b/tools/kagami/build.rs
@@ -1,8 +1,16 @@
 //! Provides macros used to get the version
 
-use std::error::Error;
+use std::{env::set_var, error::Error};
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // We default to upstream's latest hash (usually `iroha2-dev`)
+    // to enable shallow cloning in swarm
+    let repo = git2::Repository::open("../..")?;
+    let sha = match repo.revparse_single("@{u}") {
+        Ok(rev) => rev.id(),
+        Err(_) => repo.revparse_single("HEAD")?.id(),
+    };
+    set_var("VERGEN_GIT_SHA", sha.to_string());
     vergen::EmitBuilder::builder().git_sha(false).emit()?;
     Ok(())
 }

--- a/tools/kagami/src/main.rs
+++ b/tools/kagami/src/main.rs
@@ -77,7 +77,9 @@ pub enum Args {
     Config(config::Args),
     /// Generate a Markdown reference of configuration parameters
     Docs(Box<docs::Args>),
-    /// Generate the default validator
+    /// Generate the default validator. It clones the Iroha repo
+    /// behind the scenes if the command is run from a standalone
+    /// binary
     Validator(validator::Args),
     /// Generate Docker Compose configuration
     Swarm(swarm::Args),

--- a/tools/kagami/src/validator.rs
+++ b/tools/kagami/src/validator.rs
@@ -6,7 +6,7 @@ use swarm::AbsolutePath;
 
 use super::*;
 
-#[derive(ClapArgs, Debug, Clone, Copy)]
+#[derive(ClapArgs, Debug, Clone)]
 pub struct Args;
 
 impl<T: Write> RunArgs<T> for Args {
@@ -17,14 +17,13 @@ impl<T: Write> RunArgs<T> for Args {
             .wrap_err("Failed to write wasm validator into the buffer.")
     }
 }
+
 pub fn compute_validator_path() -> Result<PathBuf> {
     // If `CARGO_MANIFEST_DIR` is set, it means the `kagami` binary is run via `cargo run`
     // command, otherwise it is called as a standalone
     std::env::var("CARGO_MANIFEST_DIR").map_or_else(
         |_| {
-            let source_dir = tempfile::tempdir()
-                .wrap_err("Failed to create temp dir for default runtime validator sources")?;
-            let out_dir = AbsolutePath::try_from(source_dir.path().join(DIR_CLONE))?;
+            let out_dir = AbsolutePath::try_from(PathBuf::from(".").join(DIR_CLONE))?;
             swarm::shallow_git_clone(GIT_ORIGIN, GIT_REVISION, &out_dir)?;
             Ok(out_dir.to_path_buf().join("default_validator"))
         },


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
Added a dumb CI check to verify that we can run `kagami validator` as a standalone binary with no errors.
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue
<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3700 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
Peace of mind. Even though this is not the most intended usage, our QA already came across this problem. 
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
