### PR TITLE
[feature] #3651: WSV snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,6 @@ dependencies = [
  "iroha_config",
  "iroha_crypto",
  "iroha_data_model",
- "iroha_dsl",
  "iroha_genesis",
  "iroha_logger",
  "iroha_primitives",

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -242,10 +242,12 @@ impl Iroha {
             std::path::Path::new(&config.kura.block_store_path),
             config.kura.debug_output_new_blocks,
         )?;
-        let wsv = WorldStateView::from_configuration(config.wsv, world, Arc::clone(&kura));
 
         let notify_shutdown = Arc::new(Notify::new());
-        let block_count = kura.init()?;
+        let (wsv, block_count) = kura.init()?;
+        let wsv = wsv.unwrap_or_else(|| {
+            WorldStateView::from_configuration(config.wsv, world, Arc::clone(&kura))
+        });
 
         let queue = Arc::new(Queue::from_configuration(&config.queue));
         if Self::start_telemetry(telemetry, &config).await? {

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -18,18 +18,21 @@ use iroha_data_model::block::VersionedCommittedBlock;
 use iroha_logger::prelude::*;
 use iroha_version::scale::{DecodeVersioned, EncodeVersioned};
 use parking_lot::Mutex;
+use serde::{de::DeserializeSeed, Serialize};
 
-use crate::handler::ThreadHandler;
+use crate::{
+    handler::ThreadHandler,
+    wsv::{WorldStateView, WsvSeed},
+};
 
 const INDEX_FILE_NAME: &str = "blocks.index";
 const DATA_FILE_NAME: &str = "blocks.data";
+const SNAPSHOT_FILE_NAME: &str = "snapshot.data";
 const LOCK_FILE_NAME: &str = "kura.lock";
 
 /// The interface of Kura subsystem
 #[derive(Debug)]
 pub struct Kura {
-    // TODO: Kura doesn't have different initialisation modes!!!
-    #[allow(dead_code)]
     /// The mode of initialisation of [`Kura`].
     mode: Mode,
     /// The block storage
@@ -115,8 +118,43 @@ impl Kura {
     /// - file storage is unavailable
     /// - data in file storage is invalid or corrupted
     #[iroha_logger::log(skip_all, name = "kura_init")]
-    pub fn init(&self) -> Result<BlockCount> {
+    pub fn init(self: &Arc<Self>) -> Result<(Option<WorldStateView>, BlockCount)> {
         let block_store = self.block_store.lock();
+
+        let mut wsv = None;
+        let mut skip_block_count = 0usize;
+
+        if matches!(self.mode, Mode::Fast) {
+            let mut data = Vec::new();
+            match block_store.read_snapshot_data(&mut data) {
+                Ok(_) => {
+                    let seed = WsvSeed { kura: self.clone() };
+                    let mut deserializer = serde_json::Deserializer::from_slice(&data);
+                    match seed.deserialize(&mut deserializer) {
+                        Ok(read_wsv) => {
+                            skip_block_count = read_wsv
+                                .height()
+                                .try_into()
+                                .expect("We don't have 4 billion blocks.");
+                            iroha_logger::trace!(?skip_block_count, "Read WSV from snapshot");
+                            wsv = Some(read_wsv);
+                        }
+                        Err(e) => {
+                            iroha_logger::warn!(
+                                ?e,
+                                "Kura initialized in Fast mode but failed to deserialize snapshot file"
+                            )
+                        }
+                    }
+                }
+                Err(e) => {
+                    iroha_logger::warn!(
+                        ?e,
+                        "Kura initialized in Fast mode but failed to read snapshot file"
+                    )
+                }
+            }
+        }
 
         let block_index_count: usize = block_store
             .read_index_count()?
@@ -152,7 +190,22 @@ impl Kura {
         // The none value is set in order to indicate that the blocks exist on disk but
         // are not yet loaded.
         *self.block_data.lock() = block_hashes.into_iter().map(|hash| (hash, None)).collect();
-        Ok(BlockCount(block_count))
+        Ok((
+            wsv,
+            BlockCount {
+                total: block_count,
+                skip: skip_block_count,
+            },
+        ))
+    }
+
+    /// Write `wsv` to snapshot file
+    ///
+    /// # Errors
+    /// - Serialization
+    /// - I/O
+    pub fn write_snapshot(&self, wsv: &WorldStateView) -> Result<()> {
+        self.block_store.lock().write_snapshot_data(wsv)
     }
 
     #[allow(clippy::expect_used, clippy::cognitive_complexity, clippy::panic)]
@@ -386,9 +439,15 @@ impl Unlocked {
     }
 }
 
-/// Newtype wrapper for block count
+/// Loaded block count
 #[derive(Clone, Copy, Debug)]
-pub struct BlockCount(pub usize);
+pub struct BlockCount {
+    /// Total count of blocks in store
+    pub total: usize,
+    /// Count of blocks already applied
+    /// to loaded WSV snapshot
+    pub skip: usize,
+}
 
 /// Marker struct for typestate, signifies that store is protected by
 /// a lockfile owned by this instance of [`BlockStore`] and thus can be written into.
@@ -570,6 +629,21 @@ impl<L: Lock> BlockStore<L> {
         // Each entry is 16 bytes.
     }
 
+    /// Read snaphsot data
+    ///
+    /// # Errors
+    /// IO Error.
+    pub fn read_snapshot_data(&self, buf: &mut Vec<u8>) -> Result<()> {
+        let path = self.path_to_blockchain.join(SNAPSHOT_FILE_NAME);
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .open(path.clone())
+            .map_err(|e| Error::IO(e, path.clone()))?;
+        file.read_to_end(buf)
+            .map_err(|e| Error::IO(e, path.clone()))?;
+        Ok(())
+    }
+
     /// Read block data starting from the
     /// `start_location_in_data_file` in data file in order to fill
     /// `dest_buffer`.
@@ -718,6 +792,25 @@ impl BlockStore<Locked> {
         Ok(())
     }
 
+    /// Serialize and write`data` to snapshot file,
+    /// overwriting any previously stored data.
+    ///
+    /// # Errors
+    /// IO Error.
+    pub fn write_snapshot_data<T: Serialize>(&mut self, data: &T) -> Result<()> {
+        let path = self.path_to_blockchain.join(SNAPSHOT_FILE_NAME);
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path.clone())
+            .map_err(|e| Error::IO(e, path.clone()))?;
+        let mut serializer = serde_json::Serializer::new(file);
+        data.serialize(&mut serializer)
+            .map_err(Error::Serialization)?;
+        Ok(())
+    }
+
     /// Create the index and data files if they do not
     /// already exist.
     ///
@@ -779,6 +872,8 @@ pub enum Error {
     MkDir(#[source] std::io::Error, PathBuf),
     /// Failed to serialize/deserialize block
     Codec(#[from] iroha_version::error::Error),
+    /// Error (de)serializing [`WorldStateView`] snapshot
+    Serialization(#[from] serde_json::Error),
     /// Failed to allocate buffer
     Alloc(#[from] std::collections::TryReserveError),
     /// Tried reading block data out of bounds: {start_block_height}, {block_count}

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -989,6 +989,10 @@ pub(crate) fn run(
             is_genesis_peer,
         );
     }
+
+    if let Err(error) = sumeragi.kura.write_snapshot(&sumeragi.wsv) {
+        iroha_logger::error!(?error, "Failed to write WorldStateView snapshot")
+    }
 }
 
 fn add_signatures<const EXPECT_VALID: bool>(

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -213,7 +213,11 @@ impl SumeragiHandle {
             kura,
             network,
             genesis_network,
-            block_count: BlockCount(block_count),
+            block_count:
+                BlockCount {
+                    total: block_count,
+                    skip: skip_block_count,
+                },
         }: SumeragiStartArgs,
     ) -> SumeragiHandle {
         let (control_message_sender, control_message_receiver) = mpsc::sync_channel(100);
@@ -224,7 +228,9 @@ impl SumeragiHandle {
                 .expect("Sumeragi should be able to load the block that was reported as presented. If not, the block storage was probably disconnected.")
         });
 
-        let block_iter_except_last = (&mut blocks_iter).take(block_count.saturating_sub(1));
+        let block_iter_except_last = (&mut blocks_iter)
+            .skip(skip_block_count)
+            .take(block_count.saturating_sub(1));
         for block in block_iter_except_last {
             block.revalidate(&mut wsv).expect(
                 "The block should be valid in init. Blocks loaded from kura assumed to be valid",

--- a/data_model/src/events/mod.rs
+++ b/data_model/src/events/mod.rs
@@ -40,7 +40,9 @@ pub mod model {
     }
 
     /// Event type which could invoke trigger execution.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Decode, Encode, IntoSchema)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Eq, Decode, Encode, IntoSchema, Serialize, Deserialize,
+    )]
     pub enum TriggeringEventType {
         /// Pipeline event.
         Pipeline,


### PR DESCRIPTION
## Description

Implement `Serialize`/`Deserialize` for `WorldStateView` and down the tree.
Initial implementation of `Fast` init mode for Kura - for now just saves serialized WSV on Kura shutdown, restore when Kura is in `Fast` init mode. In the future this behaviour could be expanded to save snapshots periodically and/or on request, snapshot pruning, etc.

### Linked issue

#3651

### Benefits

Faster start-up time.
Possibly useful for debugging of block stores - WSV snapshot is easier to inspect than a blockchain.

### Drawbacks

Contains manual implementations of serde traits that will need to be maintained. Deriving doesn't seem possible, since there's no support for `DeserializeSeed` in `serde_derive` (and [not planned](https://github.com/serde-rs/serde/issues/881#issuecomment-1627865581)). 

### Alternate designs

Instead of `serde` we could possibly use Parity SCALE, but I believe writing `Decode`/`Encode` implementations would require significant effort.
Instead of serializing `WorldStateView` directly we could use some sort of proxy struct. That would come with performance overhead.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
