### PR TITLE
[ci] #3825: Clean default runner free space

### DIFF
--- a/.github/workflows/iroha2-dev-pr-ui.yml
+++ b/.github/workflows/iroha2-dev-pr-ui.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         feature_flag: [all-features, no-default-features]
     steps:
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with ${{ matrix.feature_flag }}

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -17,6 +17,10 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Build iroha
@@ -50,6 +54,10 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
       - name: Run benchmarks
@@ -62,6 +70,10 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3.11.0
@@ -112,6 +124,10 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v3
       - name: Run long tests
         run: mold --run cargo test --workspace --no-fail-fast -- --ignored --test-threads=1 long


### PR DESCRIPTION
## Description
Some CI jobs have a lack of space problem on the default GitHub runners.

### Linked issue
#3825 

### Benefits
This possible fix might help to free up approximate 10G disk size.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
