### PR TITLE
[feature] #3812 adding registerbox to DSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,6 +3230,7 @@ dependencies = [
 name = "iroha_dsl"
 version = "2.0.0-pre-rc.19"
 dependencies = [
+ "enum_dispatch",
  "iroha_client",
  "iroha_config",
  "iroha_crypto",

--- a/dsl/Cargo.toml
+++ b/dsl/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 quote = "1.0"
 proc-macro2 = "1.0"
 litrs = "0.4.0"
+enum_dispatch = "0.3.5"
 
 [dev-dependencies]
 iroha_data_model = { workspace = true }

--- a/dsl/examples/basic.rs
+++ b/dsl/examples/basic.rs
@@ -1,0 +1,12 @@
+extern crate iroha_dsl;
+extern crate iroha_data_model;
+use iroha_dsl::expr;
+use iroha_data_model::{prelude::*};
+
+fn main() {
+    assert_eq!(expr!(54654*5 + 1), Add::new(Multiply::new(54654_u64, 5_u64), 1_u64));
+    // println!("{}", expr!(not true and false));
+    // println!("{}", expr!(if 4 = 4 then 64 else 32));
+    println!("{}", expr!(register "bucket"));
+    println!("{}", expr!(register "beans@bucket"));
+}

--- a/dsl/src/lib.rs
+++ b/dsl/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryFrom, iter::Peekable, str::FromStr};
 
+use enum_dispatch::enum_dispatch;
 use litrs::Literal;
 use proc_macro2::{
     token_stream::IntoIter,
@@ -8,11 +9,23 @@ use proc_macro2::{
 };
 use quote::quote;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Copy, Clone)]
 enum ExprType {
     Nil,
     Int,
     Bool,
+
+    /// RegisterBox
+    Register,
+
+    /// alice@bucket
+    Account,
+    /// bucket
+    Domain,
+    /// beans#bucket
+    AssetDefinition,
+    /// beans##alice@bucket
+    Asset,
 }
 
 // within the compiler, these generate tokens for
@@ -22,7 +35,104 @@ struct ParsedExpr {
     tokens: TokenStream,
 }
 
