### PR TITLE
[fix]: `mkdir -r` with store path, not lock path

### DIFF
--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -425,7 +425,7 @@ impl BlockStore {
                 match e.kind() {
                     std::io::ErrorKind::AlreadyExists => Err(Error::Locked(lock_path)),
                     std::io::ErrorKind::NotFound => {
-                        match std::fs::create_dir_all(&store_path)
+                        match std::fs::create_dir_all(store_path)
                             .map_err(|e| Error::MkDir(e, store_path.to_path_buf()))
                         {
                             Err(e) => Err(e),

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -420,13 +420,13 @@ impl BlockStore {
                 .read(true)
                 .write(true)
                 .create_new(true)
-                .open(lock_path.clone())
+                .open(&lock_path)
             {
                 match e.kind() {
                     std::io::ErrorKind::AlreadyExists => Err(Error::Locked(lock_path)),
                     std::io::ErrorKind::NotFound => {
                         match std::fs::create_dir_all(&store_path)
-                            .map_err(|e| Error::MkDir(e, store_path.into()))
+                            .map_err(|e| Error::MkDir(e, store_path.to_path_buf()))
                         {
                             Err(e) => Err(e),
                             Ok(_) => {
@@ -434,7 +434,7 @@ impl BlockStore {
                                     .read(true)
                                     .write(true)
                                     .create_new(true)
-                                    .open(lock_path.clone())
+                                    .open(&lock_path)
                                 {
                                     Err(Error::IO(e, lock_path))
                                 } else {

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -425,8 +425,8 @@ impl BlockStore {
                 match e.kind() {
                     std::io::ErrorKind::AlreadyExists => Err(Error::Locked(lock_path)),
                     std::io::ErrorKind::NotFound => {
-                        match std::fs::create_dir_all(store_path)
-                            .map_err(|e| Error::MkDir(e, lock_path.clone()))
+                        match std::fs::create_dir_all(&store_path)
+                            .map_err(|e| Error::MkDir(e, store_path.into()))
                         {
                             Err(e) => Err(e),
                             Ok(_) => {


### PR DESCRIPTION
## Description

TBH, I am lazy to prepare a proper reproduction of the bug. In my case, Iroha repeatedly failed to start, complaining about existence of the lock file all the time. After all, it turned out that `./storage/kura.lock`, created by Iroha, **is a directory, not a file**.

This PR makes variables naming clearer, and passes actual block-store path into `mkdir -r`, not the path of the lockfile. 