### PR TITLE
[feature] #3780: Add tini to forward signals to processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ RUN  set -ex && \
      mkdir $STORAGE && \
      chown iroha:iroha $STORAGE
 
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
 COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH
 COPY --from=builder $TARGET_DIR/kagami $BIN_PATH
 USER iroha
-CMD  iroha
+CMD ["iroha"]

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -46,8 +46,12 @@ RUN  set -ex && \
      mkdir $STORAGE && \
      chown iroha:iroha $STORAGE
 
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
 COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH
 COPY --from=builder $TARGET_DIR/kagami $BIN_PATH
 USER iroha
-CMD  iroha
+CMD ["iroha"]


### PR DESCRIPTION
## Description

Add [Tini](https://github.com/krallin/tini) to pass signals to the Iroha processes.
Sets up Tini using its current builds, and uses GPG for the certificate checks.
**GPG build part unchecked; this is a draft.**

Modifies Dockerfiles:

* https://github.com/hyperledger/iroha/blob/iroha2-dev/Dockerfile
* https://github.com/hyperledger/iroha/blob/iroha2-dev/Dockerfile.build

* https://github.com/hyperledger/iroha/blob/iroha2-dev/Dockerfile.glibc
* https://github.com/hyperledger/iroha/blob/iroha2-dev/Dockerfile.build.glibc

### Linked issue

https://github.com/hyperledger/iroha/issues/3780

### Benefits

The Iroha processes will shut down normally.