-struct Operator(i32, ExprType, &'static str);
+#[enum_dispatch]
+trait BinaryOperator {
+    fn accept(&self, op: &String) -> bool;
+    fn level(&self) -> i32;
+    fn type_check(&self, lhs: ExprType, rhs: ExprType) -> ExprType;
+    fn compile(&self, t: ExprType, lhs: TokenStream, rhs: TokenStream) -> TokenStream;
+}
+
+#[enum_dispatch(BinaryOperator)]
+#[derive(Clone)]
+enum BinaryOperatorEnum {
+    TrivialBinaryOperator,
+}
+
+#[derive(Clone)]
+struct TrivialBinaryOperator {
+    operator: &'static str,
+    precedence: i32,
+    t: ExprType,
+    name: &'static str,
+}
+
+impl TrivialBinaryOperator {
+    const fn new(
+        operator: &'static str,
+        prec: i32,
+        t: ExprType,
+        name: &'static str,
+    ) -> BinaryOperatorEnum {
+        BinaryOperatorEnum::TrivialBinaryOperator(TrivialBinaryOperator {
+            operator,
+            precedence: prec,
+            t,
+            name,
+        })
+    }
+}
+
+impl BinaryOperator for TrivialBinaryOperator {
+    fn accept(&self, op: &String) -> bool {
+        self.operator == op
+    }
+
+    fn level(&self) -> i32 {
+        self.precedence
+    }
+
+    fn type_check(&self, lhs: ExprType, rhs: ExprType) -> ExprType {
+        assert!(
+            lhs == self.t && rhs == self.t,
+            "cannot perform binary operator on these!"
+        );
+
+        self.t
+    }
+
+    fn compile(&self, _t: ExprType, lhs: TokenStream, rhs: TokenStream) -> TokenStream {
+        let op = proc_macro2::TokenStream::from_str(self.name).unwrap();
+        quote! { #op::new(#lhs, #rhs) }
+    }
+}
+
+const OPERATORS: &'static [BinaryOperatorEnum] = &[
+    // arithmatic
+    TrivialBinaryOperator::new("+", 1, ExprType::Int, "Add"),
+    TrivialBinaryOperator::new("-", 1, ExprType::Int, "Subtract"),
+    TrivialBinaryOperator::new("*", 2, ExprType::Int, "Multiply"),
+    // compares
+    TrivialBinaryOperator::new("=", 3, ExprType::Int, "Equal"),
+    TrivialBinaryOperator::new(">", 3, ExprType::Int, "Greater"),
+    TrivialBinaryOperator::new("<", 3, ExprType::Int, "Less"),
+    // logical
+    TrivialBinaryOperator::new("&", 4, ExprType::Bool, "And"),
+    TrivialBinaryOperator::new("|", 4, ExprType::Bool, "Or"),
+    TrivialBinaryOperator::new("and", 4, ExprType::Bool, "And"),
+    TrivialBinaryOperator::new("or", 4, ExprType::Bool, "Or"),
+];
+
+fn infer_type_from_name(name: &str) -> ExprType {
+    let len = name.len();
+    let arr = name.as_bytes();
+
+    for (i, ch) in arr.iter().enumerate() {
+        match ch {
+            b'@' => return ExprType::Account,
+            b'#' => {
+                if i + 1 < len && arr[i + 1] == b'#' {
+                    return ExprType::Asset;
+                } else {
+                    return ExprType::AssetDefinition;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ExprType::Domain
+}
 
 fn parse_literal(it: &mut Peekable<IntoIter>) -> ParsedExpr {
     let token = it
@@ -30,15 +140,23 @@ fn parse_literal(it: &mut Peekable<IntoIter>) -> ParsedExpr {
         .expect("failed to parse literal, hit end of string");
 
     match token {
-        Punct(ref x) => {
-            if x.as_char() == '(' {
+        Punct(ref x) => match x.as_char() {
+            '(' => {
                 let v = parse_expr(it);
 
                 it.next()
                     .expect("expected closing paren, hit end of string");
                 return v;
             }
-        }
+            '!' => {
+                let v = parse_literal(it).tokens;
+                return ParsedExpr {
+                    t: ExprType::Bool,
+                    tokens: quote! { Not::new(#v) },
+                };
+            }
+            _ => {}
+        },
 
         // boolean literals
         Ident(ref x) => match x.to_string().as_str() {
@@ -63,6 +181,7 @@ fn parse_literal(it: &mut Peekable<IntoIter>) -> ParsedExpr {
                     tokens: quote! { Not::new(#v) },
                 };
             }
+
             _ => panic!("error: unknown identifier"),
         },
 
@@ -71,65 +190,69 @@ fn parse_literal(it: &mut Peekable<IntoIter>) -> ParsedExpr {
     }
 
     // integer literals
-    if let Ok(Literal::Integer(i)) = Literal::try_from(token) {
-        let v = i.value::<u64>().expect("i don't think this integer fits?");
-        return ParsedExpr {
-            t: ExprType::Int,
-            tokens: quote! { #v },
-        };
-    }
+    match Literal::try_from(token) {
+        Ok(Literal::Integer(i)) => {
+            let v = i.value::<u64>().expect("i don't think this integer fits?");
+            return ParsedExpr {
+                t: ExprType::Int,
+                tokens: quote! { #v },
+            };
+        }
 
-    ParsedExpr {
-        t: ExprType::Nil,
-        tokens: TokenStream::new(),
+        Ok(Literal::String(lit)) => {
+            let v = lit.value();
+            let t = infer_type_from_name(v);
+
+            let tokens = match t {
+                ExprType::Domain => quote! { Domain::new(#v.parse().unwrap()) },
+                ExprType::Asset => quote! { Asset::new(#v.parse().unwrap()) },
+                ExprType::Account => quote! { Account::new(#v.parse().unwrap(), []) },
+                ExprType::AssetDefinition => quote! { AssetDefinition::new(#v.parse().unwrap()) },
+                _ => todo!(),
+            };
+
+            return ParsedExpr { t, tokens };
+        }
+
+        _ => {
+            return ParsedExpr {
+                t: ExprType::Nil,
+                tokens: TokenStream::new(),
+            }
+        }
     }
 }
 
-fn precedence(it: &mut Peekable<IntoIter>) -> Option<Operator> {
-    match it.peek() {
-        Some(Punct(x)) => match x.as_char() {
-            // arithmatic
-            '+' => Some(Operator(4, ExprType::Int, "Add")),
-            '-' => Some(Operator(4, ExprType::Int, "Subtract")),
-            '*' => Some(Operator(3, ExprType::Int, "Multiply")),
+fn get_binop(it: &mut Peekable<IntoIter>) -> Option<BinaryOperatorEnum> {
+    let op_name = it.peek()?.to_string();
 
-            // compares
-            '=' => Some(Operator(2, ExprType::Int, "Equal")),
-            '>' => Some(Operator(2, ExprType::Int, "Greater")),
-            '<' => Some(Operator(2, ExprType::Int, "Less")),
-            _ => None,
-        },
-        Some(Ident(ref x)) => match x.to_string().as_str() {
-            "and" => Some(Operator(1, ExprType::Bool, "And")),
-            "or" => Some(Operator(1, ExprType::Bool, "Or")),
-            _ => None,
-        },
-        _ => None,
+    // find a matching operator
+    for op in OPERATORS {
+        if op.accept(&op_name) {
+            return Some(op.clone());
+        }
     }
+
+    None
 }
 
 /// precedence walking
 fn parse_binop(it: &mut Peekable<IntoIter>, min_prec: i32) -> ParsedExpr {
     let mut lhs = parse_literal(it);
-    while let Some(prec) = precedence(it) {
-        it.next();
-        if prec.0 < min_prec {
+    while let Some(op) = get_binop(it) {
+        let prec = op.level();
+        if op.level() < min_prec {
             break;
         }
 
-        let op = proc_macro2::TokenStream::from_str(prec.2).unwrap();
-        let rhs = parse_literal(it);
+        it.next();
 
-        assert!(
-            lhs.t == prec.1 && rhs.t == prec.1,
-            "cannot perform binary operator on these!"
-        );
+        let rhs = parse_binop(it, prec + 1);
+        let t = op.type_check(lhs.t, rhs.t);
 
-        let lhs_tokens = lhs.tokens;
-        let rhs_tokens = rhs.tokens;
         lhs = ParsedExpr {
-            t: prec.1,
-            tokens: quote! { #op::new(#lhs_tokens, #rhs_tokens) },
+            t,
+            tokens: op.compile(t, lhs.tokens, rhs.tokens),
         };
     }
 
@@ -145,33 +268,48 @@ fn is_ident(a: &TokenTree, b: &'static str) -> bool {
 }
 
 fn parse_expr(it: &mut Peekable<IntoIter>) -> ParsedExpr {
-    if is_ident(it.peek().expect("hit end of string"), "if") {
-        it.next();
+    match it.peek() {
+        Some(Ident(ref x)) => match x.to_string().as_str() {
+            "if" => {
+                it.next();
 
-        let cond_tokens = parse_binop(it, 0).tokens;
-        assert!(
-            is_ident(&it.next().expect("hit end of string"), "then"),
-            "expected 'then'"
-        );
+                let cond_tokens = parse_binop(it, 0).tokens;
+                assert!(
+                    is_ident(&it.next().expect("hit end of string"), "then"),
+                    "expected 'then'"
+                );
 
-        let true_case = parse_binop(it, 0);
-        assert!(
-            is_ident(&it.next().expect("hit end of string"), "else"),
-            "expected 'else'"
-        );
+                let true_case = parse_binop(it, 0);
+                assert!(
+                    is_ident(&it.next().expect("hit end of string"), "else"),
+                    "expected 'else'"
+                );
 
-        let false_case = parse_binop(it, 0);
-        assert!(
-            true_case.t == false_case.t,
-            "both types in a conditional must match"
-        );
+                let false_case = parse_binop(it, 0);
+                assert!(
+                    true_case.t == false_case.t,
+                    "both types in a conditional must match"
+                );
 
-        let true_tokens = true_case.tokens;
-        let false_tokens = false_case.tokens;
-        return ParsedExpr {
-            t: ExprType::Int,
-            tokens: quote! { If::new(#cond_tokens, #true_tokens, #false_tokens) },
-        };
+                let true_tokens = true_case.tokens;
+                let false_tokens = false_case.tokens;
+                return ParsedExpr {
+                    t: ExprType::Int,
+                    tokens: quote! { If::new(#cond_tokens, #true_tokens, #false_tokens) },
+                };
+            }
+            "register" => {
+                it.next();
+
+                let e = parse_binop(it, 0).tokens;
+                return ParsedExpr {
+                    t: ExprType::Register,
+                    tokens: quote! { RegisterBox::new(#e) },
+                };
+            }
+            _ => {}
+        },
+        _ => {}
     }
 
     // normal expression


### PR DESCRIPTION
## Description

Getting started on a syntax for `RegisterBox` to replace writing `RegisterBox::new(Domain::new("neverland".parse()?))` with `expr!(register "neverland")`, currently there's no way to describe objects which aren't domains. It also makes sense to separate the name detection logic from the DSL.

### Benefits

There's a consistent grammar across different kinds of resources like domains, assets, accounts which can be inferred when creating objects within the DSL. For instance, all assets will be `asset#domain`.

https://hyperledger.github.io/iroha-2-docs/guide/blockchain/naming.html

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] syntax for `register`
- [x] Domains
- [ ] Assets
- [x] AssetDefinitions
- [ ] Accounts
- [ ] Moving detection code into separate crate
- [ ] CI checks
