### PR TITLE
[fix] #3741: Fix tempfile error in `kagami validator`

### DIFF
--- a/tools/kagami/src/genesis.rs
+++ b/tools/kagami/src/genesis.rs
@@ -178,7 +178,10 @@ pub fn generate_default(validator_path: Option<PathBuf>) -> color_eyre::Result<R
 }
 
 fn construct_validator() -> color_eyre::Result<Validator> {
-    let path = super::validator::compute_validator_path()?;
+    let temp_dir = tempfile::tempdir()
+        .wrap_err("Failed to generate a tempdir for validator sources")?
+        .into_path();
+    let path = super::validator::compute_validator_path(temp_dir)?;
     let wasm_blob = super::validator::construct_validator(path)?;
     Ok(Validator::new(WasmSmartContract::from_compiled(wasm_blob)))
 }

--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -536,14 +536,16 @@ impl PrepareConfig {
 
                 let spinner = ui.spinner_validator();
 
-                let validator_path = match source {
-                    ResolvedImageSource::Build { ref path } => {
-                        super::validator::compute_validator_path_with_swarm_dir(path).wrap_err(
-                            "Failed to construct the validator path from swarm build directory",
-                        )?
-                    }
-                    _ => super::validator::compute_validator_path()
-                        .wrap_err("Failed to construct the validator")?,
+                let validator_path = if let ResolvedImageSource::Build { ref path } = source {
+                    super::validator::compute_validator_path_with_build_dir(path).wrap_err(
+                        "Failed to construct the validator path from swarm build directory",
+                    )?
+                } else {
+                    let out_dir = tempfile::tempdir()
+                        .wrap_err("Failed to generate a tempdir for validator sources")?
+                        .into_path();
+                    super::validator::compute_validator_path(out_dir)
+                        .wrap_err("Failed to construct the validator")?
                 };
                 let validator = super::validator::construct_validator(validator_path)?;
 


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
Getting rid of `tempdir` was a driveby fix I did in the CI PR that wasn't merged. Also fixing two other smaller bugs that didn't even have an issue assigned.
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3741. <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
`kagami validator` and `kagami swarm` working as expected.
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
