### PR TITLE
[refactor] #3740: Replace impl From<Pagination> for Vec<...> with a method

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -387,8 +387,8 @@ impl QueryRequest {
 
         match self.request {
             iroha_data_model::query::QueryRequest::Query(query_with_params) => builder
-                .params(Vec::from(query_with_params.sorting().clone()))
-                .params(Vec::from(*query_with_params.pagination()))
+                .params(query_with_params.sorting().clone().into_query_parameters())
+                .params(query_with_params.pagination().into_query_parameters())
                 .body(query_with_params.query().clone()),
             iroha_data_model::query::QueryRequest::Cursor(cursor) => {
                 builder.params(Vec::from(cursor))
@@ -969,7 +969,7 @@ impl Client {
         retry_in: Duration,
         pagination: Pagination,
     ) -> Result<Option<SignedTransaction>> {
-        let pagination: Vec<_> = pagination.into();
+        let pagination = pagination.into_query_parameters();
         for _ in 0..retry_count {
             let response = DefaultRequestBuilder::new(
                 HttpMethod::GET,
@@ -977,7 +977,7 @@ impl Client {
                     .join(uri::PENDING_TRANSACTIONS)
                     .expect("Valid URI"),
             )
-            .params(pagination.clone())
+            .params(&pagination)
             .headers(self.headers.clone())
             .build()?
             .send()?;

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -977,7 +977,7 @@ impl Client {
                     .join(uri::PENDING_TRANSACTIONS)
                     .expect("Valid URI"),
             )
-            .params(&pagination)
+            .params(pagination.clone())
             .headers(self.headers.clone())
             .build()?
             .send()?;

--- a/data_model/src/query/pagination.rs
+++ b/data_model/src/query/pagination.rs
@@ -38,9 +38,12 @@ pub struct Pagination {
     pub start: Option<NonZeroU64>,
 }
 
-impl From<Pagination> for Vec<(&'static str, NonZeroU64)> {
-    fn from(pagination: Pagination) -> Self {
-        match (pagination.start, pagination.limit) {
+impl Pagination {
+    /// Converts self to Vec of tuples to be used in queries
+    ///
+    /// The length of the output Vec is not constant and it's in (0..3)
+    pub fn into_query_parameters(self) -> Vec<(&'static str, NonZeroU64)> {
+        match (self.start, self.limit) {
             (Some(start), Some(limit)) => {
                 vec![(PAGINATION_LIMIT, limit.into()), (PAGINATION_START, start)]
             }

--- a/data_model/src/query/pagination.rs
+++ b/data_model/src/query/pagination.rs
@@ -39,18 +39,21 @@ pub struct Pagination {
 }
 
 impl Pagination {
-    /// Converts self to Vec of tuples to be used in queries
+    /// Converts self to iterator of tuples to be used in queries
     ///
-    /// The length of the output Vec is not constant and it's in (0..3)
-    pub fn into_query_parameters(self) -> Vec<(&'static str, NonZeroU64)> {
-        match (self.start, self.limit) {
+    /// The length of the output iterator is not constant and it's in (0..3)
+    pub fn into_query_parameters(
+        self,
+    ) -> impl IntoIterator<Item = (&'static str, NonZeroU64)> + Clone {
+        let result_vec = match (self.start, self.limit) {
             (Some(start), Some(limit)) => {
                 vec![(PAGINATION_LIMIT, limit.into()), (PAGINATION_START, start)]
             }
             (Some(start), None) => vec![(PAGINATION_START, start)],
             (None, Some(limit)) => vec![(PAGINATION_LIMIT, limit.into())],
             (None, None) => Vec::new(),
-        }
+        };
+        result_vec.into_iter()
     }
 }
 

--- a/data_model/src/query/sorting.rs
+++ b/data_model/src/query/sorting.rs
@@ -39,12 +39,13 @@ impl Sorting {
 }
 
 impl Sorting {
-    /// Converts self to Vec of tuples to be used in queries
+    /// Converts self to iterator of tuples to be used in queries
     ///
-    /// The length of the output Vec is not constant and it's in (0..3)
-    pub fn into_query_parameters(self) -> Vec<(&'static str, Name)> {
+    /// The length of the output iterator is not constant and has either 0 or 1 value
+    pub fn into_query_parameters(self) -> impl IntoIterator<Item = (&'static str, Name)> + Clone {
         self.sort_by_metadata_key
-            .map_or(Vec::new(), |key| vec![(SORT_BY_KEY, key)])
+            .map(|key| (SORT_BY_KEY, key))
+            .into_iter()
     }
 }
 

--- a/data_model/src/query/sorting.rs
+++ b/data_model/src/query/sorting.rs
@@ -38,13 +38,13 @@ impl Sorting {
     }
 }
 
-impl From<Sorting> for Vec<(&'static str, Name)> {
-    fn from(sorting: Sorting) -> Self {
-        if let Some(key) = sorting.sort_by_metadata_key {
-            return vec![(SORT_BY_KEY, key)];
-        }
-
-        Vec::new()
+impl Sorting {
+    /// Converts self to Vec of tuples to be used in queries
+    ///
+    /// The length of the output Vec is not constant and it's in (0..3)
+    pub fn into_query_parameters(self) -> Vec<(&'static str, Name)> {
+        self.sort_by_metadata_key
+            .map_or(Vec::new(), |key| vec![(SORT_BY_KEY, key)])
     }
 }
 


### PR DESCRIPTION
## Description
@Arjentix suggested that strange casts from Pagination and Sorting to Vec of tuples is not very readable and suggested refactoring these casts to a methods

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3740 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
