### PR TITLE
[feature] #3130: Add type-state-pattern to divide client into sync and async parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ include/generated/*
 peers.list
 cmake-build*
 result
+.obsidian/
 
 .gtm
 /.gtm/

--- a/client/README.md
+++ b/client/README.md
@@ -28,3 +28,38 @@ let mut iroha_client = Client::new(configuration);
 ```
 
 We highly recommend looking at the sample [`iroha_client_cli`](../client_cli) implementation binary as well as our [tutorial](https://hyperledger.github.io/iroha-2-docs/guide/rust.html) for more examples and explanations.
+
+## Foundation for asynchronous libraries
+
+This crate also provides a [Future](https://doc.rust-lang.org/stable/std/future/trait.Future.html)-compatible API to create your own libraries and applications based on it.
+### A glue library
+The async API is runtime-agnostic so basically you just need to implement a couple of [traits](https://docs.rs/std/keyword.trait.html) to make any async-runtime compatible with the Iroha 2 client - the implementation would be a glue code between the Iroha 2 client library and your chosen transport using a specific async-runtime.
+### Existing glue libraries
+We provide [our own glue library](../client_awc/README) built for use in the [Actix](https://actix.rs) runtime and based on [awc](https://docs.rs/awc). We highly recommend to use this library if you use [Actix](https://actix.rs). There is [another crate](../client_hyper/README) to use in the [Tokio](https://docs.rs/tokio) runtime and built on top of [hyper](https://hyper.rs).
+```mermaid
+flowchart LR
+  IC[iroha_client]
+  ICC[iroha_client_cli]
+  S[Your sync application]
+  IA[iroha_awc]
+  IH[iroha_hyper]
+  G[Your glue crate]
+  GG[Your application]
+  IC --> ICC
+  IC --> S
+  IC --> IA
+  IC --> IH
+  IC --> G
+  subgraph SGA[Actix runtime]
+	IA --> A[Your application]
+  end
+  style SGA fill: grey
+  subgraph SBT[Tokio runtime]
+    IH --> T[Your application]
+  end
+  style SBT fill: grey
+  subgraph SBG[X runtime]
+    G --> GG
+  end
+  style SBG fill: grey
+```

--- a/client/benches/tps/utils.rs
+++ b/client/benches/tps/utils.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use eyre::{Result, WrapErr};
-use iroha_client::client::Client;
+use iroha_client::DefaultSyncClient;
 use iroha_data_model::{
     parameter::{default::MAX_TRANSACTIONS_IN_BLOCK, ParametersBuilder},
     prelude::*,
@@ -151,7 +151,7 @@ impl Config {
 
 struct MeasurerUnit {
     pub config: Config,
-    pub client: Client,
+    pub client: DefaultSyncClient,
     pub name: UnitName,
     pub next_name: UnitName,
 }

--- a/client/examples/tutorial.rs
+++ b/client/examples/tutorial.rs
@@ -3,6 +3,7 @@
 use std::fs::File;
 
 use eyre::{Error, WrapErr};
+use iroha_client::DefaultSyncClient;
 // #region rust_config_crates
 use iroha_config::client::Configuration;
 use iroha_data_model::TryToValue;
@@ -37,17 +38,14 @@ fn main() {
 }
 
 fn json_config_client_test(config: &Configuration) -> Result<(), Error> {
-    use iroha_client::client::Client;
-
     // Initialise a client with a provided config
-    let _current_client: Client = Client::new(config)?;
+    let _current_client = DefaultSyncClient::new(config)?;
 
     Ok(())
 }
 
 fn domain_registration_test(config: &Configuration) -> Result<(), Error> {
     // #region domain_register_example_crates
-    use iroha_client::client::Client;
     use iroha_data_model::{
         metadata::UnlimitedMetadata,
         prelude::{Domain, DomainId, InstructionExpr, RegisterExpr},
@@ -66,7 +64,7 @@ fn domain_registration_test(config: &Configuration) -> Result<(), Error> {
 
     // #region rust_client_create
     // Create an Iroha client
-    let iroha_client: Client = Client::new(config)?;
+    let iroha_client = DefaultSyncClient::new(config)?;
     // #endregion rust_client_create
 
     // #region domain_register_example_prepare_tx
@@ -111,7 +109,6 @@ fn account_definition_test() -> Result<(), Error> {
 
 fn account_registration_test(config: &Configuration) -> Result<(), Error> {
     // #region register_account_crates
-    use iroha_client::client::Client;
     use iroha_crypto::KeyPair;
     use iroha_data_model::{
         metadata::UnlimitedMetadata,
@@ -120,7 +117,7 @@ fn account_registration_test(config: &Configuration) -> Result<(), Error> {
     // #endregion register_account_crates
 
     // Create an Iroha client
-    let iroha_client: Client = Client::new(config)?;
+    let iroha_client = DefaultSyncClient::new(config)?;
 
     // #region register_account_create
     // Create an AccountId instance by providing the account and domain name
@@ -161,14 +158,13 @@ fn asset_registration_test(config: &Configuration) -> Result<(), Error> {
     // #region register_asset_crates
     use std::str::FromStr as _;
 
-    use iroha_client::client::Client;
     use iroha_data_model::prelude::{
         AccountId, AssetDefinition, AssetDefinitionId, AssetId, IdBox, MintExpr, RegisterExpr,
     };
     // #endregion register_asset_crates
 
     // Create an Iroha client
-    let iroha_client: Client = Client::new(config)?;
+    let iroha_client = DefaultSyncClient::new(config)?;
 
     // #region register_asset_create_asset
     // Create an asset
@@ -209,7 +205,6 @@ fn asset_minting_test(config: &Configuration) -> Result<(), Error> {
     // #region mint_asset_crates
     use std::str::FromStr;
 
-    use iroha_client::client::Client;
     use iroha_data_model::{
         prelude::{AccountId, AssetDefinitionId, AssetId, MintExpr, ToValue},
         IdBox,
@@ -217,7 +212,7 @@ fn asset_minting_test(config: &Configuration) -> Result<(), Error> {
     // #endregion mint_asset_crates
 
     // Create an Iroha client
-    let iroha_client: Client = Client::new(config)?;
+    let iroha_client = DefaultSyncClient::new(config)?;
 
     // Define the instances of an Asset and Account
     // #region mint_asset_define_asset_account
@@ -267,7 +262,6 @@ fn asset_burning_test(config: &Configuration) -> Result<(), Error> {
     // #region burn_asset_crates
     use std::str::FromStr;
 
-    use iroha_client::client::Client;
     use iroha_data_model::{
         prelude::{AccountId, AssetDefinitionId, AssetId, BurnExpr, ToValue},
         IdBox,
@@ -275,7 +269,7 @@ fn asset_burning_test(config: &Configuration) -> Result<(), Error> {
     // #endregion burn_asset_crates
 
     // Create an Iroha client
-    let iroha_client: Client = Client::new(config)?;
+    let iroha_client = DefaultSyncClient::new(config)?;
 
     // #region burn_asset_define_asset_account
     // Define the instances of an Asset and Account

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,6 +6,9 @@ pub mod client;
 pub mod http;
 mod http_default;
 
+pub type DefaultSyncClient =
+    client::Client<http::SyncRequestManager<http_default::DefaultSendRequest>>;
+
 /// Module containing sample configurations for tests and benchmarks.
 pub mod samples {
     use iroha_config::{

--- a/client/tests/integration/asset.rs
+++ b/client/tests/integration/asset.rs
@@ -30,7 +30,10 @@ fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
     // Registering an asset to an account which doesn't have one
     // should result in asset being created
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
@@ -62,7 +65,10 @@ fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
 
     // Wait for asset to be registered
     test_client.poll_request(client::asset::by_account_id(account_id.clone()), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets
             .iter()
@@ -73,7 +79,10 @@ fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
 
     // ... and check that it is removed after Unregister
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets
             .iter()
@@ -106,7 +115,10 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
     let tx = test_client.build_transaction(instructions, metadata)?;
     test_client.submit_transaction(&tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
@@ -140,7 +152,10 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
     let tx = test_client.build_transaction(instructions, metadata)?;
     test_client.submit_transaction(&tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
@@ -175,7 +190,10 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
     let tx = test_client.build_transaction(instructions, metadata)?;
     test_client.submit_transaction(&tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id.clone()), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
@@ -197,7 +215,10 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
         .checked_add(quantity2)
         .map_err(|e| eyre::eyre!("{}", e))?;
     test_client.submit_till(mint, client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
@@ -233,8 +254,11 @@ fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transacti
     thread::sleep(pipeline_time * 4);
 
     let mut asset_definition_ids = test_client
-        .request(client::asset::all_definitions())
-        .expect("Failed to execute request.")
+        .seek(
+            test_client
+                .request(client::asset::all_definitions())
+                .expect("Failed to execute request."),
+        )
         .collect::<QueryResult<Vec<_>>>()
         .expect("Failed to execute request.")
         .into_iter()

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -46,16 +46,18 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
 
     //Then
     let peer = network.peers.values().last().unwrap();
-    client::Client::test(&peer.api_address).poll_request(
-        client::asset::by_account_id(account_id),
-        |result| {
-            let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+    let test_client = client::Client::test(&peer.api_address);
 
-            assets.iter().any(|asset| {
-                asset.id().definition_id == asset_definition_id
-                    && *asset.value() == AssetValue::Quantity(quantity)
-            })
-        },
-    )?;
+    test_client.poll_request(client::asset::by_account_id(account_id), |result| {
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
+
+        assets.iter().any(|asset| {
+            asset.id().definition_id == asset_definition_id
+                && *asset.value() == AssetValue::Quantity(quantity)
+        })
+    })?;
     Ok(())
 }

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -74,7 +74,7 @@ fn test_with_instruction_and_status_and_port(
 
 #[derive(Clone)]
 struct Checker {
-    listener: iroha_client::client::Client,
+    listener: iroha_client::DefaultSyncClient,
     hash: iroha_crypto::HashOf<TransactionPayload>,
 }
 

--- a/client/tests/integration/multiple_blocks_created.rs
+++ b/client/tests/integration/multiple_blocks_created.rs
@@ -58,16 +58,17 @@ fn long_multiple_blocks_created() -> Result<()> {
 
     //Then
     let peer = network.peers().last().unwrap();
-    Client::test(&peer.api_address).poll_request(
-        client::asset::by_account_id(account_id),
-        |result| {
-            let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+    let test_client = Client::test(&peer.api_address);
+    test_client.poll_request(client::asset::by_account_id(account_id), |result| {
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
 
-            assets.iter().any(|asset| {
-                asset.id().definition_id == asset_definition_id
-                    && *asset.value() == AssetValue::Quantity(account_has_quantity)
-            })
-        },
-    )?;
+        assets.iter().any(|asset| {
+            asset.id().definition_id == asset_definition_id
+                && *asset.value() == AssetValue::Quantity(account_has_quantity)
+        })
+    })?;
     Ok(())
 }

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -67,7 +67,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() -> Result<()> {
     let client_1 = Client::new(&client_configuration).expect("Invalid client configuration");
     let request = client::asset::by_account_id(alice_id);
     let assets = client_1
-        .request(request.clone())?
+        .seek(client_1.request(request.clone())?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert_eq!(
         assets.len(),
@@ -86,7 +86,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() -> Result<()> {
     client_2.submit_transaction(&client_2.sign_transaction(transaction)?)?;
     thread::sleep(pipeline_time);
     let assets = client_1
-        .request(request)?
+        .seek(client_1.request(request)?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert!(!assets.is_empty());
     let camomile_asset = assets

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -32,7 +32,10 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
     // We can register and mint the non-mintable token
     test_client.submit_transaction(&tx)?;
     test_client.poll_request(client::asset::by_account_id(account_id.clone()), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Quantity(200_u32)
@@ -45,7 +48,10 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
     // However, this will fail
     assert!(test_client
         .poll_request(client::asset::by_account_id(account_id), |result| {
-            let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+            let assets = test_client
+                .seek(result)
+                .collect::<QueryResult<Vec<_>>>()
+                .expect("Valid");
             assets.iter().any(|asset| {
                 asset.id().definition_id == asset_definition_id
                     && *asset.value() == AssetValue::Quantity(400_u32)
@@ -72,7 +78,10 @@ fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Re
     // We can register the non-mintable token
     test_client.submit_all([create_asset, register_asset.clone()])?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Quantity(1_u32)
@@ -109,7 +118,10 @@ fn non_mintable_asset_can_be_minted_if_registered_with_zero_value() -> Result<()
         [create_asset.into(), register_asset.into(), mint.into()];
     test_client.submit_all(instructions)?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
-        let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+        let assets = test_client
+            .seek(result)
+            .collect::<QueryResult<Vec<_>>>()
+            .expect("Valid");
         assets.iter().any(|asset| {
             asset.id().definition_id == asset_definition_id
                 && *asset.value() == AssetValue::Quantity(1_u32)

--- a/client/tests/integration/offline_peers.rs
+++ b/client/tests/integration/offline_peers.rs
@@ -32,7 +32,7 @@ fn genesis_block_is_committed_with_some_offline_peers() -> Result<()> {
 
     //Then
     let assets = client
-        .request(client::asset::by_account_id(alice_id))?
+        .seek(client.request(client::asset::by_account_id(alice_id))?)
         .collect::<QueryResult<Vec<_>>>()?;
     let asset = assets
         .iter()

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -20,13 +20,13 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
     client.submit_all_blocking(register)?;
 
     let vec = client
-        .request_with_pagination(
+        .seek(client.request_with_pagination(
             asset::all_definitions(),
             Pagination {
                 limit: NonZeroU32::new(5),
                 start: NonZeroU64::new(5),
             },
-        )?
+        )?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert_eq!(vec.len(), 5);
     Ok(())

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -1,7 +1,10 @@
 use std::{str::FromStr as _, thread, time::Duration};
 
 use eyre::Result;
-use iroha_client::client::{self, Client, QueryResult};
+use iroha_client::{
+    client::{self, QueryResult},
+    DefaultSyncClient,
+};
 use iroha_data_model::prelude::*;
 use iroha_genesis::GenesisNetwork;
 use serde_json::json;
@@ -57,10 +60,13 @@ fn genesis_transactions_are_validated() {
     }
 }
 
-fn get_assets(iroha_client: &Client, id: &AccountId) -> Vec<Asset> {
+fn get_assets(iroha_client: &DefaultSyncClient, id: &AccountId) -> Vec<Asset> {
     iroha_client
-        .request(client::asset::by_account_id(id.clone()))
-        .expect("Failed to execute request.")
+        .seek(
+            iroha_client
+                .request(client::asset::by_account_id(id.clone()))
+                .expect("Failed to execute request."),
+        )
         .collect::<QueryResult<Vec<_>>>()
         .expect("Failed to execute request.")
 }

--- a/client/tests/integration/queries/account.rs
+++ b/client/tests/integration/queries/account.rs
@@ -63,7 +63,7 @@ fn find_accounts_with_asset() -> Result<()> {
     );
 
     let found_accounts = test_client
-        .request(client::account::all_with_asset(definition_id))?
+        .seek(test_client.request(client::account::all_with_asset(definition_id))?)
         .collect::<QueryResult<Vec<_>>>()?;
     let found_ids = found_accounts
         .into_iter()

--- a/client/tests/integration/queries/role.rs
+++ b/client/tests/integration/queries/role.rs
@@ -35,7 +35,7 @@ fn find_roles() -> Result<()> {
 
     // Checking results
     let found_role_ids = test_client
-        .request(client::role::all())?
+        .seek(test_client.request(client::role::all())?)
         .collect::<QueryResult<Vec<_>>>()?
         .into_iter();
 
@@ -67,7 +67,7 @@ fn find_role_ids() -> Result<()> {
 
     // Checking results
     let found_role_ids = test_client
-        .request(client::role::all_ids())?
+        .seek(test_client.request(client::role::all_ids())?)
         .collect::<QueryResult<Vec<_>>>()?;
     let found_role_ids = found_role_ids.into_iter().collect::<HashSet<_>>();
 
@@ -148,7 +148,7 @@ fn find_roles_by_account_id() -> Result<()> {
 
     // Checking results
     let found_role_ids = test_client
-        .request(client::role::by_account_id(alice_id))?
+        .seek(test_client.request(client::role::by_account_id(alice_id))?)
         .collect::<QueryResult<Vec<_>>>()?;
     let found_role_ids = found_role_ids.into_iter().collect::<HashSet<_>>();
 

--- a/client/tests/integration/restart_peer.rs
+++ b/client/tests/integration/restart_peer.rs
@@ -46,7 +46,7 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
         iroha_client.submit_blocking(mint_asset)?;
 
         let assets = iroha_client
-            .request(client::asset::by_account_id(account_id.clone()))?
+            .seek(iroha_client.request(client::asset::by_account_id(account_id.clone()))?)
             .collect::<QueryResult<Vec<_>>>()?;
         let asset = assets
             .into_iter()
@@ -67,7 +67,10 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
         wait_for_genesis_committed(&vec![iroha_client.clone()], 0);
 
         iroha_client.poll_request(client::asset::by_account_id(account_id), |result| {
-            let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+            let assets = iroha_client
+                .seek(result)
+                .collect::<QueryResult<Vec<_>>>()
+                .expect("Valid");
             iroha_logger::error!(?assets);
 
             let account_asset = assets

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -88,7 +88,7 @@ fn register_and_grant_role_for_metadata_access() -> Result<()> {
 
     // Making request to find Alice's roles
     let found_role_ids = test_client
-        .request(client::role::by_account_id(alice_id))?
+        .seek(test_client.request(client::role::by_account_id(alice_id))?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert!(found_role_ids.contains(&role_id));
 
@@ -123,7 +123,7 @@ fn unregistered_role_removed_from_account() -> Result<()> {
 
     // Check that Mouse has root role
     let found_mouse_roles = test_client
-        .request(client::role::by_account_id(mouse_id.clone()))?
+        .seek(test_client.request(client::role::by_account_id(mouse_id.clone()))?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert!(found_mouse_roles.contains(&role_id));
 
@@ -133,7 +133,7 @@ fn unregistered_role_removed_from_account() -> Result<()> {
 
     // Check that Mouse doesn't have the root role
     let found_mouse_roles = test_client
-        .request(client::role::by_account_id(mouse_id))?
+        .seek(test_client.request(client::role::by_account_id(mouse_id))?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert!(!found_mouse_roles.contains(&role_id));
 

--- a/client/tests/integration/set_parameter.rs
+++ b/client/tests/integration/set_parameter.rs
@@ -15,7 +15,7 @@ fn can_change_parameter_value() -> Result<()> {
     let param_box = SetParameterExpr::new(parameter);
 
     let old_params = test_client
-        .request(client::parameter::all())?
+        .seek(test_client.request(client::parameter::all())?)
         .collect::<QueryResult<Vec<_>>>()?;
     let param_val_old = old_params
         .iter()
@@ -26,7 +26,7 @@ fn can_change_parameter_value() -> Result<()> {
     test_client.submit_blocking(param_box)?;
 
     let new_params = test_client
-        .request(client::parameter::all())?
+        .seek(test_client.request(client::parameter::all())?)
         .collect::<QueryResult<Vec<_>>>()?;
     let param_val_new = new_params
         .iter()

--- a/client/tests/integration/sorting.rs
+++ b/client/tests/integration/sorting.rs
@@ -58,15 +58,18 @@ fn correct_pagination_assets_after_creating_new_one() {
     let sorting = Sorting::by_metadata_key(sort_by_metadata_key.clone());
 
     let res = test_client
-        .request_with_pagination_and_sorting(
-            client::asset::by_account_id(account_id.clone()),
-            Pagination {
-                limit: NonZeroU32::new(5),
-                start: None,
-            },
-            sorting.clone(),
+        .seek(
+            test_client
+                .request_with_pagination_and_sorting(
+                    client::asset::by_account_id(account_id.clone()),
+                    Pagination {
+                        limit: NonZeroU32::new(5),
+                        start: None,
+                    },
+                    sorting.clone(),
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -101,15 +104,18 @@ fn correct_pagination_assets_after_creating_new_one() {
         .expect("Valid");
 
     let res = test_client
-        .request_with_pagination_and_sorting(
-            client::asset::by_account_id(account_id),
-            Pagination {
-                limit: NonZeroU32::new(13),
-                start: NonZeroU64::new(8),
-            },
-            sorting,
+        .seek(
+            test_client
+                .request_with_pagination_and_sorting(
+                    client::asset::by_account_id(account_id),
+                    Pagination {
+                        limit: NonZeroU32::new(13),
+                        start: NonZeroU64::new(8),
+                    },
+                    sorting,
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -162,14 +168,17 @@ fn correct_sorting_of_entities() {
         .expect("Valid");
 
     let res = test_client
-        .request_with_filter_and_sorting(
-            client::asset::all_definitions(),
-            Sorting::by_metadata_key(sort_by_metadata_key.clone()),
-            PredicateBox::new(value::ValuePredicate::Identifiable(
-                string::StringPredicate::starts_with("xor_"),
-            )),
+        .seek(
+            test_client
+                .request_with_filter_and_sorting(
+                    client::asset::all_definitions(),
+                    Sorting::by_metadata_key(sort_by_metadata_key.clone()),
+                    PredicateBox::new(value::ValuePredicate::Identifiable(
+                        string::StringPredicate::starts_with("xor_"),
+                    )),
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -213,14 +222,17 @@ fn correct_sorting_of_entities() {
         .expect("Valid");
 
     let res = test_client
-        .request_with_filter_and_sorting(
-            client::account::all(),
-            Sorting::by_metadata_key(sort_by_metadata_key.clone()),
-            PredicateBox::new(value::ValuePredicate::Identifiable(
-                string::StringPredicate::starts_with("charlie"),
-            )),
+        .seek(
+            test_client
+                .request_with_filter_and_sorting(
+                    client::account::all(),
+                    Sorting::by_metadata_key(sort_by_metadata_key.clone()),
+                    PredicateBox::new(value::ValuePredicate::Identifiable(
+                        string::StringPredicate::starts_with("charlie"),
+                    )),
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -260,15 +272,18 @@ fn correct_sorting_of_entities() {
         .expect("Valid");
 
     let res = test_client
-        .request_with_filter_and_pagination_and_sorting(
-            client::domain::all(),
-            Pagination::default(),
-            Sorting::by_metadata_key(sort_by_metadata_key.clone()),
-            PredicateBox::new(value::ValuePredicate::Identifiable(
-                string::StringPredicate::starts_with("neverland"),
-            )),
+        .seek(
+            test_client
+                .request_with_filter_and_pagination_and_sorting(
+                    client::domain::all(),
+                    Pagination::default(),
+                    Sorting::by_metadata_key(sort_by_metadata_key.clone()),
+                    PredicateBox::new(value::ValuePredicate::Identifiable(
+                        string::StringPredicate::starts_with("neverland"),
+                    )),
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -309,13 +324,16 @@ fn correct_sorting_of_entities() {
         string::StringPredicate::starts_with("neverland_"),
     ));
     let res = test_client
-        .request_with_filter_and_pagination_and_sorting(
-            client::domain::all(),
-            Pagination::default(),
-            Sorting::by_metadata_key(sort_by_metadata_key),
-            filter,
+        .seek(
+            test_client
+                .request_with_filter_and_pagination_and_sorting(
+                    client::domain::all(),
+                    Pagination::default(),
+                    Sorting::by_metadata_key(sort_by_metadata_key),
+                    filter,
+                )
+                .expect("Valid"),
         )
-        .expect("Valid")
         .collect::<QueryResult<Vec<_>>>()
         .expect("Valid");
 
@@ -371,14 +389,17 @@ fn sort_only_elements_which_have_sorting_key() -> Result<()> {
         .wrap_err("Failed to register accounts")?;
 
     let res = test_client
-        .request_with_filter_and_sorting(
-            client::account::all(),
-            Sorting::by_metadata_key(sort_by_metadata_key),
-            PredicateBox::new(value::ValuePredicate::Identifiable(
-                string::StringPredicate::starts_with("charlie"),
-            )),
+        .seek(
+            test_client
+                .request_with_filter_and_sorting(
+                    client::account::all(),
+                    Sorting::by_metadata_key(sort_by_metadata_key),
+                    PredicateBox::new(value::ValuePredicate::Identifiable(
+                        string::StringPredicate::starts_with("charlie"),
+                    )),
+                )
+                .wrap_err("Failed to submit request")?,
         )
-        .wrap_err("Failed to submit request")?
         .collect::<QueryResult<Vec<_>>>()?;
 
     let accounts = accounts_a.iter().rev().chain(accounts_b.iter());

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -88,7 +88,10 @@ fn simulate_transfer<
             transfer_asset,
             client::asset::by_account_id(mouse_id.clone()),
             |result| {
-                let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+                let assets = iroha_client
+                    .seek(result)
+                    .collect::<QueryResult<Vec<_>>>()
+                    .expect("Valid");
 
                 assets.iter().any(|asset| {
                     asset.id().definition_id == asset_definition_id

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr as _, sync::mpsc, thread, time::Duration};
 
 use eyre::{eyre, Result, WrapErr};
-use iroha_client::client::{self, Client};
+use iroha_client::{client, DefaultSyncClient};
 use iroha_data_model::{
     prelude::*,
     query::error::{FindError, QueryExecutionFail},
@@ -484,7 +484,7 @@ fn trigger_burn_repetitions() -> Result<()> {
     Ok(())
 }
 
-fn get_asset_value(client: &mut Client, asset_id: AssetId) -> Result<u32> {
+fn get_asset_value(client: &mut DefaultSyncClient, asset_id: AssetId) -> Result<u32> {
     let asset = client.request(client::asset::by_id(asset_id))?;
     Ok(*TryAsRef::<u32>::try_as_ref(asset.value())?)
 }

--- a/client/tests/integration/triggers/data_trigger.rs
+++ b/client/tests/integration/triggers/data_trigger.rs
@@ -1,5 +1,5 @@
 use eyre::Result;
-use iroha_client::client;
+use iroha_client::{client, DefaultSyncClient};
 use iroha_data_model::prelude::*;
 use test_network::*;
 
@@ -109,7 +109,7 @@ fn domain_scoped_trigger_must_be_executed_only_on_events_in_its_domain() -> Resu
     Ok(())
 }
 
-fn get_asset_value(client: &client::Client, asset_id: AssetId) -> Result<u32> {
+fn get_asset_value(client: &DefaultSyncClient, asset_id: AssetId) -> Result<u32> {
     let asset = client.request(client::asset::by_id(asset_id))?;
     Ok(*TryAsRef::<u32>::try_as_ref(asset.value())?)
 }

--- a/client/tests/integration/triggers/event_trigger.rs
+++ b/client/tests/integration/triggers/event_trigger.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iroha_client::client::{self, Client};
+use iroha_client::{client, DefaultSyncClient};
 use iroha_data_model::prelude::*;
 use test_network::*;
 
@@ -42,7 +42,7 @@ fn test_mint_asset_when_new_asset_definition_created() -> Result<()> {
     Ok(())
 }
 
-fn get_asset_value(client: &mut Client, asset_id: AssetId) -> Result<u32> {
+fn get_asset_value(client: &mut DefaultSyncClient, asset_id: AssetId) -> Result<u32> {
     let asset = client.request(client::asset::by_id(asset_id))?;
     Ok(*TryAsRef::<u32>::try_as_ref(asset.value())?)
 }

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -51,15 +51,14 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() -> Result<()> 
     }
     thread::sleep(pipeline_time * 5);
 
-    let transactions = client
-        .request_with_pagination(
-            transaction::by_account_id(account_id.clone()),
-            Pagination {
-                limit: NonZeroU32::new(50),
-                start: NonZeroU64::new(1),
-            },
-        )?
-        .collect::<QueryResult<Vec<_>>>()?;
+    let result = client.request_with_pagination(
+        transaction::by_account_id(account_id.clone()),
+        Pagination {
+            limit: NonZeroU32::new(50),
+            start: NonZeroU64::new(1),
+        },
+    )?;
+    let transactions = client.seek(result).collect::<QueryResult<Vec<_>>>()?;
     assert_eq!(transactions.len(), 50);
 
     let mut prev_creation_time = core::time::Duration::from_millis(0);

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -28,12 +28,14 @@ fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes(
 
     //Then
     let request = client::asset::by_account_id(account_id);
-    let query_result = client.request(request)?.collect::<QueryResult<Vec<_>>>()?;
+    let query_result = client
+        .seek(client.request(request)?)
+        .collect::<QueryResult<Vec<_>>>()?;
     assert!(query_result
         .iter()
         .all(|asset| asset.id().definition_id != wrong_asset_definition_id));
     let definition_query_result = client
-        .request(client::asset::all_definitions())?
+        .seek(client.request(client::asset::all_definitions())?)
         .collect::<QueryResult<Vec<_>>>()?;
     assert!(definition_query_result
         .iter()

--- a/client/tests/integration/unstable_network.rs
+++ b/client/tests/integration/unstable_network.rs
@@ -116,7 +116,10 @@ fn unstable_network(
                 Configuration::pipeline_time(),
                 4,
                 |result| {
-                    let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
+                    let assets = iroha_client
+                        .seek(result)
+                        .collect::<QueryResult<Vec<_>>>()
+                        .expect("Valid");
 
                     assets.iter().any(|asset| {
                         asset.id().definition_id == asset_definition_id

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -406,7 +406,7 @@ mod domain {
         fn run(self, context: &mut dyn RunContext) -> Result<()> {
             let client = Client::new(context.configuration())?;
 
-            let vec = match self {
+            let result_set = match self {
                 Self::All => client
                     .request(client::domain::all())
                     .wrap_err("Failed to get all domains"),
@@ -414,7 +414,7 @@ mod domain {
                     .request_with_filter(client::domain::all(), filter.predicate)
                     .wrap_err("Failed to get filtered domains"),
             }?;
-            context.print_data(&vec.collect::<QueryResult<Vec<_>>>()?)?;
+            context.print_data(&client.seek(result_set).collect::<QueryResult<Vec<_>>>()?)?;
             Ok(())
         }
     }
@@ -554,7 +554,7 @@ mod account {
                     .request_with_filter(client::account::all(), filter.predicate)
                     .wrap_err("Failed to get filtered accounts"),
             }?;
-            context.print_data(&vec.collect::<QueryResult<Vec<_>>>()?)?;
+            context.print_data(&client.seek(vec).collect::<QueryResult<Vec<_>>>()?)?;
             Ok(())
         }
     }
@@ -618,14 +618,17 @@ mod account {
             let permissions = client
                 .request(find_all_permissions)
                 .wrap_err("Failed to get all account permissions")?;
-            context.print_data(&permissions.collect::<QueryResult<Vec<_>>>()?)?;
+            context.print_data(&client.seek(permissions).collect::<QueryResult<Vec<_>>>()?)?;
             Ok(())
         }
     }
 }
 
 mod asset {
-    use iroha_client::client::{self, asset, Client};
+    use iroha_client::{
+        client::{self, asset, Client},
+        DefaultSyncClient,
+    };
 
     use super::*;
 
@@ -816,7 +819,7 @@ mod asset {
     impl RunArgs for Get {
         fn run(self, context: &mut dyn RunContext) -> Result<()> {
             let Self { account, asset } = self;
-            let iroha_client = Client::new(context.configuration())?;
+            let iroha_client: DefaultSyncClient = Client::new(context.configuration())?;
             let asset_id = AssetId::new(asset, account);
             let asset = iroha_client
                 .request(asset::by_id(asset_id))
@@ -847,7 +850,7 @@ mod asset {
                     .request_with_filter(client::asset::all(), filter.predicate)
                     .wrap_err("Failed to get filtered assets"),
             }?;
-            context.print_data(&vec.collect::<QueryResult<Vec<_>>>()?)?;
+            context.print_data(&client.seek(vec).collect::<QueryResult<Vec<_>>>()?)?;
             Ok(())
         }
     }


### PR DESCRIPTION
## Description

This PR adds traits to implement type-state-pattern on `Client` to divide it into sync and async parts.
I'm going to open also two pull requests:
- Add async client features
- `iroha_awc` and `iroha_hyper` crates implementations

### Linked issue

Closes #3130

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] Rewrite doc tests and examples
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs 

<!-- HINT:  Add more points to checklist for large draft PRs-->
- [ ] Open a pull request that adds async client features
- [ ] Open a pull request that add implementations of the `iroha_awc` and `iroha_hyper` crates

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
