### PR TITLE
[BACKPORT] #3995: Fix wasm cache directory permission bug in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ENV  CONFIG_DIR=/config
 ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
 ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
 ENV  KURA_BLOCK_STORE_PATH=$STORAGE
+ENV  WASM_DIRECTORY=/app/.cache/wasmtime
 ENV  USER=iroha
 ENV  UID=1001
 ENV  GID=1001
@@ -57,8 +58,10 @@ RUN  set -ex && \
      --uid "$UID" \
      "$USER" && \
      mkdir -p $CONFIG_DIR && \
-     mkdir $STORAGE && \
-     chown $USER:$USER $STORAGE
+     mkdir -p $STORAGE && \
+     mkdir -p $WASM_DIRECTORY && \
+     chown $USER:$USER $STORAGE && \
+     chown $USER:$USER $WASM_DIRECTORY
 
 COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
 COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -33,6 +33,7 @@ ENV  CONFIG_DIR=/config
 ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
 ENV  IROHA2_GENESIS_PATH=$CONFIG_DIR/genesis.json
 ENV  KURA_BLOCK_STORE_PATH=$STORAGE
+ENV  WASM_DIRECTORY=/app/.cache/wasmtime
 
 RUN  set -ex && \
      apk --update add libstdc++ curl ca-certificates gcompat && \
@@ -44,7 +45,9 @@ RUN  set -ex && \
      adduser --disabled-password iroha --shell /bin/bash --home /app && \
      mkdir -p $CONFIG_DIR && \
      mkdir $STORAGE && \
-     chown iroha:iroha $STORAGE
+     mkdir -p $WASM_DIRECTORY && \
+     chown iroha:iroha $STORAGE && \
+     chown iroha:iroha $WASM_DIRECTORY
 
 COPY --from=builder $TARGET_DIR/iroha $BIN_PATH
 COPY --from=builder $TARGET_DIR/iroha_client_cli $BIN_PATH

--- a/docker-compose.stable.yml
+++ b/docker-compose.stable.yml
@@ -2,6 +2,7 @@ version: "3.8"
 services:
   iroha0:
     image: hyperledger/iroha2:stable
+    platform: linux/amd64
     environment:
       TORII_P2P_ADDR: iroha0:1337
       TORII_API_URL: iroha0:8080
@@ -25,6 +26,7 @@ services:
 
   iroha1:
     image: hyperledger/iroha2:stable
+    platform: linux/amd64
     environment:
       TORII_P2P_ADDR: iroha1:1338
       TORII_API_URL: iroha1:8081
@@ -46,6 +48,7 @@ services:
 
   iroha2:
     image: hyperledger/iroha2:stable
+    platform: linux/amd64
     environment:
       TORII_P2P_ADDR: iroha2:1339
       TORII_API_URL: iroha2:8082
@@ -67,6 +70,7 @@ services:
 
   iroha3:
     image: hyperledger/iroha2:stable
+    platform: linux/amd64
     environment:
       TORII_P2P_ADDR: iroha3:1340
       TORII_API_URL: iroha3:8083


### PR DESCRIPTION
## Description

Wasm cache directory is being created in the Dockerfile and all required permissions are being granted to the user.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

- Closes #3955 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Working Iroha stable image

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
