### PR TITLE
[feature]: parse filter as JSON5 in `iroha_client_cli`

### DIFF
--- a/client_cli/README.md
+++ b/client_cli/README.md
@@ -141,7 +141,7 @@ Generally it looks like this:
 ./iroha_client_cli ENTITY list filter PREDICATE
 ```
 
-Where ENTITY is asset, account or domain and PREDICATE is condition used for filtering serialized using JSON (check `ValuePredicate` and `GenericPredicateBox` in [schema](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/references/schema.json) for reference).
+Where ENTITY is asset, account or domain and PREDICATE is condition used for filtering serialized using JSON5 (check `iroha_data_model::predicate::value::ValuePredicate` type).
 
 Examples:
 

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -283,14 +283,13 @@ mod filter {
     /// Filter for queries
     #[derive(Clone, Debug, clap::Parser)]
     pub struct Filter {
-        /// Predicate for filtering given as JSON string
+        /// Predicate for filtering given as JSON5 string
         #[clap(value_parser = parse_filter)]
         pub predicate: PredicateBox,
     }
 
     fn parse_filter(s: &str) -> Result<PredicateBox, String> {
-        serde_json::from_str(s)
-            .map_err(|err| format!("Failed to deserialize filter from JSON: {err}"))
+        json5::from_str(s).map_err(|err| format!("Failed to deserialize filter from JSON5: {err}"))
     }
 }
 


### PR DESCRIPTION
## Description

There is inconsistency of what `iroha_client_cli` accepts:

- JSON5 input for `iroha_client_cli json` command
- JSON input for filters, e.g.
  ```bash
  iroha_client_cli domains list filter '{"Identifiable": {"Is": "wonderland"}}'
  ```

This chore PR adds support for JSON5 for filters:

```bash
iroha_client_cli domains list filter '{Identifiable: {Is: "wonderland"}}'
```


### Context

It makes examples of `iroha_client_cli` usage _a little_ more clear and consistent.