### PR TITLE
[fix] #4097: Fix warp noise in logs

### DIFF
--- a/cli/src/torii/routing.rs
+++ b/cli/src/torii/routing.rs
@@ -528,9 +528,7 @@ impl Torii {
                 })
             });
 
-        let ws_router = events_ws_router
-            .or(blocks_ws_router)
-            .with(warp::trace::request());
+        let ws_router = events_ws_router.or(blocks_ws_router);
 
         warp::any()
             .and(


### PR DESCRIPTION
## Description

- `warp::trace::request()` was attached twice for some endpoints, which lead to noise in logs
- logging error inside queue push was redundant because error should be handled on caller site

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4097 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Less noise in logs.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
