### PR TITLE
[refactor] #3880 : Make `prepare_query_request` public

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -800,7 +800,7 @@ impl Client {
     ///     Ok(accounts.output())
     /// }
     /// ```
-    fn prepare_query_request<R: Query>(
+    pub fn prepare_query_request<R: Query>(
         &self,
         request: R,
         filter: PredicateBox,


### PR DESCRIPTION
## Description
Making the ```prepare_query_request``` public to make ```RC19``` comapatible with blockchain explorer.

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue
Closes #3880 
<!-- Duplicate the main issue and add additional issues closed by this PR. -->

### Benefits

Currently, the blockchain explorer backend requires various methods that were in Iroha version 2.0.0-pre-rc.16 but are not present / structured changed in Iroha version 2.0.0-pre-rc.19.
This patch will be addressing commits related to it.
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
