### PR TITLE
[refactor] #3911: Migrate `iroha_futures_derive` to syn 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,10 +3261,11 @@ dependencies = [
 name = "iroha_futures_derive"
 version = "2.0.0-pre-rc.19"
 dependencies = [
- "proc-macro-error",
+ "iroha_macro_utils",
+ "manyhow",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,7 +1,6 @@
 //! This module contains structures and implementations related to the cryptographic parts of the Iroha.
 #![cfg_attr(not(feature = "std"), no_std)]
 // in no_std some code gets cfg-ed out, so we silence the warnings
-#![cfg_attr(not(feature = "std"), allow(unused, unused_tuple_struct_fields))]
 #![allow(clippy::arithmetic_side_effects)]
 
 #[cfg(not(feature = "std"))]
@@ -120,6 +119,10 @@ impl FromStr for Algorithm {
 
 /// Options for key generation
 #[cfg(not(feature = "ffi_import"))]
+#[cfg_attr(
+    any(not(feature = "std"), feature = "ffi_import"),
+    allow(unused_tuple_struct_fields)
+)]
 #[derive(Debug, Clone)]
 enum KeyGenOption {
     /// Use seed

--- a/futures/derive/Cargo.toml
+++ b/futures/derive/Cargo.toml
@@ -19,7 +19,9 @@ telemetry = []
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["default", "full"] }
+iroha_macro_utils = { workspace = true }
+
+syn2 = { workspace = true, features = ["default", "full"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
-proc-macro-error = { workspace = true }
+manyhow = { workspace = true }


### PR DESCRIPTION
## Description

Update `iroha_futures_derive` to use syn 2.0

Would be nice to be able to use the `Emitter` type from #3897, will update the PR when it will be merged

Also, a drive-by fix to silence the "unused" lints in some other feature combinations

### Linked issue

Closes #3911 

### Checklist

- [x] make CI pass
- [x] use `Emitter` once #3882 is merged

