### PR TITLE
[refactor] #3822, #3737, #2437: Refactor iroha_data_model_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,9 +3173,12 @@ name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.19"
 dependencies = [
  "darling",
+ "derive_more",
  "iroha_data_model",
  "iroha_macro_utils",
+ "iroha_schema",
  "manyhow",
+ "parity-scale-codec",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,14 +3172,15 @@ dependencies = [
 name = "iroha_data_model_derive"
 version = "2.0.0-pre-rc.19"
 dependencies = [
+ "darling",
  "iroha_data_model",
  "iroha_macro_utils",
- "proc-macro-error",
+ "manyhow",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.26",
  "trybuild",
 ]
 
@@ -3226,9 +3227,9 @@ name = "iroha_ffi_derive"
 version = "2.0.0-pre-rc.19"
 dependencies = [
  "darling",
- "drop_bomb",
  "getset",
  "iroha_ffi",
+ "iroha_macro_utils",
  "manyhow",
  "parse-display",
  "proc-macro2",
@@ -3311,10 +3312,13 @@ dependencies = [
 name = "iroha_macro_utils"
 version = "2.0.0-pre-rc.19"
 dependencies = [
- "proc-macro-error",
+ "darling",
+ "drop_bomb",
+ "manyhow",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "syn 2.0.26",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,7 +3183,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.26",
+ "syn 2.0.28",
  "trybuild",
 ]
 
@@ -3321,7 +3321,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "syn 2.0.26",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-syn2 = { workspace = true, features = ["default", "full", "extra-traits"] }
+syn2 = { workspace = true, features = ["default", "full", "extra-traits", "visit-mut"] }
 quote = { workspace = true }
 darling = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -14,12 +14,12 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["default", "full", "extra-traits"] }
+syn2 = { workspace = true, features = ["default", "full", "extra-traits"] }
 quote = { workspace = true }
+darling = { workspace = true }
 proc-macro2 = { workspace = true }
-proc-macro-error = { workspace = true }
+manyhow = { workspace = true }
 iroha_macro_utils = { workspace = true }
-serde_json = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 iroha_data_model = { workspace = true, features = ["http"] }

--- a/data_model/derive/Cargo.toml
+++ b/data_model/derive/Cargo.toml
@@ -23,6 +23,9 @@ iroha_macro_utils = { workspace = true }
 
 [dev-dependencies]
 iroha_data_model = { workspace = true, features = ["http"] }
+iroha_schema = { workspace = true }
+parity-scale-codec = { workspace = true }
+derive_more = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -598,8 +598,14 @@ pub fn partially_tagged_deserialize_derive(input: TokenStream) -> Result<TokenSt
 /// ```
 #[manyhow]
 #[proc_macro_derive(HasOrigin, attributes(has_origin))]
-pub fn has_origin_derive(input: TokenStream) -> Result<TokenStream> {
-    let input = syn2::parse2(input)?;
+pub fn has_origin_derive(input: TokenStream) -> TokenStream {
+    let mut emitter = Emitter::new();
 
-    has_origin::impl_has_origin(&input)
+    let Some(input) = emitter.handle(syn2::parse2(input)) else {
+        return emitter.finish_token_stream()
+    };
+
+    let result = has_origin::impl_has_origin(&mut emitter, &input);
+
+    emitter.finish_token_stream_with(result)
 }

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -230,10 +230,15 @@ pub fn model_single(input: TokenStream) -> TokenStream {
 ///
 #[manyhow]
 #[proc_macro_derive(IdEqOrdHash, attributes(id, opaque))]
-pub fn id_eq_ord_hash(input: TokenStream) -> Result<TokenStream> {
-    let input = syn2::parse2(input)?;
+pub fn id_eq_ord_hash(input: TokenStream) -> TokenStream {
+    let mut emitter = Emitter::new();
 
-    id::impl_id(&input)
+    let Some(input) = emitter.handle(syn2::parse2(input)) else {
+        return emitter.finish_token_stream();
+    };
+
+    let result = id::impl_id_eq_ord_hash(&mut emitter, &input);
+    emitter.finish_token_stream_with(result)
 }
 
 /// [`Filter`] is used for code generation of `...Filter` structs and `...EventFilter` enums, as well as

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -447,7 +447,7 @@ pub fn filter_derive(input: TokenStream) -> TokenStream {
 pub fn partially_tagged_serialize_derive(input: TokenStream) -> Result<TokenStream> {
     let input = syn2::parse2(input)?;
 
-    Ok(partially_tagged::impl_partially_tagged_serialize(&input))
+    partially_tagged::impl_partially_tagged_serialize(&input)
 }
 
 /// Derive `::serde::Deserialize` trait for `enum` with possibility to avoid tags for selected variants
@@ -510,7 +510,7 @@ pub fn partially_tagged_serialize_derive(input: TokenStream) -> Result<TokenStre
 pub fn partially_tagged_deserialize_derive(input: TokenStream) -> Result<TokenStream> {
     let input = syn2::parse2(input)?;
 
-    Ok(partially_tagged::impl_partially_tagged_deserialize(&input))
+    partially_tagged::impl_partially_tagged_deserialize(&input)
 }
 
 /// Derive macro for `HasOrigin`.

--- a/data_model/derive/src/lib.rs
+++ b/data_model/derive/src/lib.rs
@@ -400,10 +400,15 @@ pub fn id_eq_ord_hash(input: TokenStream) -> Result<TokenStream> {
 /// It assumes that the derive is imported and referred to by its original name.
 #[manyhow]
 #[proc_macro_derive(Filter)]
-pub fn filter_derive(input: TokenStream) -> Result<TokenStream> {
-    let input = syn2::parse2(input)?;
+pub fn filter_derive(input: TokenStream) -> TokenStream {
+    let mut emitter = Emitter::new();
 
-    Ok(filter::impl_filter(&input))
+    let Some(input) = emitter.handle(syn2::parse2(input)) else {
+        return emitter.finish_token_stream();
+    };
+
+    let result = filter::impl_filter(&mut emitter, &input);
+    emitter.finish_token_stream_with(result)
 }
 
 /// Derive `::serde::Serialize` trait for `enum` with possibility to avoid tags for selected variants

--- a/data_model/derive/src/partially_tagged/resolve_self.rs
+++ b/data_model/derive/src/partially_tagged/resolve_self.rs
@@ -1,0 +1,63 @@
+use syn2::visit_mut::VisitMut;
+
+struct Visitor<'a> {
+    self_ty: &'a syn2::Type,
+}
+
+impl VisitMut for Visitor<'_> {
+    fn visit_type_mut(&mut self, ty: &mut syn2::Type) {
+        match ty {
+            syn2::Type::Path(path_ty)
+                if path_ty.qself.is_none() && path_ty.path.is_ident("Self") =>
+            {
+                *ty = self.self_ty.clone();
+            }
+            _ => syn2::visit_mut::visit_type_mut(self, ty),
+        }
+    }
+}
+
+/// Transforms the [`resolving_ty`] by replacing `Self` with [`self_ty`].
+///
+/// This is required to be able to use `Self` in `PartiallyTaggedSerialize` and `PartiallyTaggedDeserialize`,
+///     as they define an additional intermediate type during serialization/deserialization. Using `Self` there would refer to an incorrect type.
+pub fn resolve_self(self_ty: &syn2::Type, mut resolving_ty: syn2::Type) -> syn2::Type {
+    Visitor { self_ty }.visit_type_mut(&mut resolving_ty);
+    resolving_ty
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens;
+    use syn2::{parse_quote, Type};
+
+    #[test]
+    fn test_resolve_self() {
+        let test_types = [
+            parse_quote!(i32),
+            parse_quote!(Self),
+            parse_quote!(Vec<Self>),
+            parse_quote!((Self, Self)),
+            parse_quote!(<Self as Trait>::Type),
+        ];
+        let expected_types = [
+            parse_quote!(i32),
+            parse_quote!(()),
+            parse_quote!(Vec<()>),
+            parse_quote!(((), ())),
+            parse_quote!(<() as Trait>::Type),
+        ];
+        let _: &Type = &test_types[0];
+        let _: &Type = &expected_types[0];
+
+        for (test_type, expected_type) in test_types.iter().zip(expected_types.iter()) {
+            let resolved = super::resolve_self(&parse_quote!(()), test_type.clone());
+            assert_eq!(
+                resolved,
+                *expected_type,
+                "Failed to resolve `Self` in `{}`",
+                test_type.to_token_stream()
+            );
+        }
+    }
+}

--- a/data_model/derive/tests/filter.rs
+++ b/data_model/derive/tests/filter.rs
@@ -1,0 +1,110 @@
+//! A smoke-test for the `derive(Filter)`
+
+use iroha_data_model::{
+    prelude::{HasOrigin, Identifiable},
+    IdBox,
+};
+use iroha_data_model_derive::{Filter, IdEqOrdHash};
+use iroha_schema::IntoSchema;
+use parity_scale_codec::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+// These are dummy types for the FilterDerive to work
+// They would not work with `feature = transparent_api`, but are enough for the smoke test
+mod prelude {
+    use iroha_schema::IntoSchema;
+    use parity_scale_codec::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, IntoSchema)]
+    pub struct FilterOpt<T>(T);
+
+    #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, IntoSchema)]
+    pub struct OriginFilter<T>(T);
+
+    pub use super::LayerEvent;
+}
+
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    IntoSchema,
+)]
+pub struct SubLayerEvent;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, IntoSchema)]
+pub struct SubLayerFilter;
+
+#[derive(
+    Copy,
+    Clone,
+    IntoSchema,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Decode,
+    Encode,
+    Debug,
+    Hash,
+)]
+pub struct LayerId {
+    name: u32,
+}
+
+impl HasOrigin for LayerEvent {
+    type Origin = Layer;
+
+    fn origin_id(&self) -> &<Self::Origin as Identifiable>::Id {
+        todo!()
+    }
+}
+
+#[derive(Debug, IdEqOrdHash)]
+pub struct Layer {
+    id: LayerId,
+}
+
+impl From<LayerId> for IdBox {
+    fn from(_: LayerId) -> Self {
+        unreachable!()
+    }
+}
+
+/// The tested type
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    IntoSchema,
+    Filter,
+)]
+pub enum LayerEvent {
+    SubLayer(SubLayerEvent),
+    Created(LayerId),
+}
+
+#[test]
+fn filter() {
+    // nothing much to test here...
+    // I guess we do test that it compiles
+}

