### PR TITLE
[documentation] #3878: Add the documentation-related Iroha configurat…

### DIFF
--- a/configs/documentation/Cargo.rc19.toml
+++ b/configs/documentation/Cargo.rc19.toml
@@ -1,0 +1,5 @@
+[dependencies]
+iroha_client = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/client" }
+iroha_data_model = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/data_model" }
+iroha_crypto = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/crypto" }
+iroha_config = { version = "=2.0.0-pre-rc.19", path = "~/Git/iroha/config" }

--- a/configs/documentation/README.md
+++ b/configs/documentation/README.md
@@ -1,0 +1,8 @@
+# Documentation-related configurations
+
+This directory contains the configuration files used by for Iroha documentation.
+These files are maintained and updated depending on the internal changes in Iroha.
+
+## Configuration list
+
+* Cargo.*.toml - Cargo configuration for the Rust tutorial.


### PR DESCRIPTION
Original issue: https://github.com/hyperledger/iroha/issues/3878

We're actively using the "[Code snippets](https://hyperledger.github.io/iroha-2-docs/documenting/snippets.html)" feature, and I'm trying to have more.
While doing https://github.com/hyperledger/iroha-2-docs/pull/394, I want to reach some granularity.

I can either have `Cargo.toml` for the "[Client setup](https://hyperledger.github.io/iroha-2-docs/guide/rust.html#_1-iroha-2-client-setup)" section of the [Rust tutorial](https://hyperledger.github.io/iroha-2-docs/guide/rust.html) here or add it to the snippets directory in Iroha 2 documentation. It has less chance of remaining unnoticed for a long time if it belongs to the main repo, at least in my opinion.

Collecting a list of doc-related configurations that depend on the release in the main repo seems OK to me, but someone may disagree.

Please comment here.