### PR TITLE
[ci] #3578: Add client-cli-tests results uploading to Allure Test Ops

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -15,6 +15,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CLIENT_CLI_DIR: "/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/target/debug"
+  ALLURE_RESULTS: "${{ github.workspace }}/allure-results"
+  ALLURE_JOB_RUN_ID: ${{ github.event.inputs.ALLURE_JOB_RUN_ID }}
 
 jobs:
   consistency:
@@ -136,40 +139,42 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     timeout-minutes: 60
-
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
+      - name: Install and configure allurectl
+        uses: allure-framework/setup-allurectl@v1
+        with:
+          allure-endpoint: https://soramitsu.testops.cloud
+          allure-token: ${{ secrets.ALLURE_TOKEN }}
+          allure-project-id: 1
       - name: Build binaries
         run: |
           cargo build --bin iroha_client_cli
           cargo build --bin kagami
           cargo build --bin iroha
-
       - name: Mark binaries as executable
         run: |
-          chmod +x $CLIENT_CLI_DIR/
-
+          chmod +x ${{ env.CLIENT_CLI_DIR }}/
       - name: Run Iroha 2 on bare metal
         run: |
           ./scripts/test_env.py setup
-
       - name: Copy Iroha 2 client config
         run: |
-          cp ./configs/client/config.json $CLIENT_CLI_DIR/
-
+          cp ./configs/client/config.json ${{ env.CLIENT_CLI_DIR }}/
       - name: Set up .env for client_cli tests
         run: |
-          echo "CLIENT_CLI_DIR=$CLIENT_CLI_DIR" >> ./client_cli/pytests/.env
+          echo "CLIENT_CLI_DIR=${{ env.CLIENT_CLI_DIR }}" >> ./client_cli/pytests/.env
           echo "TORII_API_PORT_MIN=8080" >> ./client_cli/pytests/.env
           echo "TORII_API_PORT_MAX=8083" >> ./client_cli/pytests/.env
-
       - name: Install dependencies using Poetry
         working-directory: client_cli/pytests
         run: |
           poetry install
-
-      - name: Run client cli tests
+      - name: Run client cli tests and upload results to Allure Test Ops
         working-directory: client_cli/pytests
         run: |
-          poetry run pytest
+          allurectl watch -- poetry run pytest --alluredir=${ALLURE_RESULTS}
+          printenv | grep GITHUB_TESTS_
+        env:
+          GITHUB_TESTS_REF_NAME: ${{ github.ref_name }}

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,8 +3,7 @@ FROM archlinux:base-devel
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    POETRY_HOME=/opt/poetry \
-    CLIENT_CLI_DIR=/__w/iroha/iroha/target/debug
+    POETRY_HOME=/opt/poetry
 
 ENV PATH=$POETRY_HOME/bin:$PATH
 

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -2,9 +2,19 @@ FROM archlinux:base-devel
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    POETRY_HOME=/opt/poetry
 
-RUN pacman -Syu rustup mold openssl libgit2 git docker docker-buildx docker-compose glibc lib32-glibc --noconfirm
+ENV PATH=$POETRY_HOME/bin:$PATH
+
+RUN pacman -Syu rustup mold openssl libgit2 git docker \
+    docker-buildx docker-compose glibc lib32-glibc \
+    python python-pip --noconfirm --disable-download-timeout && \
+    curl -sSL https://install.python-poetry.org | python3 -
+
+WORKDIR /client_cli/pytests
+COPY /client_cli/pytests/pyproject.toml /client_cli/pytests/poetry.lock $WORKDIR
+RUN poetry install
 
 RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
 RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Description
1. Integrate `client-cli-tests` results uploading to Allure Test Ops inside `client-cli-test` job
2. Update `Dockerfile.build.glibc` regarding to #3818 

### Linked issue
#3578 

### Benefits
1. Upload `client-cli pytest` results to Test Ops suite
2. Have `poetry` installation inside `Dockerfile.build.glibc`

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up


### USEFUL LINKS 
[Allure Test Ops](https://soramitsu.testops.cloud/project/1/launches)
