### PR TITLE
[fix] #3709: Correct how tx_amounts histogram is calculated.

### DIFF
--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -227,8 +227,7 @@ pub mod isi {
 
             #[allow(clippy::float_arithmetic)]
             {
-                wsv.metric_tx_amounts += new_quantity.into_metric();
-                wsv.metric_tx_amounts_counter += 1;
+                wsv.new_tx_amounts.lock().push(new_quantity.into_metric());
                 wsv.increase_asset_total_amount(&asset_id.definition_id, mint.object)?;
             }
 
@@ -284,8 +283,7 @@ pub mod isi {
 
             #[allow(clippy::float_arithmetic)]
             {
-                wsv.metric_tx_amounts += burn_quantity.into_metric();
-                wsv.metric_tx_amounts_counter += 1;
+                wsv.new_tx_amounts.lock().push(burn_quantity.into_metric());
                 wsv.decrease_asset_total_amount(&asset_id.definition_id, burn.object)?;
             }
 
@@ -353,8 +351,9 @@ pub mod isi {
 
             #[allow(clippy::float_arithmetic)]
             {
-                wsv.metric_tx_amounts += transfer_quantity.into_metric();
-                wsv.metric_tx_amounts_counter += 1;
+                wsv.new_tx_amounts
+                    .lock()
+                    .push(transfer_quantity.into_metric());
             }
 
             wsv.emit_events([

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -141,7 +141,8 @@ impl Validator {
 
         match self {
             Self::Initial => {
-                let (_authority, Executable::Instructions(instructions)) = transaction.into() else {
+                let (_authority, Executable::Instructions(instructions)) = transaction.into()
+                else {
                     return Ok(());
                 };
                 for isi in instructions {


### PR DESCRIPTION
## Description

The previous implementation was wrong because of my misunderstanding of prometheus histograms.

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3709 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
