### PR TITLE
[fix] #3762: Fix `irrefutable_let_patterns` in the `#[model]` macro

### DIFF
--- a/data_model/src/events/notification.rs
+++ b/data_model/src/events/notification.rs
@@ -1,5 +1,4 @@
 //! Notification events and their filter
-#![allow(irrefutable_let_patterns)]
 
 #[cfg(not(feature = "std"))]
 use alloc::{format, string::String, vec::Vec};


### PR DESCRIPTION
## Description
Slightly amended `#[derive(FromVariant)]` macro to account for the degenerate case of a single variant enum, thus fixing the lint.
<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3762. <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
No annoying warnings
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
