### PR TITLE
[ci] #4184: Bump to 2024-01-12 toolchain & Revert to custom Coveralls settings

### DIFF
--- a/.github/workflows/iroha2-ci-image.yml
+++ b/.github/workflows/iroha2-ci-image.yml
@@ -15,7 +15,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: hyperledger/iroha2-ci:nightly-2023-06-25
+          tags: hyperledger/iroha2-ci:nightly-2024-01-12
           labels: commit=${{ github.sha }}
           file: Dockerfile.build
           # This context specification is required

--- a/.github/workflows/iroha2-dev-nightly.yml
+++ b/.github/workflows/iroha2-dev-nightly.yml
@@ -6,7 +6,7 @@ jobs:
   dockerhub:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -14,13 +14,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTUP_TOOLCHAIN: nightly-2023-06-25
+  RUSTUP_TOOLCHAIN: nightly-2024-01-12
 
 jobs:
   smart_contracts_analysis:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -38,7 +38,7 @@ jobs:
   workspace_analysis:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-dev-pr-ui.yml
+++ b/.github/workflows/iroha2-dev-pr-ui.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -19,13 +19,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTUP_TOOLCHAIN: nightly-2023-06-25
+  RUSTUP_TOOLCHAIN: nightly-2024-01-12
 
 jobs:
   tests:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -21,7 +21,7 @@ jobs:
   consistency:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -44,7 +44,7 @@ jobs:
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v3
       # TODO Remove this step #2165
@@ -66,15 +66,14 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           file: lcov.info
-          git-branch: ${{ github.base_ref }}
+          compare-ref: ${{ github.base_ref }}
+          compare-sha: ${{ github.event.pull_request.base.sha}}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-empty: true
-          fail_ci_if_error: true
 
   integration:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
@@ -87,7 +86,7 @@ jobs:
   unstable:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +100,7 @@ jobs:
     if: startsWith(github.head_ref, 'iroha2-pr-deploy/')
     runs-on: [self-hosted, Linux, iroha2-dev-push]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - name: Login to Soramitsu Harbor
@@ -131,7 +130,7 @@ jobs:
   client-cli-tests:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -11,7 +11,7 @@ jobs:
   registry:
     runs-on: [self-hosted, Linux, iroha2-dev-push]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -49,7 +49,7 @@ jobs:
   archive_binaries_and_schema:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -85,7 +85,7 @@ jobs:
     if: false
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -18,7 +18,7 @@ jobs:
   client-cli-tests:
     runs-on: [self-hosted, Linux, iroha2ci]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - name: Maximize build space
         run: |
@@ -76,7 +76,7 @@ jobs:
   java-api:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - name: Maximize build space
         run: |
@@ -130,7 +130,7 @@ jobs:
   long:
     runs-on: ubuntu-latest #[self-hosted, Linux]
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - name: Maximize build space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -11,7 +11,7 @@ jobs:
   registry:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -59,7 +59,7 @@ jobs:
   configs:
     runs-on: ubuntu-latest
     container:
-      image: hyperledger/iroha2-ci:nightly-2023-06-25
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
     permissions:
       contents: write
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN pacman -Syu --noconfirm --disable-download-timeout
 
 # Set up Rust toolchain
 RUN pacman -S rustup mold musl rust-musl wget --noconfirm --disable-download-timeout
-RUN rustup toolchain install nightly-2023-06-25
-RUN rustup default nightly-2023-06-25
+RUN rustup toolchain install nightly-2024-01-12
+RUN rustup default nightly-2024-01-12
 RUN rustup target add x86_64-unknown-linux-musl wasm32-unknown-unknown
 RUN rustup component add rust-src
 
@@ -33,7 +33,7 @@ RUN cargo build --target x86_64-unknown-linux-musl --profile deploy
 
 
 # final image
-FROM alpine:3.18
+FROM alpine:3.19
 
 ARG  STORAGE=/storage
 ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-musl/deploy

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -18,8 +18,8 @@ WORKDIR /client_cli/pytests
 COPY /client_cli/pytests/pyproject.toml /client_cli/pytests/poetry.lock $WORKDIR
 RUN poetry install
 
-RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
-RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu
+RUN rustup toolchain install nightly-2024-01-12-x86_64-unknown-linux-gnu
+RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
 RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -18,8 +18,8 @@ WORKDIR /client_cli/pytests
 COPY /client_cli/pytests/pyproject.toml /client_cli/pytests/poetry.lock $WORKDIR
 RUN poetry install
 
-RUN rustup toolchain install nightly-2023-06-25-x86_64-unknown-linux-gnu
-RUN rustup default nightly-2023-06-25-x86_64-unknown-linux-gnu
+RUN rustup toolchain install nightly-2024-01-12_64-unknown-linux-gnu
+RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
 RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -11,8 +11,8 @@ RUN pacman -Syu --noconfirm --disable-download-timeout
 
 # Set up Rust toolchain
 RUN pacman -S rustup mold wget --noconfirm --disable-download-timeout
-RUN rustup toolchain install nightly-2023-06-25
-RUN rustup default nightly-2023-06-25
+RUN rustup toolchain install nightly-2024-01-12
+RUN rustup default nightly-2024-01-12
 RUN rustup target add wasm32-unknown-unknown
 RUN rustup component add rust-src
 

--- a/wasm_builder/src/lib.rs
+++ b/wasm_builder/src/lib.rs
@@ -14,7 +14,7 @@ use eyre::{bail, eyre, Context as _, Result};
 use path_absolutize::Absolutize;
 
 /// Current toolchain used to build smartcontracts
-const TOOLCHAIN: &str = "+nightly-2023-06-25";
+const TOOLCHAIN: &str = "+nightly-2024-01-12";
 
 /// WASM Builder for smartcontracts (e.g. triggers and executors).
 ///


### PR DESCRIPTION
## Description
1. Update `iroha2ci-image` to the latest nightly toolchain (`2024-01-12`).
2. Bump `ci-contaier` in workflows to `hyperledger/iroha2-ci:nightly-2024-01-12`
3. Revert to the custom base branch comparison for Coveralls

### Linked issue
#4184 #4131 

### Benefits
1. Use the freshest rust nightly toolchain in CI
2. Attempt to normalize the Coveralls work

### IMPORTANT NOTE
Since we have updated the ci-image, WE MUST build and push it before the actual workflows will start to use it in CI. Previously we did it outside iroha repo (usually from forks) using the special HL DockerHub credentials that Hyperledger provided to us. Unfortunately, as Ry Jones told, they decided to remove these credentials since they can't continue to pay for that. Thus, we must to build and push the new ci-image asap when this PR will be merged.

### UPD
Ry Jones decided to give us one more year for external HL DockerHub account. So, the new ci-image 
has been already pushed from my fork.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
