### PR TITLE
Repairing MacOs build on develop

### DIFF
--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -203,19 +203,15 @@ jobs:
             pull_request)       if   commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ;then
                                   if git_is_merge_commit FETCH_HEAD ;then
                                     echo ::warning::'/build directive in merge commit overrides default "/build before-merge"'
-                                    echo here2
                                   fi
-                                  echo here1
                                 elif commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ;then
-                                  echo here3
                                   true
                                 else
-                                  echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
                                   echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
-                                  echo "/build macos ubuntu debug release normal gcc-10"
+                                  echo "/build ubuntu debug release normal gcc-10"
                                 } >/tmp/comment_body ;;
             workflow_dispatch)  echo >/tmp/comment_body "${{github.event.inputs.build_spec}}" ;;
             *)                  echo >&2 "::error::Unexpected event"; false ;;

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -696,6 +696,8 @@ jobs:
       - *step_show_context
 
   build-M:
+    env:
+      CC_NAME: gcc-10
     needs:
       - prepare-macos-env
       - generate_matrixes

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -225,6 +225,7 @@ jobs:
         id: matrixes
         run: |
           set -x
+          cat /tmp/comment_body
           cat /tmp/comment_body | .github/chatops-gen-matrix.sh
           echo "::set-output name=matrix_ubuntu::$(cat matrix_ubuntu)"
           echo "::set-output name=matrix_ubuntu_release::$(cat matrix_ubuntu_release)"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -212,7 +212,7 @@ jobs:
                                 else
                                   echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -212,7 +212,7 @@ jobs:
                                 else
                                   echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -203,10 +203,14 @@ jobs:
             pull_request)       if   commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ;then
                                   if git_is_merge_commit FETCH_HEAD ;then
                                     echo ::warning::'/build directive in merge commit overrides default "/build before-merge"'
+                                    echo here2
                                   fi
+                                  echo here1
                                 elif commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ;then
+                                  echo here3
                                   true
                                 else
+                                  echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
                                   echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
                                 fi ;;

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -208,7 +208,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos gcc-10 debug normal"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"
@@ -696,8 +696,6 @@ jobs:
       - *step_show_context
 
   build-M:
-    env:
-      CC_NAME: gcc-10
     needs:
       - prepare-macos-env
       - generate_matrixes

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -208,7 +208,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug gcc-10"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug clang"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -208,7 +208,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos gcc-10 debug normal"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug gcc-10"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"

--- a/.github/build-iroha1.src.yml
+++ b/.github/build-iroha1.src.yml
@@ -208,7 +208,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"
+                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/chatops-gen-matrix.sh
+++ b/.github/chatops-gen-matrix.sh
@@ -19,7 +19,7 @@ echoerr(){
 readonly ALL_oses="ubuntu macos windows" ALL_build_types="Debug Release" ALL_cmake_opts="normal burrow ursa" ALL_compilers="gcc-9 gcc-10 clang-10 clang llvm msvc"
 readonly DEFAULT_oses="ubuntu macos windows" DEFAULT_build_types="Debug" DEFAULT_cmake_opts="normal burrow ursa"
 readonly DEFAULT_ubuntu_compilers="gcc-9" AVAILABLE_ubuntu_compilers="gcc-9 gcc-10 clang-10"
-readonly DEFAULT_macos_compilers="clang"  AVAILABLE_macos_compilers="clang" ## Also "llvm gcc-10" but they fail
+readonly DEFAULT_macos_compilers="clang"  AVAILABLE_macos_compilers="clang gcc-10" ## Also "llvm gcc-10" but they fail
 readonly DEFAULT_windows_compilers="msvc" AVAILABLE_windows_compilers="msvc" ## Also "clang mingw cygwin" but they are redundant
 
 --help-buildspec(){

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -223,7 +223,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos gcc-10 debug normal"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"
@@ -1038,8 +1038,6 @@ jobs:
           END
           echo "::endgroup::"
   build-M:
-    env:
-      CC_NAME: gcc-10
     needs:
       - prepare-macos-env
       - generate_matrixes

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -227,7 +227,7 @@ jobs:
                                 else
                                   echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -239,6 +239,7 @@ jobs:
         id: matrixes
         run: |
           set -x
+          cat /tmp/comment_body
           cat /tmp/comment_body | .github/chatops-gen-matrix.sh
           echo "::set-output name=matrix_ubuntu::$(cat matrix_ubuntu)"
           echo "::set-output name=matrix_ubuntu_release::$(cat matrix_ubuntu_release)"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -218,19 +218,15 @@ jobs:
             pull_request)       if   commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ;then
                                   if git_is_merge_commit FETCH_HEAD ;then
                                     echo ::warning::'/build directive in merge commit overrides default "/build before-merge"'
-                                    echo here2
                                   fi
-                                  echo here1
                                 elif commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ;then
-                                  echo here3
                                   true
                                 else
-                                  echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
                                   echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
-                                  echo "/build macos ubuntu debug release normal gcc-10"
+                                  echo "/build ubuntu debug release normal gcc-10"
                                 } >/tmp/comment_body ;;
             workflow_dispatch)  echo >/tmp/comment_body "${{github.event.inputs.build_spec}}" ;;
             *)                  echo >&2 "::error::Unexpected event"; false ;;

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -1038,6 +1038,8 @@ jobs:
           END
           echo "::endgroup::"
   build-M:
