### PR TITLE
[documentation] #3802: Unicode "kagami swarm" seed

### DIFF
--- a/tools/kagami/src/swarm.rs
+++ b/tools/kagami/src/swarm.rs
@@ -30,9 +30,8 @@ mod clap_args {
         /// How many peers to generate within the Docker Compose setup.
         #[arg(long, short)]
         pub peers: NonZeroU16,
-        /// Used for deterministic key-generation.
+        /// The Unicode `seed` string for deterministic key-generation.
         ///
-        /// Any valid UTF-8 sequence is acceptable.
         // TODO: Check for length limitations, and if non-UTF-8 sequences are working.
         #[arg(long, short)]
         pub seed: Option<String>,


### PR DESCRIPTION
## Description

A small Kagami help update

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

Closes #3802

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up