### PR TITLE
[feature] #3974: Add subcommand into `iroha_client_cli` to transfer domains

### DIFF
--- a/client/tests/integration/domain_owner.rs
+++ b/client/tests/integration/domain_owner.rs
@@ -270,6 +270,11 @@ fn domain_owner_trigger_permissions() -> Result<()> {
     Ok(())
 }
 
+#[deprecated(
+    since = "2.0.0-pre-rc.20",
+    note = "This test suite is deprecated, use test_transfer_domains.py instead"
+)]
+#[ignore = "migrated to client cli python tests"]
 #[test]
 fn domain_owner_transfer() -> Result<()> {
     let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_100).start_with_runtime();

--- a/client_cli/pytests/src/client_cli/client_cli.py
+++ b/client_cli/pytests/src/client_cli/client_cli.py
@@ -246,18 +246,23 @@ class ClientCli:
         """
         return self
 
-    def execute(self):
+    def execute(self, command=None):
         """
         Executes the command and captures stdout and stderr.
 
         :return: The current ClientCli object.
         :rtype: ClientCli
         """
-        command = '\n'.join(self.command)
-        with allure.step(f'{command} on the {str(self.config.torii_api_port)} peer'):
+        if command is None:
+            command = self.command
+        else:
+            command = [self.BASE_PATH] + self.BASE_FLAGS + command.split()
+        allure_command = ' '.join(map(str, command[3:]))
+        print(allure_command)
+        with allure.step(f'{allure_command} on the {str(self.config.torii_api_port)} peer'):
             try:
                 with subprocess.Popen(
-                        self.command,
+                        command,
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                         text=True

--- a/client_cli/pytests/src/client_cli/have.py
+++ b/client_cli/pytests/src/client_cli/have.py
@@ -21,17 +21,26 @@ def expected_in_actual(expected, actual) -> bool:
     return expected in actual
 
 
-def domain(expected):
+def domain(expected, owned_by=None):
     """
     Check if the expected domain is present in the list of domains.
+    Optionally checks if the domain is owned by a specific owner.
 
     :param expected: The expected domain object.
-    :return: True if the domain is present, False otherwise.
+    :param owned_by: The owner of the domain, default is None.
+    :return: True if the domain is present (and owned by the specified owner if provided), False otherwise.
     """
 
     def domain_in_domains() -> bool:
         domains = iroha.list_filter(f'{{"Identifiable": {{"Is": "{expected}"}}}}').domains()
-        return expected_in_actual(expected, domains)
+        if not expected_in_actual(expected, domains):
+            return False
+        if owned_by:
+            domain_info = domains.get(expected)
+            if not domain_info or domain_info.get('owned_by') != str(owned_by):
+                return False
+
+        return True
 
     return client_cli.wait_for(domain_in_domains)
 

--- a/client_cli/pytests/src/client_cli/iroha.py
+++ b/client_cli/pytests/src/client_cli/iroha.py
@@ -43,7 +43,7 @@ class Iroha(ClientCli):
         """
         return self
 
-    def domains(self) -> List[str]:
+    def domains(self) -> Dict[str, Dict]:
         """
         Retrieve domains from the Iroha network and return then as list of ids.
 
@@ -52,8 +52,8 @@ class Iroha(ClientCli):
         """
         self._execute_command('domain')
         domains = json.loads(self.stdout)
