### PR TITLE
[ci]: Get more free space on the runner for release's long tests

### DIFF
--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -133,9 +133,15 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
       - name: Maximize build space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
       - uses: actions/checkout@v4
       - name: Run long tests
         run: mold --run cargo test --workspace --no-fail-fast -- --ignored --test-threads=1 long


### PR DESCRIPTION
## Description
I noticed that with soft disk space free up on the default runner for `long` tests into `I2::Release::Tests` we still receive the error `[long](https://github.com/hyperledger/iroha/actions/runs/6850948216/job/18626197954)
System.IO.IOException: No space left on device`.
I propose to use the specific Action for hard disk space free up.

### Linked issue
[Failed long tests job](https://github.com/hyperledger/iroha/actions/runs/6850948216/job/18626197954)

### Benefits
Free up more disk space as much it's possible to be able to execute long release tests.


### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
