### PR TITLE
[feature] #1915: Implement Fast kura init mode

### DIFF
--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -14,7 +14,6 @@ use iroha_crypto::KeyPair;
 use iroha_data_model::{
     block::VersionedCommittedBlock, prelude::*, transaction::TransactionLimits,
 };
-use iroha_version::scale::EncodeVersioned;
 use tokio::{fs, runtime::Runtime};
 
 async fn measure_block_size_for_n_validators(n_validators: u32) {
@@ -62,10 +61,7 @@ async fn measure_block_size_for_n_validators(n_validators: u32) {
     let mut block_store = BlockStore::new(dir.path(), LockStatus::Unlocked);
     block_store.create_files_if_they_do_not_exist().unwrap();
 
-    let serialized_block: Vec<u8> = block.encode_versioned();
-    block_store
-        .append_block_to_chain(&serialized_block)
-        .unwrap();
+    block_store.append_block_to_chain(&block).unwrap();
 
     let metadata = fs::metadata(dir.path().join("blocks.data")).await.unwrap();
     let file_size = Byte::from_bytes(u128::from(metadata.len())).get_appropriate_unit(false);


### PR DESCRIPTION
## Description

Implement `fast` kura init mode.
Which can skip loading blocks from disk and thus bootstrap startup time. 

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #1915 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Improve startup time.


### Downsides

Take additional space for storing hashes on disk (32 bytes per hash) time/memory tradeoff.

`fast` init mode should be used with caution because it can detect some mutations in hashes file. 

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### How to test

1. Run iroha with `strict` kura init mode
2. Create couple of blocks
3. Check that `storage/blocks.hashes` is created
4. Shutdown iroha peer
5. Switch to `fast` kura init mode in the configuration
6. Start peer again
7. Check that peer is running correctly
8. Shutdown iroha peer ones more
9. Make backup of `storage/blocks.hashes` (`storage/blocks.hahses.old`)
10. Remove some data from data from `storage/blocks.hashes` or whole file entirely
11. Start peer
12. Check that kura failed to load in `fast` mode and failed back to STRICT mode (grep for “Hashes file is broken”)
13. Check that peer is running correctly
14. Check that `storage/blocks.hashes` is restored (`storage/blocks.hashes` == `storage/blocks.hashes.old`)
15. Check that peer is running correctly

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
