### PR TITLE
[fix] #3928: Make failing the wasm tests actually fail the CI

### DIFF
--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -47,5 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
+      - name: Install iroha_wasm_test_runner
+        run: cd .. && cargo install --path tools/wasm_test_runner
       - name: Run tests
         run: mold --run cargo test --tests --no-fail-fast --quiet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
@@ -3539,6 +3539,14 @@ dependencies = [
  "iroha_core_wasm_codec_derive",
  "parity-scale-codec",
  "thiserror",
+ "wasmtime",
+]
+
+[[package]]
+name = "iroha_wasm_test_runner"
+version = "2.0.0-pre-rc.19"
+dependencies = [
+ "anyhow",
  "wasmtime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ members = [
   "tools/parity_scale_decoder",
   "tools/swarm",
   "tools/wasm_builder_cli",
+  "tools/wasm_test_runner",
   "version",
   "version/derive",
   "wasm_codec",

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -23,7 +23,6 @@ RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install webassembly-test-runner
 RUN cargo install cargo-llvm-cov
 
 # TODO: Figure out a way to pull in libgit2, which doesn't crash if this useless variable is gone.

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -12,7 +12,6 @@ RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install webassembly-test-runner
 RUN cargo install cargo-llvm-cov
 
 # TODO: Figure out a way to pull in libgit2, which doesn't crash if this useless variable is gone.

--- a/ffi/.cargo/config.toml
+++ b/ffi/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.wasm32-unknown-unknown]
-runner = "webassembly-test-runner"
+runner = "iroha_wasm_test_runner"

--- a/tools/wasm_test_runner/Cargo.toml
+++ b/tools/wasm_test_runner/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "iroha_wasm_test_runner"
+
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasmtime = { workspace = true }
+anyhow = "1.0.75"