--- a/data_model/derive/tests/has_origin.rs
+++ b/data_model/derive/tests/has_origin.rs
@@ -1,0 +1,53 @@
+use iroha_data_model::prelude::{HasOrigin, Identifiable};
+use iroha_data_model_derive::{HasOrigin, IdEqOrdHash};
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+struct ObjectId(pub i32);
+
+// fake impl for `#[derive(IdEqOrdHash)]`
+impl From<ObjectId> for iroha_data_model::IdBox {
+    fn from(_: ObjectId) -> Self {
+        unimplemented!("fake impl")
+    }
+}
+
+#[derive(Debug, IdEqOrdHash)]
+struct Object {
+    id: ObjectId,
+}
+
+impl Object {
+    fn id(&self) -> &ObjectId {
+        &self.id
+    }
+}
+
+#[allow(clippy::enum_variant_names)] // it's a test, duh
+#[derive(Debug, HasOrigin)]
+#[has_origin(origin = Object)]
+enum ObjectEvent {
+    EventWithId(ObjectId),
+    #[has_origin(event => &event.0)]
+    EventWithExtractor((ObjectId, i32)),
+    #[has_origin(obj => obj.id())]
+    EventWithAnotherExtractor(Object),
+}
+
+#[test]
+fn has_origin() {
+    let events = vec![
+        ObjectEvent::EventWithId(ObjectId(1)),
+        ObjectEvent::EventWithExtractor((ObjectId(2), 2)),
+        ObjectEvent::EventWithAnotherExtractor(Object { id: ObjectId(3) }),
+    ];
+    let expected_ids = vec![ObjectId(1), ObjectId(2), ObjectId(3)];
+
+    for (event, expected_id) in events.into_iter().zip(expected_ids) {
+        assert_eq!(
+            event.origin_id(),
+            &expected_id,
+            "mismatched origin id for event {:?}",
+            event
+        );
+    }
+}

