### PR TITLE
[docs]: #391 move the Rust examples

### DIFF
--- a/client/examples/Cargo.toml.rc13
+++ b/client/examples/Cargo.toml.rc13
@@ -1,0 +1,5 @@
+[dependencies]
+iroha_client = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/client" }
+iroha_data_model = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/data_model" }
+iroha_crypto = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/crypto" }
+iroha_config = { version = "=2.0.0-pre-rc.13", path = "~/Git/iroha/config" }

--- a/client/examples/Cargo.toml.rc19
+++ b/client/examples/Cargo.toml.rc19
@@ -1,0 +1,5 @@
+[dependencies]
+iroha_client = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/client" }
+iroha_data_model = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/data_model" }
+iroha_crypto = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/crypto" }
+iroha_config = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/config" }

--- a/client/examples/ClientConfiguration.rs
+++ b/client/examples/ClientConfiguration.rs
@@ -1,0 +1,36 @@
+// #region rust_config_crates
+use iroha_core::prelude::*;
+use iroha_data_model::prelude::*;
+// #endregion rust_config_crates
+
+fn construct_client_configuration_test() -> Result<(), Error> {
+    // #region client_configuration_test
+    let public_str = r#"ed01207233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0"#;
+    let private_hex = "9ac47abf59b356e0bd7dcbbbb4dec080e302156a48ca907e47cb6aea1d32719e7233bfc89dcbd68c19fde6ce6158225298ec1131b6a130d1aeb454c1ab5183c0";
+
+    let kp = KeyPair::new(
+        PublicKey::from_str(public_str)?,
+        PrivateKey::from_hex(Algorithm::Ed25519, private_hex.into())?
+    )?;
+    
+    let (public_key, private_key) = kp.clone().into();
+    let account_id: AccountId = "alice@wonderland".parse()?;
+    
+    let config = ClientConfiguration {
+        public_key,
+        private_key,
+        account_id,
+        torii_api_url: SmallStr::from_string(iroha_config::torii::uri::DEFAULT_API_URL.to_owned()),
+        ..ClientConfiguration::default()
+    };
+    // #endregion client_configuration_test
+
+    // Finish the test successfully
+    Ok(())
+}
+
+fn main() {
+    construct_client_configuration_test()
+        .expect("In-place client configuration example is expected to work correctly");
+    println!("Success!");
+}

--- a/client/examples/account_registration.rs
+++ b/client/examples/account_registration.rs
@@ -1,0 +1,9 @@
+// FIXME: `get_key_from_white_rabbit` is an oddly specific name that we never see in Iroha code
+// #region get_key_from
+let key: PublicKey = get_key_from_white_rabbit();
+// #endregion get_key_from
+
+// #region create_account
+let create_account =
+    RegisterBox::new(IdentifiableBox::from(NewAccount::with_signatory(id, key)));
+// #endregion create_account

--- a/client/examples/domain_registration_tests.rs
+++ b/client/examples/domain_registration_tests.rs
@@ -1,0 +1,32 @@
+// TODO Consider whether such a test can be performed without an actual peer
+// and how reasonable it is.
+//
+// We'll need to have a mock server imitating a peer and sending back the responses,
+// serialized with a SCALE codec.
+
+fn main() {
+    register_without_metadata_test()
+        .expect("Registration example is expected to work correctly");
+    register_with_metadata_test()
+        .expect("Registration example with metadata is expected to work correctly");
+    println!("Success!");
+}
+
+fn register_without_metadata_test() -> Result<(), Error> {
+    // #region submit
+    iroha_client.submit(create_looking_glass)?;
+    // #endregion submit
+
+    // Finish the test successfully
+    Ok(())
+}
+
+fn register_with_metadata_test() -> Result<(), Error> {
+    // #region submit_with_metadata
+    iroha_client
+        .submit_with_metadata(create_looking_glass, UnlimitedMetadata::default())?;
+    // #endregion submit_with_metadata
+
+    // Finish the test successfully
+    Ok(())
+}

--- a/client/examples/output_filter.rs
+++ b/client/examples/output_filter.rs
@@ -1,0 +1,26 @@
+// #region filter_requirements
+use iroha_data_model::prelude::*;
+// #endregion filter_requirements
+
+fn main() {
+    event_listen_test()
+        .expect("Event filter example is expected to work correctly");
+}
+
+fn event_listen_test() -> Result<(), Error> {
+    // #region build_a_filter
+    let filter = FilterBox::Pipeline(PipelineEventFilter::identity());
+    // #endregion build_a_filter
+
+    // #region listen
+    for event in iroha_client.listen_for_events(filter)? {
+        match event {
+            Ok(event) => println!("Success: {:#?}", event),
+            Err(err) => println!("Sadness:( {:#?}",  err),
+        }
+    };
+    // #endregion listen
+
+    // Finish the test successfully
+    Ok(())
+}

--- a/client/examples/tutorial.rs
+++ b/client/examples/tutorial.rs
@@ -301,12 +301,12 @@ fn asset_burning_test(config: &Configuration) -> Result<(), Error> {
         .wrap_err("Failed to submit transaction")?;
     // #endregion burn_asset_submit_tx
 
-    // #region burn_asset_burn_alt
     // Burn the Asset instance (alternate syntax).
     // The syntax is `asset_name#asset_domain#account_name@account_domain`,
     // or `roses.to_string() + "#" + alice.to_string()`.
-    // The `##` is a short-hand for the rose `which belongs to the same domain as the account
+    // The `##` is a short-hand for the rose which belongs to the same domain as the account
     // to which it belongs to.
+    // #region burn_asset_burn_alt
     let burn_roses_alt = BurnBox::new(
         10_u32.to_value(),
         IdBox::AssetId("rose##alice@wonderland".parse()?),


### PR DESCRIPTION
## Description

This is a draft PR that moves code from the blocks in `iroha-2-docs` repo.

### Linked issue

Closes #391

### Benefits

Docs will be more clean and the doctests will be more detailed.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
