### PR TITLE
[refactor] #3674: Elide `.cloned()` in `data_model/src/block.rs`

### DIFF
--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -315,7 +315,7 @@ mod committed {
     #[cfg(feature = "std")]
     impl From<&CommittedBlock> for Vec<Event> {
         fn from(block: &CommittedBlock) -> Self {
-            let tx = block.transactions.iter().cloned().map(|tx| {
+            let tx = block.transactions.iter().map(|tx| {
                 let status = tx.error.as_ref().map_or_else(
                     || PipelineStatus::Committed,
                     |error| PipelineStatus::Rejected(error.clone().into()),


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
Get rid of unnecessary `iter::cloned()` call.
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3674. <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