--- a/data_model/derive/tests/has_origin_generics.rs
+++ b/data_model/derive/tests/has_origin_generics.rs
@@ -1,0 +1,53 @@
+use iroha_data_model::prelude::{HasOrigin, Identifiable};
+use iroha_data_model_derive::{HasOrigin, IdEqOrdHash};
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+struct ObjectId(pub i32);
+
+// fake impl for `#[derive(IdEqOrdHash)]`
+impl From<ObjectId> for iroha_data_model::IdBox {
+    fn from(_: ObjectId) -> Self {
+        unimplemented!("fake impl")
+    }
+}
+
+#[derive(Debug, IdEqOrdHash)]
+struct Object {
+    id: ObjectId,
+}
+
+impl Object {
+    fn id(&self) -> &ObjectId {
+        &self.id
+    }
+}
+
+#[allow(clippy::enum_variant_names)] // it's a test, duh
+#[derive(Debug, HasOrigin)]
+#[has_origin(origin = Object)]
+enum ObjectEvent<T: Identifiable<Id = ObjectId>> {
+    EventWithId(ObjectId),
+    #[has_origin(event => &event.0)]
+    EventWithExtractor((ObjectId, i32)),
+    #[has_origin(obj => obj.id())]
+    EventWithAnotherExtractor(T),
+}
+
+#[test]
+fn has_origin() {
+    let events = vec![
+        ObjectEvent::EventWithId(ObjectId(1)),
+        ObjectEvent::EventWithExtractor((ObjectId(2), 2)),
+        ObjectEvent::EventWithAnotherExtractor(Object { id: ObjectId(3) }),
+    ];
+    let expected_ids = vec![ObjectId(1), ObjectId(2), ObjectId(3)];
+
+    for (event, expected_id) in events.into_iter().zip(expected_ids) {
+        assert_eq!(
+            event.origin_id(),
+            &expected_id,
+            "mismatched origin id for event {:?}",
+            event
+        );
+    }
+}

