### PR TITLE
[refactor] #3856: Proc macro for default validator boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,9 +3040,14 @@ dependencies = [
 name = "iroha_executor_derive"
 version = "2.0.0-pre-rc.20"
 dependencies = [
+ "darling",
+ "iroha_data_model",
+ "iroha_macro_utils",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/client/tests/integration/smartcontracts/executor_with_admin/src/lib.rs
+++ b/client/tests/integration/smartcontracts/executor_with_admin/src/lib.rs
@@ -2,175 +2,33 @@
 //! If authority is not `admin@admin` then default validation is used as a backup.
 
 #![no_std]
-#![allow(missing_docs, clippy::missing_errors_doc)]
 
 #[cfg(not(test))]
 extern crate panic_halt;
 
-use iroha_executor::{
-    data_model::evaluate::{EvaluationError, ExpressionEvaluator},
-    parse,
-    prelude::*,
-    smart_contract,
-};
+use iroha_executor::{parse, prelude::*, smart_contract};
 use lol_alloc::{FreeListAllocator, LockedAllocator};
 
 #[global_allocator]
 static ALLOC: LockedAllocator<FreeListAllocator> = LockedAllocator::new(FreeListAllocator::new());
 
+#[derive(Constructor, ValidateEntrypoints, ExpressionEvaluator, Validate, Visit)]
+#[visit(custom(visit_instruction))]
 struct Executor {
     verdict: Result,
     block_height: u64,
     host: smart_contract::Host,
 }
 
-impl Executor {
-    /// Construct [`Self`]
-    pub fn new(block_height: u64) -> Self {
-        Self {
-            verdict: Ok(()),
-            block_height,
-            host: smart_contract::Host,
-        }
-    }
-}
-
-macro_rules! defaults {
-    ( $($executor:ident $(<$param:ident $(: $bound:path)?>)?($operation:ty)),+ $(,)? ) => { $(
-        fn $executor $(<$param $(: $bound)?>)?(&mut self, authority: &AccountId, operation: $operation) {
-            iroha_executor::default::$executor(self, authority, operation)
-        } )+
-    };
-}
-
-impl Visit for Executor {
-    fn visit_instruction(&mut self, authority: &AccountId, isi: &InstructionExpr) {
-        if parse!("admin@admin" as AccountId) == *authority {
-            pass!(self);
-        }
-
-        iroha_executor::default::visit_instruction(self, authority, isi);
+fn visit_instruction(executor: &mut Executor, authority: &AccountId, isi: &InstructionExpr) {
+    if parse!("admin@admin" as AccountId) == *authority {
+        pass!(executor);
     }
 
-    defaults! {
-        visit_unsupported<T: core::fmt::Debug>(T),
-
-        visit_transaction(&SignedTransaction),
-        visit_expression<V>(&EvaluatesTo<V>),
-        visit_sequence(&SequenceExpr),
-        visit_if(&ConditionalExpr),
-        visit_pair(&PairExpr),
-
-        // Peer validation
-        visit_unregister_peer(Unregister<Peer>),
-
-        // Domain validation
-        visit_unregister_domain(Unregister<Domain>),
-        visit_transfer_domain(Transfer<Account, DomainId, Account>),
-        visit_set_domain_key_value(SetKeyValue<Domain>),
-        visit_remove_domain_key_value(RemoveKeyValue<Domain>),
-
-        // Account validation
-        visit_unregister_account(Unregister<Account>),
-        visit_mint_account_public_key(Mint<PublicKey, Account>),
-        visit_burn_account_public_key(Burn<PublicKey, Account>),
-        visit_mint_account_signature_check_condition(Mint<SignatureCheckCondition, Account>),
-        visit_set_account_key_value(SetKeyValue<Account>),
-        visit_remove_account_key_value(RemoveKeyValue<Account>),
-
-        // Asset validation
-        visit_register_asset(Register<Asset>),
-        visit_unregister_asset(Unregister<Asset>),
-        visit_mint_asset(Mint<NumericValue, Asset>),
-        visit_burn_asset(Burn<NumericValue, Asset>),
-        visit_transfer_asset(Transfer<Asset, NumericValue, Account>),
-        visit_set_asset_key_value(SetKeyValue<Asset>),
-        visit_remove_asset_key_value(RemoveKeyValue<Asset>),
-
-        // AssetDefinition validation
-        visit_unregister_asset_definition(Unregister<AssetDefinition>),
-        visit_transfer_asset_definition(Transfer<Account, AssetDefinitionId, Account>),
-        visit_set_asset_definition_key_value(SetKeyValue<AssetDefinition>),
-        visit_remove_asset_definition_key_value(RemoveKeyValue<AssetDefinition>),
-
-        // Permission validation
-        visit_grant_account_permission(Grant<PermissionToken>),
-        visit_revoke_account_permission(Revoke<PermissionToken>),
-
-        // Role validation
-        visit_register_role(Register<Role>),
-        visit_unregister_role(Unregister<Role>),
-        visit_grant_account_role(Grant<RoleId>),
-        visit_revoke_account_role(Revoke<RoleId>),
-
-        // Trigger validation
-        visit_unregister_trigger(Unregister<Trigger<TriggeringFilterBox>>),
-        visit_mint_trigger_repetitions(Mint<u32, Trigger<TriggeringFilterBox>>),
-        visit_burn_trigger_repetitions(Burn<u32, Trigger<TriggeringFilterBox>>),
-        visit_execute_trigger(ExecuteTrigger),
-
-        // Parameter validation
-        visit_set_parameter(SetParameter),
-        visit_new_parameter(NewParameter),
-
-        // Upgrade validation
-        visit_upgrade_executor(Upgrade<iroha_executor::data_model::executor::Executor>),
-    }
-}
-
-impl Validate for Executor {
-    fn verdict(&self) -> &Result {
-        &self.verdict
-    }
-
-    fn block_height(&self) -> u64 {
-        self.block_height
-    }
-
-    fn deny(&mut self, reason: ValidationFail) {
-        self.verdict = Err(reason);
-    }
-}
-
-impl ExpressionEvaluator for Executor {
-    fn evaluate<E: Evaluate>(&self, expression: &E) -> Result<E::Value, EvaluationError> {
-        self.host.evaluate(expression)
-    }
+    iroha_executor::default::visit_instruction(executor, authority, isi);
 }
 
 #[entrypoint]
 pub fn migrate(_block_height: u64) -> MigrationResult {
     Ok(())
-}
-
-#[entrypoint]
-pub fn validate_transaction(
-    authority: AccountId,
-    transaction: SignedTransaction,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_transaction(&authority, &transaction);
-    core::mem::forget(transaction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_instruction(
-    authority: AccountId,
-    instruction: InstructionExpr,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_instruction(&authority, &instruction);
-    core::mem::forget(instruction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_query(authority: AccountId, query: QueryBox, block_height: u64) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_query(&authority, &query);
-    core::mem::forget(query);
-    executor.verdict
 }

--- a/client/tests/integration/smartcontracts/executor_with_custom_token/src/lib.rs
+++ b/client/tests/integration/smartcontracts/executor_with_custom_token/src/lib.rs
@@ -11,7 +11,6 @@
 //! get access to control all domains. Remember that this is just a test example.
 
 #![no_std]
-#![allow(missing_docs, clippy::missing_errors_doc)]
 
 extern crate alloc;
 #[cfg(not(test))]
@@ -21,11 +20,7 @@ use alloc::{borrow::ToOwned, string::String};
 
 use anyhow::anyhow;
 use iroha_executor::{
-    data_model::evaluate::{EvaluationError, ExpressionEvaluator},
-    default::default_permission_token_schema,
-    permission::Token as _,
-    prelude::*,
-    smart_contract,
+    default::default_permission_token_schema, permission::Token as _, prelude::*, smart_contract,
 };
 use iroha_schema::IntoSchema;
 use lol_alloc::{FreeListAllocator, LockedAllocator};
@@ -59,6 +54,8 @@ mod token {
     pub struct CanControlDomainLives;
 }
 
+#[derive(Constructor, ValidateEntrypoints, ExpressionEvaluator, Validate, Visit)]
+#[visit(custom(visit_register_domain, visit_unregister_domain))]
 struct Executor {
     verdict: Result,
     block_height: u64,
@@ -66,15 +63,6 @@ struct Executor {
 }
 
 impl Executor {
-    /// Construct [`Self`]
-    pub fn new(block_height: u64) -> Self {
-        Self {
-            verdict: Ok(()),
-            block_height,
-            host: smart_contract::Host,
-        }
-    }
-
     fn get_all_accounts_with_can_unregister_domain_permission(
     ) -> Result<Vec<(Account, DomainId)>, MigrationError> {
         let accounts = FindAllAccounts.execute().map_err(|error| {
@@ -182,121 +170,33 @@ impl Executor {
     }
 }
 
-macro_rules! defaults {
-    ( $($executor:ident $(<$param:ident $(: $bound:path)?>)?($operation:ty)),+ $(,)? ) => { $(
-        fn $executor $(<$param $(: $bound)?>)?(&mut self, authority: &AccountId, operation: $operation) {
-            iroha_executor::default::$executor(self, authority, operation)
-        } )+
-    };
+fn visit_register_domain(executor: &mut Executor, authority: &AccountId, _isi: Register<Domain>) {
+    if executor.block_height() == 0 {
+        pass!(executor)
+    }
+    if token::CanControlDomainLives.is_owned_by(authority) {
+        pass!(executor);
+    }
+
+    deny!(
+        executor,
+        "You don't have permission to register a new domain"
+    );
 }
 
-impl Visit for Executor {
-    fn visit_register_domain(&mut self, authority: &AccountId, _isi: Register<Domain>) {
-        if self.block_height() == 0 {
-            pass!(self);
-        }
-        if token::CanControlDomainLives.is_owned_by(authority) {
-            pass!(self);
-        }
-
-        deny!(self, "You don't have permission to register a new domain");
+fn visit_unregister_domain(
+    executor: &mut Executor,
+    authority: &AccountId,
+    _isi: Unregister<Domain>,
+) {
+    if executor.block_height() == 0 {
+        pass!(executor);
+    }
+    if token::CanControlDomainLives.is_owned_by(authority) {
+        pass!(executor);
     }
 
-    fn visit_unregister_domain(&mut self, authority: &AccountId, _isi: Unregister<Domain>) {
-        if self.block_height() == 0 {
-            pass!(self);
-        }
-        if token::CanControlDomainLives.is_owned_by(authority) {
-            pass!(self);
-        }
-
-        deny!(self, "You don't have permission to unregister domain");
-    }
-
-    defaults! {
-        visit_unsupported<T: core::fmt::Debug>(T),
-
-        visit_transaction(&SignedTransaction),
-        visit_instruction(&InstructionExpr),
-        visit_expression<V>(&EvaluatesTo<V>),
-        visit_sequence(&SequenceExpr),
-        visit_if(&ConditionalExpr),
-        visit_pair(&PairExpr),
-
-        // Peer validation
-        visit_unregister_peer(Unregister<Peer>),
-
-        // Domain validation
-        visit_transfer_domain(Transfer<Account, DomainId, Account>),
-        visit_set_domain_key_value(SetKeyValue<Domain>),
-        visit_remove_domain_key_value(RemoveKeyValue<Domain>),
-
-        // Account validation
-        visit_unregister_account(Unregister<Account>),
-        visit_mint_account_public_key(Mint<PublicKey, Account>),
-        visit_burn_account_public_key(Burn<PublicKey, Account>),
-        visit_mint_account_signature_check_condition(Mint<SignatureCheckCondition, Account>),
-        visit_set_account_key_value(SetKeyValue<Account>),
-        visit_remove_account_key_value(RemoveKeyValue<Account>),
-
-        // Asset validation
-        visit_register_asset(Register<Asset>),
-        visit_unregister_asset(Unregister<Asset>),
-        visit_mint_asset(Mint<NumericValue, Asset>),
-        visit_burn_asset(Burn<NumericValue, Asset>),
-        visit_transfer_asset(Transfer<Asset, NumericValue, Account>),
-        visit_set_asset_key_value(SetKeyValue<Asset>),
-        visit_remove_asset_key_value(RemoveKeyValue<Asset>),
-
-        // AssetDefinition validation
-        visit_unregister_asset_definition(Unregister<AssetDefinition>),
-        visit_transfer_asset_definition(Transfer<Account, AssetDefinitionId, Account>),
-        visit_set_asset_definition_key_value(SetKeyValue<AssetDefinition>),
-        visit_remove_asset_definition_key_value(RemoveKeyValue<AssetDefinition>),
-
-        // Permission validation
-        visit_grant_account_permission(Grant<PermissionToken>),
-        visit_revoke_account_permission(Revoke<PermissionToken>),
-
-        // Role validation
-        visit_register_role(Register<Role>),
-        visit_unregister_role(Unregister<Role>),
-        visit_grant_account_role(Grant<RoleId>),
-        visit_revoke_account_role(Revoke<RoleId>),
-
-        // Trigger validation
-        visit_unregister_trigger(Unregister<Trigger<TriggeringFilterBox>>),
-        visit_mint_trigger_repetitions(Mint<u32, Trigger<TriggeringFilterBox>>),
-        visit_burn_trigger_repetitions(Burn<u32, Trigger<TriggeringFilterBox>>),
-        visit_execute_trigger(ExecuteTrigger),
-
-        // Parameter validation
-        visit_set_parameter(SetParameter),
-        visit_new_parameter(NewParameter),
-
-        // Upgrade validation
-        visit_upgrade_executor(Upgrade<iroha_executor::data_model::executor::Executor>),
-    }
-}
-
-impl Validate for Executor {
-    fn verdict(&self) -> &Result {
-        &self.verdict
-    }
-
-    fn block_height(&self) -> u64 {
-        self.block_height
-    }
-
-    fn deny(&mut self, reason: ValidationFail) {
-        self.verdict = Err(reason);
-    }
-}
-
-impl ExpressionEvaluator for Executor {
-    fn evaluate<E: Evaluate>(&self, expression: &E) -> Result<E::Value, EvaluationError> {
-        self.host.evaluate(expression)
-    }
+    deny!(executor, "You don't have permission to unregister domain");
 }
 
 #[entrypoint]
@@ -313,36 +213,4 @@ pub fn migrate(_block_height: u64) -> MigrationResult {
     );
 
     Executor::replace_token(&accounts)
-}
-
-#[entrypoint]
-pub fn validate_transaction(
-    authority: AccountId,
-    transaction: SignedTransaction,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_transaction(&authority, &transaction);
-    core::mem::forget(transaction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_instruction(
-    authority: AccountId,
-    instruction: InstructionExpr,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_instruction(&authority, &instruction);
-    core::mem::forget(instruction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_query(authority: AccountId, query: QueryBox, block_height: u64) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_query(&authority, &query);
-    core::mem::forget(query);
-    executor.verdict
 }

--- a/client/tests/integration/smartcontracts/executor_with_migration_fail/src/lib.rs
+++ b/client/tests/integration/smartcontracts/executor_with_migration_fail/src/lib.rs
@@ -1,7 +1,6 @@
 //! Runtime Executor which copies default validation logic but forbids any queries and fails to migrate.
 
 #![no_std]
-#![allow(missing_docs, clippy::missing_errors_doc)]
 
 extern crate alloc;
 #[cfg(not(test))]
@@ -10,137 +9,17 @@ extern crate panic_halt;
 use alloc::{borrow::ToOwned as _, format};
 
 use anyhow::anyhow;
-use iroha_executor::{
-    data_model::{
-        evaluate::{EvaluationError, ExpressionEvaluator},
-        ValidationFail,
-    },
-    parse,
-    prelude::*,
-    smart_contract,
-};
+use iroha_executor::{parse, prelude::*, smart_contract};
 use lol_alloc::{FreeListAllocator, LockedAllocator};
 
 #[global_allocator]
 static ALLOC: LockedAllocator<FreeListAllocator> = LockedAllocator::new(FreeListAllocator::new());
 
+#[derive(Constructor, ValidateEntrypoints, ExpressionEvaluator, Validate, Visit)]
 struct Executor {
     verdict: Result,
     block_height: u64,
     host: smart_contract::Host,
-}
-
-impl Executor {
-    /// Construct [`Self`]
-    pub fn new(block_height: u64) -> Self {
-        Self {
-            verdict: Ok(()),
-            block_height,
-            host: smart_contract::Host,
-        }
-    }
-}
-
-macro_rules! defaults {
-    ( $($executor:ident $(<$param:ident $(: $bound:path)?>)?($operation:ty)),+ $(,)? ) => { $(
-        fn $executor $(<$param $(: $bound)?>)?(&mut self, authority: &AccountId, operation: $operation) {
-            iroha_executor::default::$executor(self, authority, operation)
-        } )+
-    };
-}
-
-impl Visit for Executor {
-    fn visit_query(&mut self, _authority: &AccountId, _query: &QueryBox) {
-        self.deny(ValidationFail::NotPermitted(
-            "All queries are forbidden".to_owned(),
-        ));
-    }
-
-    defaults! {
-        visit_unsupported<T: core::fmt::Debug>(T),
-
-        visit_transaction(&SignedTransaction),
-        visit_instruction(&InstructionExpr),
-        visit_expression<V>(&EvaluatesTo<V>),
-        visit_sequence(&SequenceExpr),
-        visit_if(&ConditionalExpr),
-        visit_pair(&PairExpr),
-
-        // Peer validation
-        visit_unregister_peer(Unregister<Peer>),
-
-        // Domain validation
-        visit_unregister_domain(Unregister<Domain>),
-        visit_transfer_domain(Transfer<Account, DomainId, Account>),
-        visit_set_domain_key_value(SetKeyValue<Domain>),
-        visit_remove_domain_key_value(RemoveKeyValue<Domain>),
-
-        // Account validation
-        visit_unregister_account(Unregister<Account>),
-        visit_mint_account_public_key(Mint<PublicKey, Account>),
-        visit_burn_account_public_key(Burn<PublicKey, Account>),
-        visit_mint_account_signature_check_condition(Mint<SignatureCheckCondition, Account>),
-        visit_set_account_key_value(SetKeyValue<Account>),
-        visit_remove_account_key_value(RemoveKeyValue<Account>),
-
-        // Asset validation
-        visit_register_asset(Register<Asset>),
-        visit_unregister_asset(Unregister<Asset>),
-        visit_mint_asset(Mint<NumericValue, Asset>),
-        visit_burn_asset(Burn<NumericValue, Asset>),
-        visit_transfer_asset(Transfer<Asset, NumericValue, Account>),
-        visit_set_asset_key_value(SetKeyValue<Asset>),
-        visit_remove_asset_key_value(RemoveKeyValue<Asset>),
-
-        // AssetDefinition validation
-        visit_unregister_asset_definition(Unregister<AssetDefinition>),
-        visit_transfer_asset_definition(Transfer<Account, AssetDefinitionId, Account>),
-        visit_set_asset_definition_key_value(SetKeyValue<AssetDefinition>),
-        visit_remove_asset_definition_key_value(RemoveKeyValue<AssetDefinition>),
-
-        // Permission validation
-        visit_grant_account_permission(Grant<PermissionToken>),
-        visit_revoke_account_permission(Revoke<PermissionToken>),
-
-        // Role validation
-        visit_register_role(Register<Role>),
-        visit_unregister_role(Unregister<Role>),
-        visit_grant_account_role(Grant<RoleId>),
-        visit_revoke_account_role(Revoke<RoleId>),
-
-        // Trigger validation
-        visit_unregister_trigger(Unregister<Trigger<TriggeringFilterBox>>),
-        visit_mint_trigger_repetitions(Mint<u32, Trigger<TriggeringFilterBox>>),
-        visit_burn_trigger_repetitions(Burn<u32, Trigger<TriggeringFilterBox>>),
-        visit_execute_trigger(ExecuteTrigger),
-
-        // Parameter validation
-        visit_set_parameter(SetParameter),
-        visit_new_parameter(NewParameter),
-
-        // Upgrade validation
-        visit_upgrade_executor(Upgrade<iroha_executor::data_model::executor::Executor>),
-    }
-}
-
-impl Validate for Executor {
-    fn verdict(&self) -> &Result {
-        &self.verdict
-    }
-
-    fn block_height(&self) -> u64 {
-        self.block_height
-    }
-
-    fn deny(&mut self, reason: ValidationFail) {
-        self.verdict = Err(reason);
-    }
-}
-
-impl ExpressionEvaluator for Executor {
-    fn evaluate<E: Evaluate>(&self, expression: &E) -> Result<E::Value, EvaluationError> {
-        self.host.evaluate(expression)
-    }
 }
 
 #[entrypoint]
@@ -159,36 +38,4 @@ pub fn migrate(_block_height: u64) -> MigrationResult {
         })?;
 
     Err("This executor always fails to migrate".to_owned())
-}
-
-#[entrypoint]
-pub fn validate_transaction(
-    authority: AccountId,
-    transaction: SignedTransaction,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_transaction(&authority, &transaction);
-    core::mem::forget(transaction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_instruction(
-    authority: AccountId,
-    instruction: InstructionExpr,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_instruction(&authority, &instruction);
-    core::mem::forget(instruction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_query(authority: AccountId, query: QueryBox, block_height: u64) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_query(&authority, &query);
-    core::mem::forget(query);
-    executor.verdict
 }

--- a/default_executor/src/lib.rs
+++ b/default_executor/src/lib.rs
@@ -1,7 +1,6 @@
 //! Iroha default executor.
 
 #![no_std]
-#![allow(missing_docs, clippy::missing_errors_doc)]
 
 extern crate alloc;
 #[cfg(not(test))]
@@ -9,10 +8,7 @@ extern crate panic_halt;
 
 use alloc::borrow::ToOwned as _;
 
-use iroha_executor::{
-    data_model::evaluate::ExpressionEvaluator, default::default_permission_token_schema,
-    prelude::*, smart_contract,
-};
+use iroha_executor::{default::default_permission_token_schema, prelude::*, smart_contract};
 use lol_alloc::{FreeListAllocator, LockedAllocator};
 
 #[global_allocator]
@@ -23,7 +19,7 @@ static ALLOC: LockedAllocator<FreeListAllocator> = LockedAllocator::new(FreeList
 /// # Warning
 ///
 /// The defaults are not guaranteed to be stable.
-#[derive(Debug, Clone)]
+#[derive(Clone, Constructor, Debug, ValidateEntrypoints, ExpressionEvaluator, Validate, Visit)]
 pub struct Executor {
     verdict: Result,
     block_height: u64,
@@ -31,15 +27,6 @@ pub struct Executor {
 }
 
 impl Executor {
-    /// Construct [`Self`]
-    pub fn new(block_height: u64) -> Self {
-        Self {
-            verdict: Ok(()),
-            block_height,
-            host: smart_contract::Host,
-        }
-    }
-
     fn ensure_genesis(block_height: u64) -> MigrationResult {
         if block_height != 0 {
             return Err("Default Executor is intended to be used only in genesis. \
@@ -48,104 +35,6 @@ impl Executor {
         }
 
         Ok(())
-    }
-}
-
-macro_rules! defaults {
-    ( $($executor:ident $(<$param:ident $(: $bound:path)?>)?($operation:ty)),+ $(,)? ) => { $(
-        fn $executor $(<$param $(: $bound)?>)?(&mut self, authority: &AccountId, operation: $operation) {
-            iroha_executor::default::$executor(self, authority, operation)
-        } )+
-    };
-}
-
-impl Visit for Executor {
-    defaults! {
-        visit_unsupported<T: core::fmt::Debug>(T),
-
-        visit_transaction(&SignedTransaction),
-        visit_instruction(&InstructionExpr),
-        visit_expression<V>(&EvaluatesTo<V>),
-        visit_sequence(&SequenceExpr),
-        visit_if(&ConditionalExpr),
-        visit_pair(&PairExpr),
-
-        // Peer validation
-        visit_unregister_peer(Unregister<Peer>),
-
-        // Domain validation
-        visit_unregister_domain(Unregister<Domain>),
-        visit_set_domain_key_value(SetKeyValue<Domain>),
-        visit_remove_domain_key_value(RemoveKeyValue<Domain>),
-
-        // Account validation
-        visit_unregister_account(Unregister<Account>),
-        visit_mint_account_public_key(Mint<PublicKey, Account>),
-        visit_burn_account_public_key(Burn<PublicKey, Account>),
-        visit_mint_account_signature_check_condition(Mint<SignatureCheckCondition, Account>),
-        visit_set_account_key_value(SetKeyValue<Account>),
-        visit_remove_account_key_value(RemoveKeyValue<Account>),
-
-        // Asset validation
-        visit_register_asset(Register<Asset>),
-        visit_unregister_asset(Unregister<Asset>),
-        visit_mint_asset(Mint<NumericValue, Asset>),
-        visit_burn_asset(Burn<NumericValue, Asset>),
-        visit_transfer_asset(Transfer<Asset, NumericValue, Account>),
-        visit_set_asset_key_value(SetKeyValue<Asset>),
-        visit_remove_asset_key_value(RemoveKeyValue<Asset>),
-
-        // AssetDefinition validation
-        visit_unregister_asset_definition(Unregister<AssetDefinition>),
-        visit_transfer_asset_definition(Transfer<Account, AssetDefinitionId, Account>),
-        visit_set_asset_definition_key_value(SetKeyValue<AssetDefinition>),
-        visit_remove_asset_definition_key_value(RemoveKeyValue<AssetDefinition>),
-
-        // Permission validation
-        visit_grant_account_permission(Grant<PermissionToken>),
-        visit_revoke_account_permission(Revoke<PermissionToken>),
-
-        // Role validation
-        visit_register_role(Register<Role>),
-        visit_unregister_role(Unregister<Role>),
-        visit_grant_account_role(Grant<RoleId>),
-        visit_revoke_account_role(Revoke<RoleId>),
-
-        // Trigger validation
-        visit_unregister_trigger(Unregister<Trigger<TriggeringFilterBox>>),
-        visit_mint_trigger_repetitions(Mint<u32, Trigger<TriggeringFilterBox>>),
-        visit_burn_trigger_repetitions(Burn<u32, Trigger<TriggeringFilterBox>>),
-        visit_execute_trigger(ExecuteTrigger),
-
-        // Parameter validation
-        visit_set_parameter(SetParameter),
-        visit_new_parameter(NewParameter),
-
-        // Upgrade validation
-        visit_upgrade_executor(Upgrade<iroha_executor::data_model::executor::Executor>),
-    }
-}
-
-impl Validate for Executor {
-    fn verdict(&self) -> &Result {
-        &self.verdict
-    }
-
-    fn block_height(&self) -> u64 {
-        self.block_height
-    }
-
-    fn deny(&mut self, reason: ValidationFail) {
-        self.verdict = Err(reason);
-    }
-}
-
-impl ExpressionEvaluator for Executor {
-    fn evaluate<E: Evaluate>(
-        &self,
-        expression: &E,
-    ) -> core::result::Result<E::Value, iroha_executor::data_model::evaluate::EvaluationError> {
-        self.host.evaluate(expression)
     }
 }
 
@@ -169,36 +58,4 @@ pub fn migrate(block_height: u64) -> MigrationResult {
     );
 
     Ok(())
-}
-
-#[entrypoint]
-pub fn validate_transaction(
-    authority: AccountId,
-    transaction: SignedTransaction,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_transaction(&authority, &transaction);
-    core::mem::forget(transaction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_instruction(
-    authority: AccountId,
-    instruction: InstructionExpr,
-    block_height: u64,
-) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_instruction(&authority, &instruction);
-    core::mem::forget(instruction);
-    executor.verdict
-}
-
-#[entrypoint]
-pub fn validate_query(authority: AccountId, query: QueryBox, block_height: u64) -> Result {
-    let mut executor = Executor::new(block_height);
-    executor.visit_query(&authority, &query);
-    core::mem::forget(query);
-    executor.verdict
 }

--- a/smart_contract/executor/derive/Cargo.toml
+++ b/smart_contract/executor/derive/Cargo.toml
@@ -15,6 +15,11 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-syn.workspace = true
+iroha_data_model.workspace = true
+iroha_macro_utils.workspace = true
+syn = { workspace = true, features = ["full", "derive"] }
+syn2 = { workspace = true, features = ["full", "derive"] }
 quote.workspace = true
 proc-macro2.workspace = true
+manyhow.workspace = true
+darling.workspace = true

--- a/smart_contract/executor/derive/src/default.rs
+++ b/smart_contract/executor/derive/src/default.rs
@@ -1,0 +1,367 @@
+use darling::{ast::NestedMeta, FromDeriveInput, FromMeta};
+use iroha_macro_utils::Emitter;
+use manyhow::emit;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn2::{parse_quote, Ident};
+
+type ExecutorData = darling::ast::Data<darling::util::Ignored, syn2::Field>;
+
+#[derive(Debug)]
+struct Custom(Vec<Ident>);
+
+impl FromMeta for Custom {
+    fn from_list(items: &[NestedMeta]) -> darling::Result<Self> {
+        let mut res = Vec::new();
+        for item in items {
+            if let NestedMeta::Meta(syn2::Meta::Path(p)) = item {
+                let fn_name = p.get_ident().expect("Path should be ident");
+                res.push(fn_name.clone());
+            } else {
+                return Err(darling::Error::custom(
+                    "Invalid path list supplied to `omit` attribute",
+                ));
+            }
+        }
+        Ok(Self(res))
+    }
+}
+
+#[derive(FromDeriveInput, Debug)]
+#[darling(supports(struct_named), attributes(visit, entrypoints))]
+struct ExecutorDeriveInput {
+    ident: Ident,
+    data: ExecutorData,
+    custom: Option<Custom>,
+}
+
+pub fn impl_derive_entrypoints(emitter: &mut Emitter, input: &syn2::DeriveInput) -> TokenStream2 {
+    let Some(input) = emitter.handle(ExecutorDeriveInput::from_derive_input(input)) else {
+        return quote!();
+    };
+    let ExecutorDeriveInput {
+        ident,
+        data,
+        custom,
+        ..
+    } = &input;
+    check_required_fields(data, emitter);
+
+    let (custom_idents, custom_args) = custom_field_idents_and_fn_args(data);
+
+    let mut entrypoint_fns: Vec<syn2::ItemFn> = vec![
+        parse_quote! {
+            #[::iroha_executor::prelude::entrypoint]
+            pub fn validate_instruction(
+                authority: ::iroha_executor::prelude::AccountId,
+                instruction: ::iroha_executor::prelude::InstructionExpr,
+                block_height: u64,
+                #(#custom_args),*
+            ) -> ::iroha_executor::prelude::Result {
+                let mut executor = #ident::new(block_height, #(#custom_idents),*);
+                executor.visit_instruction(&authority, &instruction);
+                ::core::mem::forget(instruction);
+                executor.verdict
+            }
+        },
+        parse_quote! {
+            #[::iroha_executor::prelude::entrypoint]
+            pub fn validate_transaction(
+                authority: ::iroha_executor::prelude::AccountId,
+                transaction: ::iroha_executor::prelude::SignedTransaction,
+                block_height: u64,
+                #(#custom_args),*
+            ) -> ::iroha_executor::prelude::Result {
+                let mut executor = #ident::new(block_height, #(#custom_idents),*);
+                executor.visit_transaction(&authority, &transaction);
+                ::core::mem::forget(transaction);
+                executor.verdict
+            }
+        },
+        parse_quote! {
+            #[::iroha_executor::prelude::entrypoint]
+            pub fn validate_query(
+                authority: ::iroha_executor::prelude::AccountId,
+                query: ::iroha_executor::prelude::QueryBox,
+                block_height: u64,
+                #(#custom_args),*
+            ) -> ::iroha_executor::prelude::Result {
+                let mut executor = #ident::new(block_height, #(#custom_idents),*);
+                executor.visit_query(&authority, &query);
+                ::core::mem::forget(query);
+                executor.verdict
+            }
+        },
+    ];
+    if let Some(custom) = custom {
+        entrypoint_fns.retain(|entrypoint| {
+            !custom
+                .0
+                .iter()
+                .any(|fn_name| fn_name == &entrypoint.sig.ident)
+        });
+    }
+
+    quote! {
+        #(#entrypoint_fns)*
+    }
+}
+
+pub fn impl_derive_visit(emitter: &mut Emitter, input: &syn2::DeriveInput) -> TokenStream2 {
+    let Some(input) = emitter.handle(ExecutorDeriveInput::from_derive_input(input)) else {
+        return quote!();
+    };
+    let ExecutorDeriveInput { ident, custom, .. } = &input;
+    let default_visit_sigs: Vec<syn2::Signature> = [
+        "fn visit_unsupported<T: core::fmt::Debug>(operation: T)",
+        "fn visit_transaction(operation: &SignedTransaction)",
+        "fn visit_instruction(operation: &InstructionExpr)",
+        "fn visit_expression<V>(operation: &EvaluatesTo<V>)",
+        "fn visit_sequence(operation: &SequenceExpr)",
+        "fn visit_if(operation: &ConditionalExpr)",
+        "fn visit_pair(operation: &PairExpr)",
+        "fn visit_unregister_peer(operation: Unregister<Peer>)",
+        "fn visit_unregister_domain(operation: Unregister<Domain>)",
+        "fn visit_transfer_domain(operation: Transfer<Account, DomainId, Account>)",
+        "fn visit_set_domain_key_value(operation: SetKeyValue<Domain>)",
+        "fn visit_remove_domain_key_value(operation: RemoveKeyValue<Domain>)",
+        "fn visit_unregister_account(operation: Unregister<Account>)",
+        "fn visit_mint_account_public_key(operation: Mint<PublicKey, Account>)",
+        "fn visit_burn_account_public_key(operation: Burn<PublicKey, Account>)",
+        "fn visit_mint_account_signature_check_condition(operation: Mint<SignatureCheckCondition, Account>)",
+        "fn visit_set_account_key_value(operation: SetKeyValue<Account>)",
+        "fn visit_remove_account_key_value(operation: RemoveKeyValue<Account>)",
+        "fn visit_register_asset(operation: Register<Asset>)",
+        "fn visit_unregister_asset(operation: Unregister<Asset>)",
+        "fn visit_mint_asset(operation: Mint<NumericValue, Asset>)",
+        "fn visit_burn_asset(operation: Burn<NumericValue, Asset>)",
+        "fn visit_transfer_asset(operation: Transfer<Asset, NumericValue, Account>)",
+        "fn visit_set_asset_key_value(operation: SetKeyValue<Asset>)",
+        "fn visit_remove_asset_key_value(operation: RemoveKeyValue<Asset>)",
+        "fn visit_unregister_asset_definition(operation: Unregister<AssetDefinition>)",
+        "fn visit_transfer_asset_definition(operation: Transfer<Account, AssetDefinitionId, Account>)",
+        "fn visit_set_asset_definition_key_value(operation: SetKeyValue<AssetDefinition>)",
+        "fn visit_remove_asset_definition_key_value(operation: RemoveKeyValue<AssetDefinition>)",
+        "fn visit_grant_account_permission(operation: Grant<PermissionToken>)",
+        "fn visit_revoke_account_permission(operation: Revoke<PermissionToken>)",
+        "fn visit_register_role(operation: Register<Role>)",
+        "fn visit_unregister_role(operation: Unregister<Role>)",
+        "fn visit_grant_account_role(operation: Grant<RoleId>)",
+        "fn visit_revoke_account_role(operation: Revoke<RoleId>)",
+        "fn visit_unregister_trigger(operation: Unregister<Trigger<TriggeringFilterBox>>)",
+        "fn visit_mint_trigger_repetitions(operation: Mint<u32, Trigger<TriggeringFilterBox>>)",
+        "fn visit_burn_trigger_repetitions(operation: Burn<u32, Trigger<TriggeringFilterBox>>)",
+        "fn visit_execute_trigger(operation: ExecuteTrigger)",
+        "fn visit_set_parameter(operation: SetParameter)",
+        "fn visit_new_parameter(operation: NewParameter)",
+        "fn visit_upgrade_executor(operation: Upgrade<iroha_executor::data_model::executor::Executor>)",
+    ]
+    .into_iter()
+    .map(|item| {
+        let mut sig: syn2::Signature =
+            syn2::parse_str(item).expect("Function names and operation signatures should be valid");
+        let recv_arg: syn2::Receiver = parse_quote!(&mut self);
+        let auth_arg: syn2::FnArg = parse_quote!(authority: &AccountId);
+        sig.inputs.insert(0, recv_arg.into());
+        sig.inputs.insert(1, auth_arg);
+        sig
+    })
+    .collect();
+
+    let visit_items = default_visit_sigs
+        .iter()
+        .map(|visit_sig| {
+            let curr_fn_name = &visit_sig.ident;
+            let local_override_fn = quote! {
+                #visit_sig {
+                    #curr_fn_name(self, authority, operation)
+                }
+            };
+            let default_override_fn = quote! {
+                #visit_sig {
+                    ::iroha_executor::default::#curr_fn_name(self, authority, operation)
+                }
+            };
+            if let Some(fns_to_exclude) = custom {
+                if fns_to_exclude
+                    .0
+                    .iter()
+                    .any(|fn_name| fn_name == &visit_sig.ident)
+                {
+                    local_override_fn
+                } else {
+                    default_override_fn
+                }
+            } else {
+                default_override_fn
+            }
+        })
+        .collect::<Vec<_>>();
+
+    println!("{}", quote!(#(#visit_items)*));
+    quote! {
+        impl ::iroha_executor::prelude::Visit for #ident {
+            #(#visit_items)*
+        }
+    }
+}
+
+pub fn impl_derive_validate(emitter: &mut Emitter, input: &syn2::DeriveInput) -> TokenStream2 {
+    let Some(input) = emitter.handle(ExecutorDeriveInput::from_derive_input(input)) else {
+        return quote!();
+    };
+    let ExecutorDeriveInput { ident, data, .. } = &input;
+    check_required_fields(data, emitter);
+    quote! {
+        impl ::iroha_executor::Validate for #ident {
+            fn verdict(&self) -> &::iroha_executor::prelude::Result {
+                &self.verdict
+            }
+
+            fn block_height(&self) -> u64 {
+                self.block_height
+            }
+
+            fn deny(&mut self, reason: ::iroha_executor::prelude::ValidationFail) {
+                self.verdict = Err(reason);
+            }
+        }
+    }
+}
+
+pub fn impl_derive_expression_evaluator(
+    emitter: &mut Emitter,
+    input: &syn2::DeriveInput,
+) -> TokenStream2 {
+    let Some(input) = emitter.handle(ExecutorDeriveInput::from_derive_input(input)) else {
+        return quote!();
+    };
+    let ExecutorDeriveInput { ident, data, .. } = &input;
+    check_required_fields(data, emitter);
+    quote! {
+        impl ::iroha_executor::data_model::evaluate::ExpressionEvaluator for #ident {
+            fn evaluate<E: ::iroha_executor::prelude::Evaluate>(
+                &self,
+                expression: &E,
+            ) -> ::core::result::Result<E::Value, ::iroha_executor::smart_contract::data_model::evaluate::EvaluationError>
+            {
+                self.host.evaluate(expression)
+            }
+        }
+
+    }
+}
+
+pub fn impl_derive_constructor(emitter: &mut Emitter, input: &syn2::DeriveInput) -> TokenStream2 {
+    let Some(input) = emitter.handle(ExecutorDeriveInput::from_derive_input(input)) else {
+        return quote!();
+    };
+    let ExecutorDeriveInput { ident, data, .. } = &input;
+
+    check_required_fields(data, emitter);
+
+    let (custom_idents, custom_args) = custom_field_idents_and_fn_args(data);
+
+    // Returning an inherent impl is okay here as there can be multiple
+    quote! {
+        impl #ident {
+            pub fn new(block_height: u64, #(#custom_args),*) -> Self {
+                Self {
+                    verdict: Ok(()),
+                    block_height,
+                    host: ::iroha_executor::smart_contract::Host,
+                    #(#custom_idents),*
+                }
+            }
+        }
+
+    }
+}
+
+fn check_required_fields(ast: &ExecutorData, emitter: &mut Emitter) {
+    let required_fields: syn2::FieldsNamed = parse_quote!({ verdict: ::iroha_executor::prelude::Result, block_height: u64, host: ::iroha_executor::smart_contract::Host });
+    let struct_fields = ast
+        .as_ref()
+        .take_struct()
+        .expect("BUG: ExecutorDeriveInput is allowed to contain struct data only")
+        .fields;
+    required_fields.named.iter().for_each(|required_field| {
+        if !struct_fields.iter().any(|struct_field| {
+            struct_field.ident == required_field.ident
+                && check_type_equivalence(&required_field.ty, &struct_field.ty)
+        }) {
+            emit!(
+                emitter,
+                Span::call_site(),
+                "The struct didn't have the required field named `{}` of type `{}`",
+                required_field
+                    .ident
+                    .as_ref()
+                    .expect("Required field should be named"),
+                required_field.ty.to_token_stream()
+            )
+        }
+    });
+}
+
+/// Check that the required fields of an `Executor` are of the correct types. As
+/// the types can be completely or partially unqualified, we need to go through the type path segments to
+/// determine equivalence. We can't account for any aliases though
+fn check_type_equivalence(full_ty: &syn2::Type, given_ty: &syn2::Type) -> bool {
+    match (full_ty, given_ty) {
+        (syn2::Type::Path(full_ty_path), syn2::Type::Path(given_ty_path)) => {
+            if full_ty_path.path.segments.len() == given_ty_path.path.segments.len() {
+                full_ty_path == given_ty_path
+            } else {
+                full_ty_path
+                    .path
+                    .segments
+                    .iter()
+                    .rev()
+                    .zip(given_ty_path.path.segments.iter().rev())
+                    .all(|(full_seg, given_seg)| full_seg == given_seg)
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Processes an `Executor` by draining it of default fields and returning the idents of the
+/// custom fields and the corresponding function arguments for use in the constructor
+fn custom_field_idents_and_fn_args(ast: &ExecutorData) -> (Vec<&Ident>, Vec<syn2::FnArg>) {
+    let required_idents: Vec<Ident> = ["verdict", "block_height", "host"]
+        .iter()
+        .map(|s| Ident::new(s, Span::call_site()))
+        .collect();
+    let mut custom_fields = ast
+        .as_ref()
+        .take_struct()
+        .expect("BUG: ExecutorDeriveInput is allowed to contain struct data only")
+        .fields;
+    custom_fields.retain(|field| {
+        let curr_ident = field
+            .ident
+            .as_ref()
+            .expect("BUG: Struct should have named fields");
+        !required_idents.iter().any(|ident| ident == curr_ident)
+    });
+    let custom_idents = custom_fields
+        .iter()
+        .map(|field| {
+            field
+                .ident
+                .as_ref()
+                .expect("BUG: Struct should have named fields")
+        })
+        .collect::<Vec<_>>();
+    let custom_args = custom_fields
+        .iter()
+        .map(|field| {
+            let ident = &field.ident;
+            let ty = &field.ty;
+            let field_arg: syn2::FnArg = parse_quote!(#ident: #ty);
+            field_arg
+        })
+        .collect::<Vec<_>>();
+    (custom_idents, custom_args)
+}

--- a/smart_contract/executor/derive/src/validate.rs
+++ b/smart_contract/executor/derive/src/validate.rs
@@ -6,7 +6,7 @@ use syn::{Attribute, Ident, Path, Type};
 use super::*;
 
 /// [`derive_validate`](crate::derive_validate()) macro implementation
-pub fn impl_derive_validate(input: TokenStream) -> TokenStream {
+pub fn impl_derive_validate_grant_revoke(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let ident = input.ident;
 

--- a/smart_contract/executor/src/lib.rs
+++ b/smart_contract/executor/src/lib.rs
@@ -252,7 +252,10 @@ pub mod prelude {
         visit::Visit,
         ValidationFail,
     };
-    pub use iroha_executor_derive::{entrypoint, Token, ValidateGrantRevoke};
+    pub use iroha_executor_derive::{
+        entrypoint, Constructor, ExpressionEvaluator, Token, Validate, ValidateEntrypoints,
+        ValidateGrantRevoke, Visit,
+    };
     pub use iroha_smart_contract::{prelude::*, Context};
 
     pub use super::{deny, pass, PermissionTokenSchema, Validate};


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
Now the different flavors of validators can be generated with less repetition.
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3856. <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
Less non-obvious boilerplate when defining custom validators.
<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