--- a/tools/wasm_test_runner/src/main.rs
+++ b/tools/wasm_test_runner/src/main.rs
@@ -1,0 +1,82 @@
+//! A tool to run `WebAssembly` tests
+//!
+//! This copies functionality of `webassembly-test-runner`, but with an ability to indicate failure with an exit code.
+
+use std::process::ExitCode;
+
+use anyhow::{bail, Result};
+use wasmtime::{Engine, Instance, Module, Store};
+
+struct TestMeta<'a> {
+    name: &'a str,
+    ignore: bool,
+}
+
+fn main() -> Result<ExitCode> {
+    let argv0 = std::env::args().next().unwrap();
+
+    let file = match std::env::args().nth(1) {
+        Some(it) => it,
+        None => {
+            bail!("usage: {} tests.wasm", argv0);
+        }
+    };
+    // Modules can be compiled through either the text or binary format
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, &file)?;
+    let mut tests = Vec::new();
+    for export in module.exports() {
+        if let Some(name) = export.name().strip_prefix("$webassembly-test$") {
+            let mut ignore = true;
+            let name = name.strip_prefix("ignore$").unwrap_or_else(|| {
+                ignore = false;
+                name
+            });
+            tests.push((export, TestMeta { name, ignore }));
+        }
+    }
+    let total = tests.len();
+
+    eprintln!("\nrunning {} tests", total);
+    let mut store = Store::new(&engine, ());
+    let mut instance = Instance::new(&mut store, &module, &[])?;
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut ignored = 0;
+    for (export, meta) in tests {
+        eprint!("test {} ...", meta.name);
+        if meta.ignore {
+            ignored += 1;
+            eprintln!(" ignored")
+        } else {
+            let f = instance.get_typed_func::<(), ()>(&mut store, export.name())?;
+
+            let pass = f.call(&mut store, ()).is_ok();
+            if pass {
+                passed += 1;
+                eprintln!(" ok")
+            } else {
+                // Reset instance on test failure. WASM uses `panic=abort`, so
+                // `Drop`s are not called after test failures, and a failed test
+                // might leave an instance in an inconsistent state.
+                store = Store::new(&engine, ());
+                instance = Instance::new(&mut store, &module, &[])?;
+
+                failed += 1;
+                eprintln!(" FAILED")
+            }
+        }
+    }
+    eprintln!(
+        "\ntest result: {}. {} passed; {} failed; {} ignored;",
+        if failed > 0 { "FAILED" } else { "ok" },
+        passed,
+        failed,
+        ignored,
+    );
+    Ok(if failed > 0 {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
+}

--- a/wasm/.cargo/config.toml
+++ b/wasm/.cargo/config.toml
@@ -2,4 +2,4 @@
 target = "wasm32-unknown-unknown"
 
 [target.wasm32-unknown-unknown]
-runner = "webassembly-test-runner"
+runner = "iroha_wasm_test_runner"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -8,10 +8,10 @@ Check the [WASM section of our tutorial](https://hyperledger.github.io/iroha-2-d
 
 ## Running tests
 
-To be able to run tests compiled for `wasm32-unknown-unknown` target install `webassembly-test-runner`:
+To be able to run tests compiled for `wasm32-unknown-unknown` target install `iroha_wasm_test_runner` from the root of the iroha repository:
 
 ```bash
-cargo install webassembly-test-runner
+cargo install --path tools/wasm_test_runner 
 ```
 
 Then run tests:

--- a/wasm/src/debug.rs
+++ b/wasm/src/debug.rs
@@ -169,15 +169,17 @@ mod tests {
 
     use webassembly_test::webassembly_test;
 
-    use crate::_decode_from_raw;
-
     fn get_dbg_message() -> &'static str {
         "dbg_message"
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn _dbg_mock(ptr: *const u8, len: usize) {
-        assert_eq!(_decode_from_raw::<String>(ptr, len), get_dbg_message());
+        use parity_scale_codec::DecodeAll;
+
+        // can't use _decode_from_raw here, because we must NOT take the ownership
+        let bytes = core::slice::from_raw_parts(ptr, len);
+        assert_eq!(String::decode_all(&mut &*bytes).unwrap(), get_dbg_message());
     }
 
     #[webassembly_test]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -448,7 +448,7 @@ mod tests {
     }
 
     fn get_test_expression() -> EvaluatesTo<NumericValue> {
-        Add::new(1_u32, 2_u32).into()
+        Add::new(2_u32, 3_u32).into()
     }
 
     #[no_mangle]

--- a/wasm/src/log.rs
+++ b/wasm/src/log.rs
@@ -88,7 +88,6 @@ mod tests {
     use webassembly_test::webassembly_test;
 
     use super::*;
-    use crate::_decode_from_raw;
 
     fn get_log_message() -> &'static str {
         "log_message"
@@ -96,7 +95,9 @@ mod tests {
 
     #[no_mangle]
     pub unsafe extern "C" fn _log_mock(ptr: *const u8, len: usize) {
-        let (log_level, msg) = _decode_from_raw::<(u8, String)>(ptr, len);
+        // can't use _decode_from_raw here, because we must NOT take the ownership
+        let bytes = core::slice::from_raw_parts(ptr, len);
+        let (log_level, msg) = <(u8, String)>::decode_all(&mut &*bytes).unwrap();
         assert_eq!(log_level, 3);
         assert_eq!(msg, get_log_message());
     }


### PR DESCRIPTION
## Description

Add a new `iroha_wasm_test_runner` tool. It mostly duplicates the `webassembly-test-runner`, but actually returns a non-zero exit code if there are any test failures. As an added bonus 

This tool is expected to be installed on the developer's system with `cargo install`. It's not going to change often, so I don't think there's a risk of it going out-of-sync with the state of the repo.

Also fix the `evaluate_expression` test, which was never passing before due to a typo.

### Linked issue

Closes #3928 

### Benefits

- Actually makes the CI check that the wasm test

### Alternatives

An alternative would be to continue to use the upstream test runner when/if https://github.com/matklad/webassembly-test/pull/1 gets merged, but I wouldn't bet on it.

### Checklist

- [x] make sure CI passes