--- a/data_model/derive/tests/id_eq_ord_hash.rs
+++ b/data_model/derive/tests/id_eq_ord_hash.rs
@@ -1,0 +1,117 @@
+//! Basic tests for traits derived by [`IdEqOrdHash`] macro
+
+use std::collections::BTreeSet;
+
+use iroha_data_model_derive::IdEqOrdHash;
+
+/// fake `Identifiable` trait
+///
+/// Doesn't require `Into<IdBox>` implementation
+pub trait Identifiable: Ord + Eq {
+    /// Type of the entity identifier
+    type Id: Ord + Eq + core::hash::Hash;
+
+    /// Get reference to the type identifier
+    fn id(&self) -> &Self::Id;
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+struct ObjectId(char);
+
+#[derive(Debug, IdEqOrdHash)]
+struct Object {
+    id: ObjectId,
+    #[allow(unused)]
+    data: i32,
+}
+#[derive(Debug, IdEqOrdHash)]
+struct ObjectWithExplicitId {
+    #[id]
+    definitely_not_id: ObjectId,
+    #[allow(unused)]
+    data: i32,
+}
+#[derive(Debug, IdEqOrdHash)]
+struct ObjectWithTransparentId {
+    #[id(transparent)] // delegate the id to `Object` type
+    definitely_not_id: Object,
+    #[allow(unused)]
+    data: i32,
+}
+
+// some objects to play with in tests
+const ID_A: ObjectId = ObjectId('A');
+const ID_B: ObjectId = ObjectId('B');
+const OBJECT_1A: Object = Object { id: ID_A, data: 1 };
+const OBJECT_1B: Object = Object { id: ID_B, data: 1 };
+const OBJECT_2A: Object = Object { id: ID_A, data: 2 };
+const EXPLICIT_OBJECT_1A: ObjectWithExplicitId = ObjectWithExplicitId {
+    definitely_not_id: ID_A,
+    data: 1,
+};
+const EXPLICIT_OBJECT_1B: ObjectWithExplicitId = ObjectWithExplicitId {
+    definitely_not_id: ID_B,
+    data: 1,
+};
+const EXPLICIT_OBJECT_2A: ObjectWithExplicitId = ObjectWithExplicitId {
+    definitely_not_id: ID_A,
+    data: 2,
+};
+const TRANSPARENT_OBJECT_1A: ObjectWithTransparentId = ObjectWithTransparentId {
+    definitely_not_id: OBJECT_1A,
+    data: 1,
+};
+const TRANSPARENT_OBJECT_1B: ObjectWithTransparentId = ObjectWithTransparentId {
+    definitely_not_id: OBJECT_1B,
+    data: 1,
+};
+const TRANSPARENT_OBJECT_2A: ObjectWithTransparentId = ObjectWithTransparentId {
+    definitely_not_id: OBJECT_2A,
+    data: 2,
+};
+
+#[test]
+fn id() {
+    assert_eq!(OBJECT_1A.id(), &ID_A);
+    assert_eq!(OBJECT_1B.id(), &ID_B);
+    assert_eq!(EXPLICIT_OBJECT_1A.id(), &ID_A);
+    assert_eq!(EXPLICIT_OBJECT_1B.id(), &ID_B);
+    assert_eq!(TRANSPARENT_OBJECT_1A.id(), &ID_A);
+    assert_eq!(TRANSPARENT_OBJECT_1B.id(), &ID_B);
+}
+
+#[test]
+fn id_eq() {
+    assert_eq!(OBJECT_1A, OBJECT_2A);
+    assert_ne!(OBJECT_1B, OBJECT_2A);
+    assert_eq!(EXPLICIT_OBJECT_1A, EXPLICIT_OBJECT_2A);
+    assert_ne!(EXPLICIT_OBJECT_1B, EXPLICIT_OBJECT_2A);
+    assert_eq!(TRANSPARENT_OBJECT_1A, TRANSPARENT_OBJECT_2A);
+    assert_ne!(TRANSPARENT_OBJECT_1B, TRANSPARENT_OBJECT_2A);
+}
+
+#[test]
+fn id_ord() {
+    assert!(OBJECT_1A < OBJECT_1B);
+    assert!(OBJECT_1B > OBJECT_1A);
+    assert!(EXPLICIT_OBJECT_1A < EXPLICIT_OBJECT_1B);
+    assert!(EXPLICIT_OBJECT_1B > EXPLICIT_OBJECT_1A);
+    assert!(TRANSPARENT_OBJECT_1A < TRANSPARENT_OBJECT_1B);
+    assert!(TRANSPARENT_OBJECT_1B > TRANSPARENT_OBJECT_1A);
+}
+
+#[test]
+fn id_hash() {
+    let mut set = BTreeSet::new();
+    set.insert(OBJECT_1A);
+    set.insert(OBJECT_2A);
+    assert_eq!(set.len(), 1);
+    assert!(set.contains(&OBJECT_1A));
+    assert!(!set.contains(&OBJECT_1B));
+    assert!(set.contains(&OBJECT_2A));
+    set.insert(OBJECT_1B);
+    assert_eq!(set.len(), 2);
+    assert!(set.contains(&OBJECT_1A));
+    assert!(set.contains(&OBJECT_1B));
+    assert!(set.contains(&OBJECT_2A));
+}

--- a/data_model/derive/tests/partial_tagged_serde.rs
+++ b/data_model/derive/tests/partial_tagged_serde.rs
@@ -7,6 +7,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[derive(Debug, PartialEq, Eq, PartiallyTaggedDeserialize, PartiallyTaggedSerialize)]
 enum Value {
     Bool(bool),
+    #[serde(rename = "StringRenamed")]
     String(String),
     #[serde_partially_tagged(untagged)]
     Numeric(NumericValue),
@@ -62,7 +63,11 @@ fn partially_tagged_serde() {
         Value::String("I am string".to_owned()),
         Value::Numeric(NumericValue(42)),
     ];
-    let serialized_values = [r#"{"Bool":true}"#, r#"{"String":"I am string"}"#, r#""42""#];
+    let serialized_values = [
+        r#"{"Bool":true}"#,
+        r#"{"StringRenamed":"I am string"}"#,
+        r#""42""#,
+    ];
 
     for (value, serialized_value) in values.iter().zip(serialized_values.iter()) {
         let serialized = serde_json::to_string(value)

--- a/data_model/derive/tests/partial_tagged_serde.rs
+++ b/data_model/derive/tests/partial_tagged_serde.rs
@@ -1,0 +1,83 @@
+use std::fmt::Formatter;
+
+use iroha_data_model_derive::{PartiallyTaggedDeserialize, PartiallyTaggedSerialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+#[allow(variant_size_differences)] // it's a test, duh
+#[derive(Debug, PartialEq, Eq, PartiallyTaggedDeserialize, PartiallyTaggedSerialize)]
+enum Value {
+    Bool(bool),
+    String(String),
+    #[serde_partially_tagged(untagged)]
+    Numeric(NumericValue),
+}
+
+// a simpler version of NumericValue than used in data_model
+// this one is always i32, but is still serialized as a string literal
+// NOTE: debug is actually required for `PartiallyTaggedDeserialize`!
+#[derive(Debug, PartialEq, Eq)]
+struct NumericValue(i32);
+
+impl Serialize for NumericValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+struct NumericValueVisitor;
+
+impl de::Visitor<'_> for NumericValueVisitor {
+    type Value = NumericValue;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("a string literal containing a number")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let parsed = v.parse::<i32>().map_err(|e| E::custom(e))?;
+
+        Ok(NumericValue(parsed))
+    }
+}
+
+impl<'de> Deserialize<'de> for NumericValue {
+    fn deserialize<D>(deserializer: D) -> Result<NumericValue, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(NumericValueVisitor)
+    }
+}
+
+#[test]
+fn partially_tagged_serde() {
+    let values = [
+        Value::Bool(true),
+        Value::String("I am string".to_owned()),
+        Value::Numeric(NumericValue(42)),
+    ];
+    let serialized_values = [r#"{"Bool":true}"#, r#"{"String":"I am string"}"#, r#""42""#];
+
+    for (value, serialized_value) in values.iter().zip(serialized_values.iter()) {
+        let serialized = serde_json::to_string(value)
+            .unwrap_or_else(|e| panic!("Failed to serialize `{:?}`: {:?}", value, e));
+        assert_eq!(
+            serialized, *serialized_value,
+            "Serialized form of `{:?}` does not match the expected value",
+            value
+        );
+        let deserialized: Value = serde_json::from_str(serialized_value)
+            .unwrap_or_else(|e| panic!("Failed to deserialize `{:?}`: {:?}", serialized_value, e));
+        assert_eq!(
+            *value, deserialized,
+            "Deserialized form of `{:?}` does not match the expected value",
+            value
+        );
+    }
+}

--- a/data_model/derive/tests/partial_tagged_serde_self.rs
+++ b/data_model/derive/tests/partial_tagged_serde_self.rs
@@ -1,0 +1,39 @@
+//! A test for `PartiallyTaggedSerialize` and `PartiallyTaggedDeserialize` which uses `Self` as a type
+
+use iroha_data_model_derive::{PartiallyTaggedDeserialize, PartiallyTaggedSerialize};
+
+#[derive(Debug, PartialEq, Eq, PartiallyTaggedSerialize, PartiallyTaggedDeserialize)]
+enum Expr<T> {
+    Negate(Box<Self>),
+    #[serde_partially_tagged(untagged)]
+    Atom(T),
+}
+
+#[test]
+fn partially_tagged_serde() {
+    use Expr::*;
+
+    let values = [
+        Atom(42),
+        Negate(Box::new(Atom(42))),
+        Negate(Box::new(Negate(Box::new(Atom(42))))),
+    ];
+    let serialized_values = [r#"42"#, r#"{"Negate":42}"#, r#"{"Negate":{"Negate":42}}"#];
+
+    for (value, serialized_value) in values.iter().zip(serialized_values.iter()) {
+        let serialized = serde_json::to_string(value)
+            .unwrap_or_else(|e| panic!("Failed to serialize `{:?}`: {:?}", value, e));
+        assert_eq!(
+            serialized, *serialized_value,
+            "Serialized form of `{:?}` does not match the expected value",
+            value
+        );
+        let deserialized: Expr<i32> = serde_json::from_str(serialized_value)
+            .unwrap_or_else(|e| panic!("Failed to deserialize `{:?}`: {:?}", serialized_value, e));
+        assert_eq!(
+            *value, deserialized,
+            "Deserialized form of `{:?}` does not match the expected value",
+            value
+        );
+    }
+}

--- a/data_model/derive/tests/ui_fail/has_origin_multiple_attributes.rs
+++ b/data_model/derive/tests/ui_fail/has_origin_multiple_attributes.rs
@@ -1,0 +1,9 @@
+use iroha_data_model_derive::HasOrigin;
+
+#[derive(HasOrigin)]
+#[has_origin(origin = Object)]
+#[has_origin(origin = Object)]
+#[has_origin(origin = Object)]
+enum MultipleAttributes {}
+
+fn main() {}

--- a/data_model/derive/tests/ui_fail/has_origin_multiple_attributes.stderr
+++ b/data_model/derive/tests/ui_fail/has_origin_multiple_attributes.stderr
@@ -1,0 +1,6 @@
+error: Only one #[has_origin] attribute is allowed!
+ --> tests/ui_fail/has_origin_multiple_attributes.rs:5:1
+  |
+5 | / #[has_origin(origin = Object)]
+6 | | #[has_origin(origin = Object)]
+  | |______________________________^

--- a/data_model/derive/tests/ui_pass/filter.rs
+++ b/data_model/derive/tests/ui_pass/filter.rs
@@ -103,8 +103,4 @@ pub enum LayerEvent {
     Created(LayerId),
 }
 
-#[test]
-fn filter() {
-    // nothing much to test here...
-    // I guess we do test that it compiles
-}
+fn main() {}

--- a/data_model/src/predicate.rs
+++ b/data_model/src/predicate.rs
@@ -91,11 +91,11 @@ macro_rules! nontrivial {
 // references (e.g. &Value).
 pub enum GenericPredicateBox<P> {
     /// Logically `&&` the results of applying the predicates.
-    And(NonTrivial<GenericPredicateBox<P>>),
+    And(NonTrivial<Self>),
     /// Logically `||` the results of applying the predicats.
-    Or(NonTrivial<GenericPredicateBox<P>>),
+    Or(NonTrivial<Self>),
     /// Negate the result of applying the predicate.
-    Not(Box<GenericPredicateBox<P>>),
+    Not(Box<Self>),
     /// The raw predicate that must be applied.
     #[serde_partially_tagged(untagged)]
     Raw(P),

--- a/ffi/derive/Cargo.toml
+++ b/ffi/derive/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 proc-macro = true
 
 [dependencies]
+iroha_macro_utils = { workspace = true }
+
 syn2 = { workspace = true, features = ["full", "visit", "visit-mut", "extra-traits"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
@@ -22,7 +24,6 @@ manyhow = { workspace = true }
 darling = { workspace = true }
 rustc-hash = { workspace = true }
 
-drop_bomb = "0.1.5"
 parse-display = "0.8.2"
 
 [dev-dependencies]

--- a/ffi/derive/src/getset_gen.rs
+++ b/ffi/derive/src/getset_gen.rs
@@ -1,6 +1,7 @@
 use std::default::Default;
 
 use darling::ast::Style;
+use iroha_macro_utils::Emitter;
 use manyhow::emit;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -13,7 +14,6 @@ use crate::{
         getset::{GetSetGenMode, GetSetStructAttrs},
     },
     convert::{FfiTypeField, FfiTypeFields},
-    emitter::Emitter,
     impl_visitor::{unwrap_result_type, Arg, FnDescriptor},
 };
 

--- a/ffi/derive/src/impl_visitor.rs
+++ b/ffi/derive/src/impl_visitor.rs
@@ -2,6 +2,7 @@
 //!
 //! It also defines descriptors - types that are used for the codegen step
 
+use iroha_macro_utils::Emitter;
 use manyhow::emit;
 use proc_macro2::Span;
 use syn2::{
@@ -10,8 +11,6 @@ use syn2::{
     visit_mut::VisitMut,
     Attribute, Ident, Path, Type, Visibility,
 };
-
-use crate::emitter::Emitter;
 
 pub struct Arg {
     self_ty: Option<Path>,

--- a/ffi/derive/src/lib.rs
+++ b/ffi/derive/src/lib.rs
@@ -3,6 +3,7 @@
 
 use darling::FromDeriveInput;
 use impl_visitor::{FnDescriptor, ImplDescriptor};
+use iroha_macro_utils::Emitter;
 use manyhow::{emit, manyhow};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -12,12 +13,10 @@ use wrapper::wrap_method;
 use crate::{
     attr_parse::derive::Derive,
     convert::{derive_ffi_type, FfiTypeData, FfiTypeInput},
-    emitter::Emitter,
 };
 
 mod attr_parse;
 mod convert;
-mod emitter;
 mod ffi_fn;
 mod getset_gen;
 mod impl_visitor;

--- a/ffi/derive/src/wrapper.rs
+++ b/ffi/derive/src/wrapper.rs
@@ -1,3 +1,4 @@
+use iroha_macro_utils::Emitter;
 use manyhow::emit;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -6,7 +7,6 @@ use syn2::{parse_quote, visit_mut::VisitMut, Attribute, Ident, Type};
 use crate::{
     attr_parse::derive::{Derive, RustcDerive},
     convert::FfiTypeInput,
-    emitter::Emitter,
     ffi_fn,
     getset_gen::{gen_resolve_type, gen_store_name},
     impl_visitor::{unwrap_result_type, Arg, FnDescriptor, ImplDescriptor, TypeImplTraitResolver},

--- a/macro/utils/Cargo.toml
+++ b/macro/utils/Cargo.toml
@@ -14,6 +14,9 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 syn = { workspace = true, features = ["default", "parsing", "printing"] }
+syn2 = { workspace = true, features = ["default", "parsing", "printing"] }
+darling = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-proc-macro-error = { workspace = true }
+manyhow = { workspace = true }
+drop_bomb = "0.1.5"

--- a/macro/utils/src/emitter.rs
+++ b/macro/utils/src/emitter.rs
@@ -1,8 +1,9 @@
+//! A wrapper type around [`manyhow::Emitter`] that provides a more ergonomic API.
+
 use drop_bomb::DropBomb;
 use manyhow::ToTokensError;
 use proc_macro2::TokenStream;
 
-// TODO: move this type to `derive-primitives` crate
 /// A wrapper type around [`manyhow::Emitter`] that provides a more ergonomic API.
 ///
 /// This type is used to accumulate errors during parsing and code generation.

--- a/macro/utils/src/emitter.rs
+++ b/macro/utils/src/emitter.rs
@@ -16,6 +16,7 @@ pub struct Emitter {
 }
 
 impl Emitter {
+    /// Creates a new emitter. It must be consumed by calling any of the `finish_*` functions before dropping or it will panic.
     pub fn new() -> Self {
         Self {
             inner: manyhow::Emitter::new(),
@@ -54,18 +55,32 @@ impl Emitter {
     }
 
     /// Consume the emitter, returning a [`manyhow::Error`] if any errors were emitted.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the emitter has some errors accumulated.
     pub fn finish(mut self) -> manyhow::Result<()> {
         self.bomb.defuse();
         self.inner.into_result()
     }
 
     /// Same as [`Emitter::finish`], but returns the given value if no errors were emitted.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the emitter has some errors accumulated.
     #[allow(unused)]
     pub fn finish_with<T>(self, result: T) -> manyhow::Result<T> {
         self.finish().map(|_| result)
     }
 
     /// Handles the given [`manyhow::Result`] and consumes the emitter.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The given result is `Err`
+    /// - The emitter has some errors accumulated
     #[allow(unused)]
     pub fn finish_and<E: ToTokensError + 'static, T>(
         mut self,
@@ -81,7 +96,7 @@ impl Emitter {
     }
 
     /// Consume the emitter, convert all errors into a token stream and append it to the given token stream.
-    pub fn into_tokens(self, tokens: &mut TokenStream) {
+    pub fn finish_to_token_stream(self, tokens: &mut TokenStream) {
         match self.finish() {
             Ok(()) => {}
             Err(e) => e.to_tokens(tokens),
@@ -91,7 +106,7 @@ impl Emitter {
     /// Consume the emitter, convert all errors into a token stream.
     pub fn finish_token_stream(self) -> TokenStream {
         let mut tokens_stream = TokenStream::new();
-        self.into_tokens(&mut tokens_stream);
+        self.finish_to_token_stream(&mut tokens_stream);
         tokens_stream
     }
 
@@ -99,8 +114,14 @@ impl Emitter {
     ///
     /// This function is useful when you want to handle errors in a macro, but want to emit some tokens even in case of an error.
     pub fn finish_token_stream_with(self, mut tokens_stream: TokenStream) -> TokenStream {
-        self.into_tokens(&mut tokens_stream);
+        self.finish_to_token_stream(&mut tokens_stream);
         tokens_stream
+    }
+}
+
+impl Default for Emitter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/macro/utils/src/lib.rs
+++ b/macro/utils/src/lib.rs
@@ -70,40 +70,87 @@ macro_rules! attr_struct {
     };
 }
 
-/// Parses a single attribute of the form `#[attr_name(...)]` for darling using a `syn::parse::Parse` implementation.
+/// Extension trait for [`darling::Error`].
 ///
-/// If no attribute with specified name is found, returns `Ok(None)`.
-pub fn parse_single_list_attr_opt<Body: syn2::parse::Parse>(
-    attr_name: &str,
-    attrs: &[syn2::Attribute],
-) -> darling::Result<Option<Body>> {
-    let mut accumulator = darling::error::Accumulator::default();
+/// Currently exists to add `with_spans` method.
+pub trait DarlingErrorExt: Sized {
+    /// Attaches a combination of multiple spans to the error.
+    ///
+    /// Note that it only attaches the first span on stable rustc, as the `Span::join` method is not yet stabilized (https://github.com/rust-lang/rust/issues/54725#issuecomment-649078500).
+    fn with_spans(self, spans: impl IntoIterator<Item = impl Into<proc_macro2::Span>>) -> Self;
+}
 
-    // first, ensure there is only one attribute with the requested name
-    // take the first one if there are multiple
+impl DarlingErrorExt for darling::Error {
+    fn with_spans(self, spans: impl IntoIterator<Item = impl Into<proc_macro2::Span>>) -> Self {
+        // Unfortunately, the story for combining multiple spans in rustc proc macro is not yet complete.
+        // (see https://github.com/rust-lang/rust/issues/54725#issuecomment-649078500, https://github.com/rust-lang/rust/issues/54725#issuecomment-1547795742)
+        // syn does some hacks to get error reporting that is a bit better: https://docs.rs/syn/2.0.37/src/syn/error.rs.html#282
+        // we can't to that because darling's error type does not let us do that.
+
+        // on nightly, we are fine, as `.join` method works. On stable, we fall back to returning the first span.
+
+        let mut iter = spans.into_iter();
+        let Some(first) = iter.next() else {
+            return self;
+        };
+        let first: proc_macro2::Span = first.into();
+        let r = iter
+            .try_fold(first, |a, b| a.join(b.into()))
+            .unwrap_or(first);
+
+        self.with_span(&r)
+    }
+}
+
+/// Finds an optional single attribute with specified name.
+///
+/// Returns `None` if no attributes with specified name are found.
+///
+/// Emits an error into accumulator if multiple attributes with specified name are found.
+#[must_use]
+pub fn find_single_attr_opt<'a>(
+    accumulator: &mut darling::error::Accumulator,
+    attr_name: &str,
+    attrs: &'a [syn2::Attribute],
+) -> Option<&'a syn2::Attribute> {
     let matching_attrs = attrs
         .iter()
         .filter(|a| a.path().is_ident(attr_name))
         .collect::<Vec<_>>();
     let attr = match *matching_attrs.as_slice() {
         [] => {
-            return accumulator.finish_with(None);
+            return None;
         }
         [attr] => attr,
         [attr, ref tail @ ..] => {
             // allow parsing to proceed further to collect more errors
             accumulator.push(
                 darling::Error::custom(format!("Only one #[{}] attribute is allowed!", attr_name))
-                    .with_span(
-                        &tail
-                            .iter()
-                            .map(syn2::spanned::Spanned::span)
-                            .reduce(|a, b| a.join(b).unwrap())
-                            .unwrap(),
-                    ),
+                    .with_spans(tail.iter().map(syn2::spanned::Spanned::span)),
             );
             attr
         }
+    };
+
+    Some(attr)
+}
+
+/// Parses a single attribute of the form `#[attr_name(...)]` for darling using a `syn::parse::Parse` implementation.
+///
+/// If no attribute with specified name is found, returns `Ok(None)`.
+///
+/// # Errors
+///
+/// - If multiple attributes with specified name are found
+/// - If attribute is not a list
+pub fn parse_single_list_attr_opt<Body: syn2::parse::Parse>(
+    attr_name: &str,
+    attrs: &[syn2::Attribute],
+) -> darling::Result<Option<Body>> {
+    let mut accumulator = darling::error::Accumulator::default();
+
+    let Some(attr) = find_single_attr_opt(&mut accumulator, attr_name, attrs) else {
+        return accumulator.finish_with(None);
     };
 
     let mut kind = None;
@@ -123,6 +170,12 @@ pub fn parse_single_list_attr_opt<Body: syn2::parse::Parse>(
 /// Parses a single attribute of the form `#[attr_name(...)]` for darling using a `syn::parse::Parse` implementation.
 ///
 /// If no attribute with specified name is found, returns an error.
+///
+/// # Errors
+///
+/// - If multiple attributes with specified name are found
+/// - If attribute is not a list
+/// - If attribute is not found
 pub fn parse_single_list_attr<Body: syn2::parse::Parse>(
     attr_name: &str,
     attrs: &[syn2::Attribute],

--- a/macro/utils/src/lib.rs
+++ b/macro/utils/src/lib.rs
@@ -1,5 +1,9 @@
 //! Module for various functions and structs to build macros in iroha.
 
+mod emitter;
+
+pub use emitter::Emitter;
+
 /// Trait for attribute parsing generalization
 pub trait AttrParser<Inner: syn::parse::Parse> {
     /// Attribute identifier `#[IDENT...]`
@@ -56,6 +60,104 @@ macro_rules! attr_struct {
 
         impl syn::parse::Parse for $name {
             fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+                Ok(Self {
+                    $(
+                        $field_name: input.parse()?,
+                    )*
+                })
+            }
+        }
+    };
+}
+
+/// Parses a single attribute of the form `#[attr_name(...)]` for darling using a `syn::parse::Parse` implementation.
+///
+/// If no attribute with specified name is found, returns `Ok(None)`.
+pub fn parse_single_list_attr_opt<Body: syn2::parse::Parse>(
+    attr_name: &str,
+    attrs: &[syn2::Attribute],
+) -> darling::Result<Option<Body>> {
+    let mut accumulator = darling::error::Accumulator::default();
+
+    // first, ensure there is only one attribute with the requested name
+    // take the first one if there are multiple
+    let matching_attrs = attrs
+        .iter()
+        .filter(|a| a.path().is_ident(attr_name))
+        .collect::<Vec<_>>();
+    let attr = match *matching_attrs.as_slice() {
+        [] => {
+            return accumulator.finish_with(None);
+        }
+        [attr] => attr,
+        [attr, ref tail @ ..] => {
+            // allow parsing to proceed further to collect more errors
+            accumulator.push(
+                darling::Error::custom(format!("Only one #[{}] attribute is allowed!", attr_name))
+                    .with_span(
+                        &tail
+                            .iter()
+                            .map(syn2::spanned::Spanned::span)
+                            .reduce(|a, b| a.join(b).unwrap())
+                            .unwrap(),
+                    ),
+            );
+            attr
+        }
+    };
+
+    let mut kind = None;
+
+    match &attr.meta {
+        syn2::Meta::Path(_) | syn2::Meta::NameValue(_) => accumulator.push(darling::Error::custom(
+            format!("Expected #[{}(...)] attribute to be a list", attr_name),
+        )),
+        syn2::Meta::List(list) => {
+            kind = accumulator.handle(syn2::parse2(list.tokens.clone()).map_err(Into::into));
+        }
+    }
+
+    accumulator.finish_with(kind)
+}
+
+/// Parses a single attribute of the form `#[attr_name(...)]` for darling using a `syn::parse::Parse` implementation.
+///
+/// If no attribute with specified name is found, returns an error.
+pub fn parse_single_list_attr<Body: syn2::parse::Parse>(
+    attr_name: &str,
+    attrs: &[syn2::Attribute],
+) -> darling::Result<Body> {
+    parse_single_list_attr_opt(attr_name, attrs)?
+        .ok_or_else(|| darling::Error::custom(format!("Missing `#[{}(...)]` attribute", attr_name)))
+}
+
+/// Macro for automatic [`syn::parse::Parse`] impl generation for keyword
+/// attribute structs in derive macros.
+#[macro_export]
+macro_rules! attr_struct2 {
+    // Matching struct with named fields
+    (
+        $( #[$meta:meta] )*
+    //  ^~~~attributes~~~~^
+        $vis:vis struct $name:ident {
+            $(
+                $( #[$field_meta:meta] )*
+    //          ^~~~field attributes~~~!^
+                $field_vis:vis $field_name:ident : $field_ty:ty
+    //          ^~~~~~~~~~~~~~~~~a single field~~~~~~~~~~~~~~~^
+            ),*
+        $(,)? }
+    ) => {
+        $( #[$meta] )*
+        $vis struct $name {
+            $(
+                $( #[$field_meta] )*
+                $field_vis $field_name : $field_ty
+            ),*
+        }
+
+        impl syn2::parse::Parse for $name {
+            fn parse(input: syn2::parse::ParseStream) -> syn2::Result<Self> {
                 Ok(Self {
                     $(
                         $field_name: input.parse()?,

--- a/macro/utils/src/lib.rs
+++ b/macro/utils/src/lib.rs
@@ -76,7 +76,8 @@ macro_rules! attr_struct {
 pub trait DarlingErrorExt: Sized {
     /// Attaches a combination of multiple spans to the error.
     ///
-    /// Note that it only attaches the first span on stable rustc, as the `Span::join` method is not yet stabilized (https://github.com/rust-lang/rust/issues/54725#issuecomment-649078500).
+    /// Note that it only attaches the first span on stable rustc, as the `Span::join` method is not yet stabilized (<https://github.com/rust-lang/rust/issues/54725#issuecomment-649078500>).
+    #[must_use]
     fn with_spans(self, spans: impl IntoIterator<Item = impl Into<proc_macro2::Span>>) -> Self;
 }
 


### PR DESCRIPTION
## Description

Introduces various improvements to `iroha_data_model_derive`:
- updated to use syn 2.0
- add tests (where possible, see [1])
- use darling derives and traits to parse macro inputs
- add support for `Self` type in serde partially tagged enums (#3737)
- address problems in `derive(Filter)` outlined in #2437

[1] I am a bit unhappy with the testing of `derive(Filter)`, but it seems so intertwined with all the parts of `iroha_data_model` that it's really hard to test. Additionally, testing the generated `Filter` impl requires the `transparent_api` feature

### Linked issue

Closes #3882, #3737, #2437

### Checklist

- [x] make CI pass