-        domains = [domain["id"] for domain in domains]
-        return domains
+        domains_dict = { domain["id"]: domain for domain in domains }
+        return domains_dict
 
     def accounts(self) -> List[str]:
         """

--- a/client_cli/pytests/test/domains/conftest.py
+++ b/client_cli/pytests/test/domains/conftest.py
@@ -10,6 +10,9 @@ from test import (
     GIVEN_string_with_reserved_character,
     GIVEN_string_with_whitespaces,
     GIVEN_existing_domain_with_uppercase_letter,
+    GIVEN_currently_authorized_account,
+    GIVEN_new_one_existing_account,
+    GIVEN_public_key,
     before_each)
 
 @pytest.fixture(scope="function", autouse=True)

--- a/client_cli/pytests/test/domains/test_register_domains.py
+++ b/client_cli/pytests/test/domains/test_register_domains.py
@@ -15,7 +15,7 @@ def test_register_domain(
         GIVEN_fake_name):
     with allure.step(
             f'WHEN client_cli registers the domain name "{GIVEN_fake_name}"'):
-        client_cli.register().domain(GIVEN_fake_name)
+        client_cli.execute(f'domain register --id={GIVEN_fake_name}')
     with allure.step(
             f'THEN Iroha should have the domain name "{GIVEN_fake_name}"'):
         iroha.should(have.domain(GIVEN_fake_name))

--- a/client_cli/pytests/test/domains/test_transfer_domains.py
+++ b/client_cli/pytests/test/domains/test_transfer_domains.py
@@ -1,0 +1,30 @@
+import allure
+
+from src.client_cli import client_cli, iroha
+import json
+
+@allure.label('sdk_test_id', 'transfer_domain_successfully')
+def test_transfer_domain_successfully(
+  GIVEN_currently_authorized_account,
+  GIVEN_new_one_existing_account,
+  GIVEN_new_one_existing_domain,
+):
+    with allure.step(
+            f'WHEN client_cli transfers this domain from {GIVEN_currently_authorized_account} to {GIVEN_new_one_existing_account}'):
+        client_cli.execute(f'domain transfer --from={GIVEN_currently_authorized_account} --to={GIVEN_new_one_existing_account} --id={GIVEN_new_one_existing_domain.name}')
+    with allure.step(
+            f'THEN {GIVEN_new_one_existing_account} should own this domain {GIVEN_new_one_existing_domain}'):
+        def condition():
+            owned_by = GIVEN_new_one_existing_account
+            domain_name = GIVEN_new_one_existing_domain.name
+            with allure.step(
+                    f'WHEN client_cli query domains filtered by name "{domain_name}"'):
+                domains = iroha.list_filter(f'{{"Identifiable": {{"Is": "{domain_name}"}}}}').domains()
+            with allure.step(
+                    f'THEN Iroha should return only return domains with "{domain_name}" name'):
+                allure.attach(
+                    json.dumps(domains),
+                    name='domains',
+                    attachment_type=allure.attachment_type.JSON)
+                return len(domains) != 0 and all(domains[key]["id"] == domain_name and domains[key]["owned_by"] == owned_by for key in domains)
+        client_cli.wait_for(condition)

--- a/client_cli/pytests/test/domains/test_transfer_domains.py
+++ b/client_cli/pytests/test/domains/test_transfer_domains.py
@@ -1,30 +1,26 @@
 import allure
+import pytest
 
-from src.client_cli import client_cli, iroha
-import json
+from src.client_cli import client_cli, iroha, have
+
+@pytest.fixture(scope="function", autouse=True)
+def story_account_transfers_domain():
+    allure.dynamic.story('Account transfers a domain')
+    allure.dynamic.label('permission', 'no_permission_required')
 
 @allure.label('sdk_test_id', 'transfer_domain_successfully')
-def test_transfer_domain_successfully(
-  GIVEN_currently_authorized_account,
-  GIVEN_new_one_existing_account,
-  GIVEN_new_one_existing_domain,
+def test_transfer_domain(
+        GIVEN_currently_authorized_account,
+        GIVEN_new_one_existing_account,
+        GIVEN_new_one_existing_domain,
 ):
     with allure.step(
-            f'WHEN client_cli transfers this domain from {GIVEN_currently_authorized_account} to {GIVEN_new_one_existing_account}'):
-        client_cli.execute(f'domain transfer --from={GIVEN_currently_authorized_account} --to={GIVEN_new_one_existing_account} --id={GIVEN_new_one_existing_domain.name}')
+            f'WHEN {GIVEN_currently_authorized_account} transfers domains '
+            f'to {GIVEN_new_one_existing_account}'):
+        client_cli.execute(f'domain transfer '
+                           f'--from={GIVEN_currently_authorized_account} '
+                           f'--to={GIVEN_new_one_existing_account} '
+                           f'--id={GIVEN_new_one_existing_domain.name}')
     with allure.step(
-            f'THEN {GIVEN_new_one_existing_account} should own this domain {GIVEN_new_one_existing_domain}'):
-        def condition():
-            owned_by = GIVEN_new_one_existing_account
-            domain_name = GIVEN_new_one_existing_domain.name
-            with allure.step(
-                    f'WHEN client_cli query domains filtered by name "{domain_name}"'):
-                domains = iroha.list_filter(f'{{"Identifiable": {{"Is": "{domain_name}"}}}}').domains()
-            with allure.step(
-                    f'THEN Iroha should return only return domains with "{domain_name}" name'):
-                allure.attach(
-                    json.dumps(domains),
-                    name='domains',
-                    attachment_type=allure.attachment_type.JSON)
-                return len(domains) != 0 and all(domains[key]["id"] == domain_name and domains[key]["owned_by"] == owned_by for key in domains)
-        client_cli.wait_for(condition)
+            f'THEN {GIVEN_new_one_existing_account} should own {GIVEN_new_one_existing_domain}'):
+        iroha.should(have.domain(GIVEN_new_one_existing_domain.name, owned_by=GIVEN_new_one_existing_account))


### PR DESCRIPTION
## Description

This pull request adds command to transfer domains between accounts into `iroha_client_cli`.

### Linked issue

Closes one of subtasks from #3974  

### Benefits

Extends the functionality of `iroha_client_cli`.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
