### PR TITLE
[fix] #3451: Fix docker build on M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN rustup component add rust-src
 # Install musl C++ toolchain to build wasm-opt
 RUN wget -c http://musl.cc/x86_64-linux-musl-native.tgz -O - | tar -xz
 RUN ln -s /x86_64-linux-musl-native/bin/x86_64-linux-musl-g++ /x86_64-linux-musl-native/bin/musl-g++
+RUN ln -s /x86_64-linux-musl-native/bin/x86_64-linux-musl-gcc-ar /x86_64-linux-musl-native/bin/musl-ar
+RUN ln -s /x86_64-linux-musl-native/bin/x86_64-linux-musl-gcc-ranlib /x86_64-linux-musl-native/bin/musl-ranlib
 ENV PATH="$PATH:/x86_64-linux-musl-native/bin"
 ENV RUSTFLAGS="-C link-arg=-static"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/x86_64-linux-musl-native/bin/x86_64-linux-musl-gcc

--- a/docker-compose.dev.local.yml
+++ b/docker-compose.dev.local.yml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   iroha0:
     build: ./
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed01208BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"8f4c15e5d664da3f13778801d23d4e89b76e94c1b94b389544168b6cb894f84f8ba62848cf767d72e7f7f4b9d2d7ba07fee33760f79abe5597a51520e292a0cb"}'
@@ -21,6 +22,7 @@ services:
     command: iroha --submit-genesis
   iroha1:
     build: ./
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120815BBDC9775D28C3633269B25F22D048E2AA2E36017CBE5AD85F15220BEB6F6F
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"c02ffad5e455e7ec620d74de5769681e4d8385906bce5a437eb67452a9efbbc2815bbdc9775d28c3633269b25f22d048e2aa2e36017cbe5ad85f15220beb6f6f"}'
@@ -37,6 +39,7 @@ services:
     init: true
   iroha2:
     build: ./
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120F417E0371E6ADB32FD66749477402B1AB67F84A8E9B082E997980CC91F327736
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"29c5ed1409cb10fd791bc4ff8a6cb5e22a5fae7e36f448ef3ea2988b1319a88bf417e0371e6adb32fd66749477402b1ab67f84a8e9b082e997980cc91f327736"}'
@@ -53,6 +56,7 @@ services:
     init: true
   iroha3:
     build: ./
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120A66522370D60B9C09E79ADE2E9BB1EF2E78733A944B999B3A6AEE687CE476D61
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"5eed4855fad183c451aac39dfc50831607e4cf408c98e2b977f3ce4a2df42ce2a66522370d60b9c09e79ade2e9bb1ef2e78733a944b999b3a6aee687ce476d61"}'

--- a/docker-compose.dev.single.yml
+++ b/docker-compose.dev.single.yml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   iroha0:
     build: ./
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed01208BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"8f4c15e5d664da3f13778801d23d4e89b76e94c1b94b389544168b6cb894f84f8ba62848cf767d72e7f7f4b9d2d7ba07fee33760f79abe5597a51520e292a0cb"}'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   iroha0:
     image: hyperledger/iroha2:dev
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed01208BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"8f4c15e5d664da3f13778801d23d4e89b76e94c1b94b389544168b6cb894f84f8ba62848cf767d72e7f7f4b9d2d7ba07fee33760f79abe5597a51520e292a0cb"}'
@@ -21,6 +22,7 @@ services:
     command: iroha --submit-genesis
   iroha1:
     image: hyperledger/iroha2:dev
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120815BBDC9775D28C3633269B25F22D048E2AA2E36017CBE5AD85F15220BEB6F6F
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"c02ffad5e455e7ec620d74de5769681e4d8385906bce5a437eb67452a9efbbc2815bbdc9775d28c3633269b25f22d048e2aa2e36017cbe5ad85f15220beb6f6f"}'
@@ -37,6 +39,7 @@ services:
     init: true
   iroha2:
     image: hyperledger/iroha2:dev
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120F417E0371E6ADB32FD66749477402B1AB67F84A8E9B082E997980CC91F327736
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"29c5ed1409cb10fd791bc4ff8a6cb5e22a5fae7e36f448ef3ea2988b1319a88bf417e0371e6adb32fd66749477402b1ab67f84a8e9b082e997980cc91f327736"}'
@@ -53,6 +56,7 @@ services:
     init: true
   iroha3:
     image: hyperledger/iroha2:dev
+    platform: linux/amd64
     environment:
       IROHA_PUBLIC_KEY: ed0120A66522370D60B9C09E79ADE2E9BB1EF2E78733A944B999B3A6AEE687CE476D61
       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"5eed4855fad183c451aac39dfc50831607e4cf408c98e2b977f3ce4a2df42ce2a66522370d60b9c09e79ade2e9bb1ef2e78733a944b999b3a6aee687ce476d61"}'

