### PR TITLE
[refactor] #4167: asset subcommand in client CLI to be consistent

### DIFF
--- a/client_cli/pytests/src/client_cli/client_cli.py
+++ b/client_cli/pytests/src/client_cli/client_cli.py
@@ -166,8 +166,9 @@ class ClientCli:
         """
         self.command.insert(3, 'asset')
         if asset_definition and account and value_of_value_type:
-            self.command.append('--account=' + account.name + '@' + asset_definition.domain)
-            self.command.append('--asset=' + repr(asset_definition))
+            self.command.append(
+                '--asset-id='
+                + asset_definition.name + '#' + account.domain + '#' + account.name + '@' + asset_definition.domain)
             self.command.append(
                 '--' + asset_definition.value_type.lower() + '=' + value_of_value_type)
             self.execute()
@@ -190,9 +191,9 @@ class ClientCli:
         """
         self.command.append('asset')
         self.command.append('transfer')
-        self.command.append('--from=' + repr(source_account))
         self.command.append('--to=' + repr(target_account))
-        self.command.append('--asset-id=' + repr(asset))
+        self.command.append(
+            '--asset-id=' + asset.name + '#' + source_account.domain + '#' + source_account.name + '@' + asset.domain)
         self.command.append('--quantity=' + quantity)
         self.execute()
         return self
@@ -211,8 +212,8 @@ class ClientCli:
         """
         self.command.append('asset')
         self.command.append('burn')
-        self.command.append('--account=' + repr(account))
-        self.command.append('--asset=' + repr(asset))
+        self.command.append(
+            '--asset-id=' + asset.name + '#' + account.domain + '#' + account.name + '@' + asset.domain)
         self.command.append('--quantity=' + quantity)
         self.execute()
         return self
@@ -230,7 +231,7 @@ class ClientCli:
         :return: The current ClientCli object.
         :rtype: ClientCli
         """
-        self.command.append('--id=' + asset + '#' + domain)
+        self.command.append('--definition-id=' + asset + '#' + domain)
         self.command.append('--value-type=' + value_type)
         self.execute()
         return self

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -795,8 +795,8 @@ mod asset {
     /// Register subcommand of asset
     #[derive(clap::Args, Debug)]
     pub struct Register {
-        /// Asset definition id for registering (in form of `name#domain_name')
-        #[arg(short, long)]
+        /// Asset definition id for registering (in form of `asset#domain_name`)
+        #[arg(long)]
         pub definition_id: AssetDefinitionId,
         /// Mintability of asset
         #[arg(short, long)]
@@ -835,7 +835,7 @@ mod asset {
     /// Command for minting asset in existing Iroha account
     #[derive(clap::Args, Debug)]
     pub struct Mint {
-        /// AssetId for the asset (in form of `asset##account@domain_name')
+        /// Asset id for the asset (in form of `asset##account@domain_name`)
         #[arg(long)]
         pub asset_id: AssetId,
         /// Quantity to mint
@@ -862,7 +862,7 @@ mod asset {
     /// Command for minting asset in existing Iroha account
     #[derive(clap::Args, Debug)]
     pub struct Burn {
-        /// AssetId for the asset (in form of `asset##account@domain_name')
+        /// Asset id for the asset (in form of `asset##account@domain_name`)
         #[arg(long)]
         pub asset_id: AssetId,
         /// Quantity to mint
@@ -889,10 +889,10 @@ mod asset {
     /// Transfer asset between accounts
     #[derive(clap::Args, Debug)]
     pub struct Transfer {
-        /// Account to which to transfer (in form `name@domain_name')
-        #[arg(short, long)]
+        /// Account to which to transfer (in form `name@domain_name`)
+        #[arg(long)]
         pub to: AccountId,
-        /// Asset id to transfer (in form like `asset##account@domain_name')
+        /// Asset id to transfer (in form like `asset##account@domain_name`)
         #[arg(long)]
         pub asset_id: AssetId,
         /// Quantity of asset as number
@@ -919,7 +919,7 @@ mod asset {
     /// Get info of asset
     #[derive(clap::Args, Debug)]
     pub struct Get {
-        /// AssetId for the asset (in form of `asset##account@domain_name')
+        /// Asset id for the asset (in form of `asset##account@domain_name`)
         #[arg(long)]
         pub asset_id: AssetId,
     }
@@ -966,7 +966,7 @@ mod asset {
 
     #[derive(clap::Args, Debug)]
     pub struct SetKeyValue {
-        /// AssetId for the Store asset (in form of `asset##account@domain_name')
+        /// Asset id for the Store asset (in form of `asset##account@domain_name`)
         #[clap(long)]
         pub asset_id: AssetId,
         /// The key for the store value
@@ -998,7 +998,7 @@ mod asset {
     }
     #[derive(clap::Args, Debug)]
     pub struct RemoveKeyValue {
-        /// AssetId for the Store asset (in form of `asset##account@domain_name')
+        /// Asset id for the Store asset (in form of `asset##account@domain_name`)
         #[clap(long)]
         pub asset_id: AssetId,
         /// The key for the store value
@@ -1017,7 +1017,7 @@ mod asset {
 
     #[derive(clap::Args, Debug)]
     pub struct GetKeyValue {
-        /// AssetId for the Store asset (in form of `asset##account@domain_name')
+        /// Asset id for the Store asset (in form of `asset##account@domain_name`)
         #[clap(long)]
         pub asset_id: AssetId,
         /// The key for the store value


### PR DESCRIPTION
## Description

In asset subcommand in the CLI operations like `mint`, `burn`, `get`, `transfer` had `register`. I refactored the subcommand to follow the suggestions in #4167.

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4167

<!-- Link if e.g. JIRA issue or  from another repository -->

### Use cases

#### Register
```bash
./iroha_client_cli asset  --definition-id="tea#looking_glass" --value-type=Quantity 
```
#### Mint
```bash
./iroha_client_cli asset mint --asset-id="tea##mad_hatter@looking_glass" --quantity="100"
```
#### Burn
```bash
./iroha_client_cli asset burn --asset-id="tea##mad_hatter@looking_glass" --quantity="10"
```

#### Get
```bash
./iroha_client_cli asset get --asset-id="tea##mad_hatter@looking_glass"  
```
#### Transfer
```bash
./iroha_client_cli asset transfer --to="white_rabbit@looking_glass" --asset-id="tea##mad_hatter@looking_glass" --quantity="5"  
```
### Checklist

- [X] I've read `CONTRIBUTING.md`
- [X] I've used the standard signed-off commit format (or will squash just before merging)
- [X] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [X] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->
