### PR TITLE
[BACKPORT] #4120: Do not use the `tungstenite` re-exported from `tokio_tungstenite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,11 +255,13 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f77d243921b0979fbbd728dd2d5162e68ac8252976797c24eb5b3a6af9090dc"
 dependencies = [
- "flate2",
  "http",
  "log",
  "native-tls",
+ "rustls",
+ "rustls-native-certs",
  "url",
+ "webpki-roots 0.25.3",
 ]
 
 [[package]]
@@ -2805,6 +2807,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing-flame",
  "tracing-subscriber",
+ "tungstenite",
  "url",
 ]
 
@@ -4711,6 +4714,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom 0.2.10",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,12 +4753,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.4",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4803,6 +4854,16 @@ name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secp256k1"
@@ -5578,6 +5639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5597,9 +5668,13 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.25.3",
 ]
 
 [[package]]
@@ -5847,10 +5922,13 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.8.5",
+ "rustls",
+ "rustls-native-certs",
  "sha1",
  "thiserror",
  "url",
  "utf-8",
+ "webpki-roots 0.24.0",
 ]
 
 [[package]]
@@ -5949,6 +6027,12 @@ name = "unsafe-libyaml"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -6580,6 +6664,21 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ futures = { version = "0.3.28", default-features = false }
 tokio = "1.33.0"
 tokio-stream = "0.1.14"
 tokio-tungstenite = "0.20.1"
+tungstenite = "0.20.1"
 
 crossbeam = "0.8.2"
 crossbeam-queue = "0.3.8"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,6 +22,31 @@ is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledg
 is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/iroha" }
 maintenance = { status = "actively-developed" }
 
+[features]
+# Use rustls by default to avoid OpenSSL dependency, simplifying compilation with musl
+default = ["tls-rustls-native-roots"]
+
+tls-native = [
+    "attohttpc/tls-native",
+    "tokio-tungstenite/native-tls",
+    "tungstenite/native-tls",
+]
+tls-native-vendored = [
+    "attohttpc/tls-native-vendored",
+    "tokio-tungstenite/native-tls-vendored",
+    "tungstenite/native-tls-vendored",
+]
+tls-rustls-native-roots = [
+    "attohttpc/tls-rustls-native-roots",
+    "tokio-tungstenite/rustls-tls-native-roots",
+    "tungstenite/rustls-tls-native-roots",
+]
+tls-rustls-webpki-roots = [
+    "attohttpc/tls-rustls-webpki-roots",
+    "tokio-tungstenite/rustls-tls-webpki-roots",
+    "tungstenite/rustls-tls-webpki-roots",
+]
+
 [dependencies]
 iroha_config = { workspace = true }
 iroha_crypto = { workspace = true }
@@ -31,7 +56,7 @@ iroha_logger = { workspace = true }
 iroha_telemetry = { workspace = true }
 iroha_version = { workspace = true, features = ["http"] }
 
-attohttpc = "0.26.1"
+attohttpc = { version = "0.26.1", default-features = false }
 eyre = { workspace = true }
 http = "0.2.9"
 url = { workspace = true }
@@ -44,7 +69,8 @@ displaydoc = { workspace = true }
 derive_more = { workspace = true }
 parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 tokio = { workspace = true, features = ["rt"] }
-tokio-tungstenite = { workspace = true, features = ["native-tls"] }
+tokio-tungstenite = { workspace = true }
+tungstenite = { workspace = true }
 futures-util = "0.3.28"
 
 [dev-dependencies]

--- a/client/src/http_default.rs
+++ b/client/src/http_default.rs
@@ -6,10 +6,8 @@ use attohttpc::{
 };
 use eyre::{eyre, Error, Result, WrapErr};
 use http::header::HeaderName;
-use tokio_tungstenite::tungstenite::{
-    client::IntoClientRequest, stream::MaybeTlsStream, WebSocket,
-};
-pub use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message as WebSocketMessage};
+use tungstenite::{client::IntoClientRequest, stream::MaybeTlsStream, WebSocket};
+pub use tungstenite::{Error as WebSocketError, Message as WebSocketMessage};
 use url::Url;
 
 use crate::http::{Method, RequestBuilder, Response};
@@ -137,7 +135,7 @@ pub struct DefaultWebSocketStreamRequest(http::Request<()>);
 impl DefaultWebSocketStreamRequest {
     /// Open [`WebSocketStream`] synchronously.
     pub fn connect(self) -> Result<WebSocketStream> {
-        let (stream, _) = tokio_tungstenite::tungstenite::connect(self.0)?;
+        let (stream, _) = tungstenite::connect(self.0)?;
         Ok(stream)
     }
 


### PR DESCRIPTION
## Description

Re-exported does not have the TLS fully functional if we only enable it on `tokio-tungstenite`, so a direct dependency is required

### Linked issue

Fixes #4120

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] make ci pass
