### PR TITLE
[fix] #3939: Fix the usage of `Span::join`

### DIFF
--- a/ffi/derive/src/attr_parse/getset.rs
+++ b/ffi/derive/src/attr_parse/getset.rs
@@ -144,7 +144,7 @@ impl syn2::parse::Parse for SpannedGetSetAttrToken {
                     let span = ident
                         .span()
                         .join(options.span)
-                        .expect("must be in the same file");
+                        .unwrap_or_else(|| ident.span());
 
                     Ok(SpannedGetSetAttrToken {
                         span,

--- a/ffi/derive/src/attr_parse/repr.rs
+++ b/ffi/derive/src/attr_parse/repr.rs
@@ -78,7 +78,8 @@ impl Parse for SpannedReprToken {
                     let Some((inside_of_group, group_span, after_group)) = after_token.group(Delimiter::Parenthesis) else {
                         return Err(cursor.error("Expected a number inside of a `repr(aligned(<number>)), found `repr(aligned)`"));
                     };
-                    span = span.join(group_span.span()).expect("Spans must be in the same file");
+
+                    span = span.join(group_span.span()).unwrap_or(span);
                     let alignment = syn2::parse2::<syn2::LitInt>(inside_of_group.token_stream())?;
                     let alignment = alignment.base10_parse::<u32>()?;
 

--- a/ffi/derive/src/convert.rs
+++ b/ffi/derive/src/convert.rs
@@ -59,7 +59,7 @@ impl syn2::parse::Parse for SpannedFfiTypeToken {
                     let Some((inside_of_group, group_span, after_group)) = after_token.group(Delimiter::Brace) else {
                         return Err(cursor.error("expected `{ ... }` after `unsafe`"))
                     };
-                    span = span.join(group_span.span()).expect("Spans must be in the same file");
+                    span = span.join(group_span.span()).unwrap_or(span);
 
                     let Some((token, after_token)) = inside_of_group.ident() else {
                         return Err(cursor.error("expected ffi type kind"))


### PR DESCRIPTION
Actually, `Span::join` doesn't work on stable at all (and returns `None`), so care should be taken to have a fallback

This means that on stable we will have error spans that are slightly incorrect

Closes #3939

