### PR TITLE
[ci] #3654: Fix iroha2 glibc-based Dockerfiles to be deployed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN cargo build --target x86_64-unknown-linux-musl --features vendored --profile
 
 
 # final image
-FROM alpine:3.16
+FROM alpine:3.18
 
 ARG  STORAGE=/storage
 ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-musl/deploy

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -4,7 +4,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN pacman -Syu rustup mold openssl libgit2 git docker docker-buildx docker-compose --noconfirm
+RUN pacman -Syu rustup mold openssl libgit2 git docker docker-buildx docker-compose glibc lib32-glibc --noconfirm
 
 RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
 RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -24,6 +24,8 @@ RUN mold --run cargo build --target x86_64-unknown-linux-gnu --profile deploy
 # final image
 FROM alpine:3.18
 
+ENV  GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
+ENV  GLIBC_VERSION=2.35-r1
 ARG  STORAGE=/storage
 ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-gnu/deploy
 ENV  BIN_PATH=/usr/local/bin/
@@ -33,7 +35,12 @@ ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
 ENV  KURA_BLOCK_STORE_PATH=$STORAGE
 
 RUN  set -ex && \
-     apk --update add curl ca-certificates && \
+     apk --update add libstdc++ curl ca-certificates gcompat && \
+     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
+         do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
+     apk add --force-overwrite --allow-untrusted /tmp/*.apk && \
+     rm -v /tmp/*.apk && \
+     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
      adduser --disabled-password iroha --shell /bin/bash --home /app && \
      mkdir -p $CONFIG_DIR && \
      mkdir $STORAGE && \


### PR DESCRIPTION
## Description
1. Fix `Dockerfile.build.glibc` and `Dockerfile.glibc` to be adopted for fully deployment scenario.
2. Bump `alpine` base image version to the stable one iroha2 musl-based image.

### Linked issue

#3654 

Closes #3654 

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up