### PR TITLE
[ci] #3849: Fix stable/lts configs pushing job

### DIFF
--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -59,22 +59,23 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
           ref: iroha2-dev
-      - name: Setup git config
-        run: |
-          cd .git
-          git config --local user.name "sorabot"
-          git config --local user.email "<>"
+          token: ${{ secrets.G_ACCESS_TOKEN }}
       - name: Update configs
         run: |
           ./scripts/update_configs.sh lts
           ./scripts/update_configs.sh stable
       - name: Commit config changes
-        run: |
-          git config --global --add safe.directory /__w/iroha/iroha
-          git add -A
-          git diff-index --quiet HEAD || git commit -m "[documentation]: Update lts/stable configs following a release" --signoff
-          git push origin iroha2-dev
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[documentation]: Update lts/stable configs following a release'
+          branch: iroha2-dev
+          commit_options: '--signoff'
+          commit_user_name: sorabot
+          commit_user_email: <>
+          commit_author: sorabot <actions@github.com>


### PR DESCRIPTION
## Description
In `I2::Release::Publish`, add third-party Action step to commit and push the changes by `sorabot` user PAT to the protected branch

### Linked issue
#3849 

### Benefits

This Action should help to solve the problem of pushing changes to the `iroha2-dev` protected branch. However, it's an experiment and might not work due we are not able to use `sorabot` bot-user on forks.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