+    env:
+      CC_NAME: gcc-10
     needs:
       - prepare-macos-env
       - generate_matrixes

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -227,7 +227,7 @@ jobs:
                                 else
                                   echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -227,7 +227,7 @@ jobs:
                                 else
                                   echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
+                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"$'\n' "/build macos debug" ;;
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -223,7 +223,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug gcc-10"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug clang"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -223,7 +223,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos gcc-10 debug normal"
+                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"$'\n' "/build macos debug gcc-10"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -223,7 +223,7 @@ jobs:
                                   true
                                 else
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
-                                  echo  >/tmp/comment_body "/build ubuntu debug release normal gcc-10"
+                                  echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
                                 fi ;;
             push)               commit_message_body_build_spec >/tmp/comment_body || {
                                   echo "/build macos ubuntu debug release normal gcc-10"

--- a/.github/workflows/build-iroha1.yml
+++ b/.github/workflows/build-iroha1.yml
@@ -218,10 +218,14 @@ jobs:
             pull_request)       if   commit_message_body_build_spec FETCH_HEAD >/tmp/comment_body ;then
                                   if git_is_merge_commit FETCH_HEAD ;then
                                     echo ::warning::'/build directive in merge commit overrides default "/build before-merge"'
+                                    echo here2
                                   fi
+                                  echo here1
                                 elif commit_was_merged_build_spec   FETCH_HEAD >/tmp/comment_body ;then
+                                  echo here3
                                   true
                                 else
+                                  echo here4
                                   #echo  >/tmp/comment_body "/build debug; /build ubuntu release debug normal"
                                   echo  >/tmp/comment_body "/build macos ubuntu debug release normal gcc-10"
                                 fi ;;

--- a/iroha-lib/examples/CMakeLists.txt
+++ b/iroha-lib/examples/CMakeLists.txt
@@ -1,51 +1,55 @@
-####### irohalib_tx_example:
-add_executable(irohalib_tx_example
-    TxExample.cpp
-)
+if (APPLE)
+    message("iroha-lib does not support MacOS currently!")
+else()
+    ###### irohalib_tx_example:
+    add_executable(irohalib_tx_example
+        TxExample.cpp
+    )
 
-target_link_libraries(irohalib_tx_example
-    iroha_lib_model
-    logger_manager
-)
+    target_link_libraries(irohalib_tx_example
+        iroha_lib_model
+        logger_manager
+    )
 
-add_install_step_for_bin(irohalib_tx_example)
-
-
-####### irohalib_batch_example:
-add_executable(irohalib_batch_example
-    BatchExample.cpp
-)
-
-target_link_libraries(irohalib_batch_example
-    iroha_lib_model
-    logger_manager
-)
-
-add_install_step_for_bin(irohalib_batch_example)
+    add_install_step_for_bin(irohalib_tx_example)
 
 
-####### irohalib_query_example:
-add_executable(irohalib_query_example
-    QueryExample.cpp
-)
+    ###### irohalib_batch_example:
+    add_executable(irohalib_batch_example
+        BatchExample.cpp
+    )
 