--- a/tools/kagami/src/genesis.rs
+++ b/tools/kagami/src/genesis.rs
@@ -130,10 +130,7 @@ pub fn generate_default(validator_path: Option<PathBuf>) -> color_eyre::Result<R
     );
     let alice_id = <Account as Identifiable>::Id::from_str("alice@wonderland")?;
     let grant_permission_to_set_parameters = GrantBox::new(
-        PermissionToken {
-            definition_id: "CanSetParameters".parse()?,
-            payload: Vec::new(),
-        },
+        PermissionToken::new("CanSetParameters".parse()?, &()),
         alice_id,
     );
     let register_user_metadata_access = RegisterBox::new(

--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -898,6 +898,7 @@ mod serialize_docker_compose {
 
     const COMMAND_SUBMIT_GENESIS: &str = "iroha --submit-genesis";
     const DOCKER_COMPOSE_VERSION: &str = "3.8";
+    const PLATFORM_ARCHITECTURE: &str = "linux/amd64";
 
     #[derive(Serialize, Debug)]
     pub struct DockerCompose {
@@ -935,10 +936,23 @@ mod serialize_docker_compose {
         }
     }
 
+    #[derive(Debug)]
+    struct PlatformArchitecture;
+
+    impl Serialize for PlatformArchitecture {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(PLATFORM_ARCHITECTURE)
+        }
+    }
+
     #[derive(Serialize, Debug)]
     pub struct DockerComposeService {
         #[serde(flatten)]
         source: ServiceSource,
+        platform: PlatformArchitecture,
         environment: FullPeerEnv,
         ports: Vec<PairColon<u16, u16>>,
         volumes: Vec<PairColon<String, String>>,
@@ -978,6 +992,7 @@ mod serialize_docker_compose {
 
             Self {
                 source,
+                platform: PlatformArchitecture,
                 command,
                 init: AlwaysTrue,
                 volumes: volumes.into_iter().map(|(a, b)| PairColon(a, b)).collect(),
@@ -1138,7 +1153,7 @@ mod serialize_docker_compose {
 
         use super::{
             CompactPeerEnv, DockerCompose, DockerComposeService, DockerComposeVersion, FullPeerEnv,
-            PairColon, ServiceSource,
+            PairColon, PlatformArchitecture, ServiceSource,
         };
         use crate::swarm::serialize_docker_compose::{AlwaysTrue, ServiceCommand};
 
@@ -1241,6 +1256,7 @@ mod serialize_docker_compose {
                     map.insert(
                         "iroha0".to_owned(),
                         DockerComposeService {
+                            platform: PlatformArchitecture,
                             source: ServiceSource::Build(PathBuf::from(".")),
                             environment: CompactPeerEnv {
                                 key_pair: key_pair.clone(),
@@ -1275,6 +1291,7 @@ mod serialize_docker_compose {
                 services:
                   iroha0:
                     build: .
+                    platform: linux/amd64
                     environment:
                       IROHA_PUBLIC_KEY: ed012039E5BF092186FACC358770792A493CA98A83740643A3D41389483CF334F748C8
                       IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"db9d90d20f969177bd5882f9fe211d14d1399d5440d04e3468783d169bbc4a8e39e5bf092186facc358770792a493ca98a83740643a3d41389483cf334f748c8"}'
@@ -1576,6 +1593,7 @@ mod tests {
             services:
               iroha0:
                 build: ./iroha-cloned
+                platform: linux/amd64
                 environment:
                   IROHA_PUBLIC_KEY: ed0120F0321EB4139163C35F88BF78520FF7071499D7F4E79854550028A196C7B49E13
                   IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"5f8d1291bf6b762ee748a87182345d135fd167062857aa4f20ba39f25e74c4b0f0321eb4139163c35f88bf78520ff7071499d7f4e79854550028a196c7b49e13"}'
@@ -1595,6 +1613,7 @@ mod tests {
                 command: iroha --submit-genesis
               iroha1:
                 build: ./iroha-cloned
+                platform: linux/amd64
                 environment:
                   IROHA_PUBLIC_KEY: ed0120A88554AA5C86D28D0EEBEC497235664433E807881CD31E12A1AF6C4D8B0F026C
                   IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"8d34d2c6a699c61e7a9d5aabbbd07629029dfb4f9a0800d65aa6570113edb465a88554aa5c86d28d0eebec497235664433e807881cd31e12a1af6c4d8b0f026c"}'
@@ -1611,6 +1630,7 @@ mod tests {
                 init: true
               iroha2:
                 build: ./iroha-cloned
+                platform: linux/amd64
                 environment:
                   IROHA_PUBLIC_KEY: ed0120312C1B7B5DE23D366ADCF23CD6DB92CE18B2AA283C7D9F5033B969C2DC2B92F4
                   IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"cf4515a82289f312868027568c0da0ee3f0fde7fef1b69deb47b19fde7cbc169312c1b7b5de23d366adcf23cd6db92ce18b2aa283c7d9f5033b969c2dc2b92f4"}'
@@ -1627,6 +1647,7 @@ mod tests {
                 init: true
               iroha3:
                 build: ./iroha-cloned
+                platform: linux/amd64
                 environment:
                   IROHA_PUBLIC_KEY: ed0120854457B2E3D6082181DA73DC01C1E6F93A72D0C45268DC8845755287E98A5DEE
                   IROHA_PRIVATE_KEY: '{"digest_function":"ed25519","payload":"ab0e99c2b845b4ac7b3e88d25a860793c7eb600a25c66c75cba0bae91e955aa6854457b2e3d6082181da73dc01c1e6f93a72d0c45268dc8845755287e98a5dee"}'


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
The docker build on M1 was failing because of lacking `platform` tag at first, and then because of some missing links to `wasm-opt`'s musl binaries.
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3451. <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
Finally local docker launching as expected on M1 machines, abysmal build times notwithstanding.
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
