### PR TITLE
[ci]: Use default settings for Coveralls action

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -66,8 +66,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           file: lcov.info
-          compare-ref: ${{ github.base_ref }}
-          compare-sha: ${{ github.event.pull_request.base.sha}}
+          git-branch: ${{ github.base_ref }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-empty: true
           fail_ci_if_error: true


### PR DESCRIPTION
## Description

Use default settings for Coveralls action

### Linked issue
#4131 

### Benefits

Fix tests coverage should be compared against the iroha2-dev branch, not iroha2-stable.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
