### PR TITLE
[fix] #4120: Do not use the `tungstenite` re-exported from `tokio_tungstenite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -2717,6 +2717,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing-flame",
  "tracing-subscriber",
+ "tungstenite",
  "url",
 ]
 
@@ -5249,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subtle-encoding"
@@ -5572,7 +5573,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -5821,10 +5822,12 @@ dependencies = [
  "native-tls",
  "rand 0.8.5",
  "rustls",
+ "rustls-native-certs",
  "sha1",
  "thiserror",
  "url",
  "utf-8",
+ "webpki-roots 0.24.0",
 ]
 
 [[package]]
@@ -5942,7 +5945,7 @@ dependencies = [
  "rustls",
  "rustls-webpki",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
@@ -6530,6 +6533,15 @@ checksum = "45e64391864794db026d27b15cbe6edd3c25864222bd90229dfa1a26ebf30705"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ futures = { version = "0.3.28", default-features = false }
 tokio = "1.33.0"
 tokio-stream = "0.1.14"
 tokio-tungstenite = "0.20.1"
+tungstenite = "0.20.1"
 
 crossbeam = "0.8.2"
 crossbeam-queue = "0.3.8"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,18 +29,22 @@ default = ["tls-rustls-native-roots"]
 tls-native = [
     "attohttpc/tls-native",
     "tokio-tungstenite/native-tls",
+    "tungstenite/native-tls",
 ]
 tls-native-vendored = [
     "attohttpc/tls-native-vendored",
     "tokio-tungstenite/native-tls-vendored",
+    "tungstenite/native-tls-vendored",
 ]
 tls-rustls-native-roots = [
     "attohttpc/tls-rustls-native-roots",
     "tokio-tungstenite/rustls-tls-native-roots",
+    "tungstenite/rustls-tls-native-roots",
 ]
 tls-rustls-webpki-roots = [
     "attohttpc/tls-rustls-webpki-roots",
     "tokio-tungstenite/rustls-tls-webpki-roots",
+    "tungstenite/rustls-tls-webpki-roots",
 ]
 
 [dependencies]
@@ -66,6 +70,7 @@ derive_more = { workspace = true }
 parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 tokio = { workspace = true, features = ["rt"] }
 tokio-tungstenite = { workspace = true }
+tungstenite = { workspace = true }
 futures-util = "0.3.28"
 
 [dev-dependencies]

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -6,10 +6,8 @@ use attohttpc::{
 };
 use eyre::{eyre, Error, Result, WrapErr};
 use http::header::HeaderName;
-use tokio_tungstenite::tungstenite::{
-    client::IntoClientRequest, stream::MaybeTlsStream, WebSocket,
-};
-pub use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message as WebSocketMessage};
+use tungstenite::{client::IntoClientRequest, stream::MaybeTlsStream, WebSocket};
+pub use tungstenite::{Error as WebSocketError, Message as WebSocketMessage};
 use url::Url;
 
 use crate::http::{Method, RequestBuilder, Response};
@@ -137,7 +135,7 @@ pub struct DefaultWebSocketStreamRequest(http::Request<()>);
 impl DefaultWebSocketStreamRequest {
     /// Open [`WebSocketStream`] synchronously.
     pub fn connect(self) -> Result<WebSocketStream> {
-        let (stream, _) = tokio_tungstenite::tungstenite::connect(self.0)?;
+        let (stream, _) = tungstenite::connect(self.0)?;
         Ok(stream)
     }
 


### PR DESCRIPTION
## Description

Re-exported does not have the TLS fully functional if we only enable it on `tokio-tungstenite`, so a direct dependency is required

### Linked issue

Fixes #4120

### Checklist

- [ ] make ci pass
