### PR TITLE
[refactor]: use AllAccountSignaturesAnd as default signature check condition

### DIFF
--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -291,7 +291,7 @@ impl FromStr for AccountId {
 
 impl Default for SignatureCheckCondition {
     fn default() -> Self {
-        Self::AnyAccountSignatureOr(ConstVec::new_empty())
+        Self::AllAccountSignaturesAnd(ConstVec::new_empty())
     }
 }
 
@@ -373,14 +373,12 @@ mod tests {
         let key3 = make_key();
         let condition = SignatureCheckCondition::default();
 
-        check_signature_check_condition(&condition, &[], &[], false);
+        check_signature_check_condition(&condition, &[], &[], true);
         check_signature_check_condition(&condition, &[&key1], &[], false);
-        check_signature_check_condition(&condition, &[], &[&key1], false);
+        check_signature_check_condition(&condition, &[], &[&key1], true);
         check_signature_check_condition(&condition, &[&key1], &[&key1], true);
         check_signature_check_condition(&condition, &[&key1], &[&key2], false);
-        check_signature_check_condition(&condition, &[&key1, &key2, &key3], &[&key1], true);
-        check_signature_check_condition(&condition, &[&key1, &key2, &key3], &[&key2], true);
-        check_signature_check_condition(&condition, &[&key1, &key2, &key3], &[&key3], true);
+        check_signature_check_condition(&condition, &[&key1, &key2, &key3], &[&key1, &key2, &key3], true);
     }
 
     #[test]


### PR DESCRIPTION
## Description

I think this makes more sense as a default. But I'd like to hear differing opinions

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
