### PR TITLE
[ci]: Fix I2:Release  job & Remove badge and load-rs job & Update i2 …

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -7,9 +7,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# Note jobs in this workflow are run on `push` meaning that there's
-# no point in burning our AWS self-hosted runners' time. Hence
-# `ubuntu-latest` and not `[self-hosted, Linux]`.
 jobs:
   registry:
     runs-on: [self-hosted, Linux, iroha2-dev-push]
@@ -48,25 +45,6 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  load-rs:
-    # TODO: Temporary workaround for failing CI job
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
-    steps:
-      - name: Build and push docker image (load-rs:dev)
-        run: |
-          sleep 10s
-          echo "wait to other workflow"
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: soramitsu
-          repo: iroha2-longevity-load-rs
-          github_token: ${{ secrets.G_ACCESS_TOKEN }}
-          workflow_file_name: load-rs-push-from-dev.yaml
-          ref: iroha2-dev
 
   archive_binaries_and_schema:
     runs-on: ubuntu-latest

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -25,6 +25,10 @@ jobs:
           PREFIX='iroha2-'
           TAG=${BRANCH#$PREFIX}
           echo "TAG=$TAG" >>$GITHUB_ENV
+      - name: Get the release from a branch name
+        run: |
+          RELEASE=$(curl -s https://raw.githubusercontent.com/hyperledger/iroha/${{ github.ref_name }}/Cargo.toml | sed -n '3p' | sed -e 's/version = "//g' -e 's/"$//' | tr -d '\n')
+          echo "RELEASE=$RELEASE" >>$GITHUB_ENV
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -41,9 +45,8 @@ jobs:
         with:
           push: true
           tags: |
-            hyperledger/iroha2:${{ env.TAG }}
-            docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}-${{ github.sha }}
-            docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}
+            hyperledger/iroha2:${{ env.TAG }}-${{ env.RELEASE }}
+            docker.soramitsu.co.jp/iroha2/iroha2:${{ env.TAG }}-${{ env.RELEASE }}
           labels: commit=${{ github.sha }}
           build-args: TAG=${{ env.TAG }}
           file: Dockerfile
@@ -62,36 +65,16 @@ jobs:
           ref: iroha2-dev
       - name: Setup git config
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
+          cd .git
+          git config --local user.name "sorabot"
+          git config --local user.email "<>"
       - name: Update configs
         run: |
           ./scripts/update_configs.sh lts
           ./scripts/update_configs.sh stable
       - name: Commit config changes
         run: |
-          git commit -am "[documentation]: Update lts/stable configs following a release" --signoff
+          git config --global --add safe.directory /__w/iroha/iroha
+          git add -A
+          git diff-index --quiet HEAD || git commit -m "[documentation]: Update lts/stable configs following a release" --signoff
           git push origin iroha2-dev
-
-  load-rs:
-    # TODO: Temporary workaround for failing CI job
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag from branch name
-        run: |
-          BRANCH=${{ github.ref_name }}
-          PREFIX='iroha2-'
-          TAG=${BRANCH#$PREFIX}
-          echo "TAG=$TAG" >>$GITHUB_ENV
-      - name: Build and push docker image (load-rs:release/stable)
-        run: |
-          sleep 10s
-          echo "wait to finish other workflow"
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: soramitsu
-          repo: iroha2-longevity-load-rs
-          github_token: ${{ secrets.G_ACCESS_TOKEN }}
-          workflow_file_name: load-rs-push-from-${{ env.TAG }}.yaml
-          ref: iroha2-${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,16 +41,27 @@ ENV  CONFIG_DIR=/config
 ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
 ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
 ENV  KURA_BLOCK_STORE_PATH=$STORAGE
+ENV  USER=iroha
+ENV  UID=1001
+ENV  GID=1001
 
 RUN  set -ex && \
-     apk --update add curl ca-certificates && \
-     adduser --disabled-password iroha --shell /bin/bash --home /app && \
+     apk add --no-cache curl ca-certificates && \
+     addgroup -g $GID $USER && \
+     adduser \
+     --disabled-password \
+     --gecos "" \
+     --home /app \
+     --ingroup "$USER" \
+     --no-create-home \
+     --uid "$UID" \
+     "$USER" && \
      mkdir -p $CONFIG_DIR && \
      mkdir $STORAGE && \
-     chown iroha:iroha $STORAGE
+     chown $USER:$USER $STORAGE
 
 COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
 COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH
 COPY --from=builder $TARGET_DIR/kagami $BIN_PATH
-USER iroha
-CMD  iroha
+USER $USER
+CMD ["${BIN_PATH}/iroha"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![Rust](https://github.com/hyperledger/iroha/workflows/Rust/badge.svg?branch=iroha2-dev)
-[![Coverage Status](https://coveralls.io/repos/github/hyperledger/iroha/badge.svg)](https://coveralls.io/github/hyperledger/iroha)
 
 Iroha is a simple and efficient blockchain ledger based on the **distributed ledger technology (DLT)**. Its design principles are inspired by the Japanese Kaizen principle of eliminating excesses (*muri*).
 

--- a/scripts/update_configs.sh
+++ b/scripts/update_configs.sh
@@ -17,9 +17,9 @@ if [ "$1" != "stable" ] && [ "$1" != "lts" ]; then
     echo $MSG && exit 1
 fi
 
-wget https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -O "./configs/client/$1/config.json"
-wget https://raw.githubusercontent.com/hyperledger/iroha/iroha2-lts/configs/peer/config.json -O "./configs/client/$1/config.json"
+curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -o ./configs/client/$1/config.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-lts/configs/peer/config.json -o ./configs/client/$1/config.json
 
-wget https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -O "./configs/peer/$1/config.json"
-wget https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/genesis.json -O "./configs/peer/$1/genesis.json"
-wget https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/genesis.json -O "./configs/peer/$1/validator.wasm"
+curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -o ./configs/peer/$1/config.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/genesis.json -o ./configs/peer/$1/genesis.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/genesis.json -o ./configs/peer/$1/validator.wasm


### PR DESCRIPTION
[ci]: Update iroha2 `I2::Dev::Publish` and `I2::Release::Publish` workflows.

## Description
1. Fix I2:Release `configs` job.
2. Remove `coveralls` badge (it works only on the default repository branch).
3. Remove `load-rs` CI dispatch trigger workflow (there is no need to trigger load-rs script build anymore).
4. Fix iroha2 user rootless `GID` inside i2 Alpine image.
5. Modify iroha2:stable and iroha2:lts images tags. Now it will be `iroha2:stable-2.0.0-pre-rc.18` or  `iroha2:lts-2.0.0-pre-rc.19`tags. I think there is not a read need to add `${{ github.sha }}` there into tags names like `lts-${{ env.VERSION }}-${{ github.sha }}`.

### Linked issue
Covers #3430 and #3771 

### Benefits
Cover issues requests and improve iroha2 CI.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