-target_link_libraries(irohalib_query_example
-    iroha_lib_model
-    logger_manager
-)
+    target_link_libraries(irohalib_batch_example
+        iroha_lib_model
+        logger_manager
+    )
 
-add_install_step_for_bin(irohalib_query_example)
+    add_install_step_for_bin(irohalib_batch_example)
 
 
-####### irohalib_domainassetcreation_example:
-add_executable(irohalib_domainassetcreation_example
-    DomainAssetCreation.cpp
-)
+    ###### irohalib_query_example:
+    add_executable(irohalib_query_example
+        QueryExample.cpp
+    )
 
-target_link_libraries(irohalib_domainassetcreation_example
-    iroha_lib_model
-    logger_manager
-    gflags
-)
+    target_link_libraries(irohalib_query_example
+        iroha_lib_model
+        logger_manager
+    )
 
-add_install_step_for_bin(irohalib_domainassetcreation_example)
+    add_install_step_for_bin(irohalib_query_example)
+
+
+    ###### irohalib_domainassetcreation_example:
+    add_executable(irohalib_domainassetcreation_example
+        DomainAssetCreation.cpp
+    )
+
+    target_link_libraries(irohalib_domainassetcreation_example
+        iroha_lib_model
+        logger_manager
+        gflags
+    )
+
+    add_install_step_for_bin(irohalib_domainassetcreation_example)
+endif()

--- a/vcpkg/patches/0014-gtest-remove-werror-compile-flag.patch
+++ b/vcpkg/patches/0014-gtest-remove-werror-compile-flag.patch
@@ -1,0 +1,38 @@
+diff --git a/ports/gtest/portfile.cmake b/ports/gtest/portfile.cmake
+index 11ac1140a..5226367cd 100644
+--- a/ports/gtest/portfile.cmake
++++ b/ports/gtest/portfile.cmake
+@@ -12,6 +12,7 @@ vcpkg_from_github(
+         0002-Fix-z7-override.patch
+         fix-main-lib-path.patch
+         fix-build-failure-in-gcc-11.patch
++        removing-werror-compiler-flag.patch
+ )
+ 
+ string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)
+diff --git a/ports/gtest/removing-werror-compiler-flag.patch b/ports/gtest/removing-werror-compiler-flag.patch
+new file mode 100644
+index 000000000..2b7339da4
+--- /dev/null
++++ b/ports/gtest/removing-werror-compiler-flag.patch
+@@ -0,0 +1,20 @@
++diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
++index 4439cb9..e385a5a 100644
++--- a/googletest/cmake/internal_utils.cmake
+++++ b/googletest/cmake/internal_utils.cmake
++@@ -82,13 +82,13 @@ macro(config_compiler_and_linker)
++     # http://stackoverflow.com/questions/3232669 explains the issue.
++     set(cxx_base_flags "${cxx_base_flags} -wd4702")
++   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
++-    set(cxx_base_flags "-Wall -Wshadow -Werror -Wconversion")
+++    set(cxx_base_flags "-Wall -Wshadow -Wconversion")
++     set(cxx_exception_flags "-fexceptions")
++     set(cxx_no_exception_flags "-fno-exceptions")
++     set(cxx_strict_flags "-W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Wchar-subscripts -Winline -Wredundant-decls")
++     set(cxx_no_rtti_flags "-fno-rtti")
++   elseif (CMAKE_COMPILER_IS_GNUCXX)
++-    set(cxx_base_flags "-Wall -Wshadow -Werror")
+++    set(cxx_base_flags "-Wall -Wshadow")
++     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
++       set(cxx_base_flags "${cxx_base_flags} -Wno-error=dangling-else")
++     endif()


### PR DESCRIPTION
## Description
develop -> master is failing to compile in MacOs: https://github.com/hyperledger/iroha/pull/3960

That is why I need to repair the compilation. It looks that GTest is not compilling for MacOS because compiler is now newer than before (newer compiler usually is more strict). Newer compiler signals some things as warnings, but GTest has `-Werror` compilation flag. So the solution is to create patch for vcpkg port of gtest to remove the flag (how to create patch is here: https://stackoverflow.com/questions/72588408/vcpkg-how-to-edit-package-file-when-compilation-fails-when-installing-package).

Details of what was done: https://github.com/hyperledger/iroha/pull/3977#issuecomment-1771606416
<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
We will be able to upgrade `main` branch with changes from `develop`

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
