### PR TITLE
[fix] #4070: Enable `tls-rustls-native-roots` `iroha_client` feature by default

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,6 +23,9 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [features]
+# Use rustls by default to avoid OpenSSL dependency, simplifying compilation with musl
+default = ["tls-rustls-native-roots"]
+
 tls-native = [
     "attohttpc/tls-native",
     "tokio-tungstenite/native-tls",

--- a/client_cli/Cargo.toml
+++ b/client_cli/Cargo.toml
@@ -23,7 +23,7 @@ is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/ir
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-iroha_client = { workspace = true, features = ["tls-rustls-native-roots"] }
+iroha_client = { workspace = true }
 iroha_data_model = { workspace = true }
 iroha_primitives = { workspace = true }
 iroha_crypto = { workspace = true }


### PR DESCRIPTION
## Description

Deploying behind an HTTPS proxy seems like a common occurrence, so we should have some TLS implementation by default.

Rustls brings less problems with linking under musl, so use it

### Linked issue

Closes #4070

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Make a sane choice so that the user does not have to. If they don't like the choice, they can disable the default features and make their own.

### Checklist

- [ ] make CI pass
