### PR TITLE
[feature] #3237: Expose cargo's output in wasm_builder_cli to have build progress information

### DIFF
--- a/tools/wasm_builder_cli/Cargo.toml
+++ b/tools/wasm_builder_cli/Cargo.toml
@@ -14,5 +14,5 @@ iroha_wasm_builder.workspace = true
 
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
-spinoff = { workspace = true, features = ["binary", "dots12"] }
+spinoff = { workspace = true, features = ["binary"] }
 owo-colors = { workspace = true, features = ["supports-colors"] }

--- a/tools/wasm_builder_cli/src/main.rs
+++ b/tools/wasm_builder_cli/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> color_eyre::Result<()> {
         Cli::Check {
             common: CommonArgs { path },
         } => {
-            let builder = Builder::new(&path);
+            let builder = Builder::new(&path).show_output();
             builder.check()?;
         }
         Cli::Build {
@@ -52,26 +52,15 @@ fn main() -> color_eyre::Result<()> {
             optimize,
             outfile,
         } => {
-            let builder = Builder::new(&path);
+            let builder = Builder::new(&path).show_output();
             let builder = if format { builder.format() } else { builder };
 
             let output = {
-                let mut sp = spinoff::Spinner::new_with_stream(
-                    spinoff::spinners::Dots12,
-                    "Building the smartcontract",
-                    None,
-                    spinoff::Streams::Stderr,
-                );
+                // not showing the spinner here, cargo does a progress bar for us
 
                 match builder.build() {
-                    Ok(output) => {
-                        sp.success("Smartcontract is built");
-                        output
-                    }
-                    err => {
-                        sp.fail("Building failed");
-                        err?
-                    }
+                    Ok(output) => output,
+                    err => err?,
                 }
             };
 


### PR DESCRIPTION
## Description

This adds a progress bar to `wasm_builder_cli` by exposing cargo's output (which already implements progress bar).

### Linked issue

Closes #3237 

### Benefits

The user can see the progress of the build

### Checklist

- [x] Make CI pass

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
