### PR TITLE
[feature] #4183: change endpoint to return Vec of matching transactions

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1018,8 +1018,7 @@ impl Client {
             .join(crate::config::torii::PENDING_TRANSACTION)
             .expect("Valid URI");
         let pagination = pagination.into_query_parameters();
-        let body = serde_json::to_vec(transaction.payload())
-            .wrap_err("Failed to serialize SignedTransaction.payload")?;
+        let body = transaction.encode();
 
         for _ in 0..retry_count {
             let response = DefaultRequestBuilder::new(HttpMethod::POST, url.clone())

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1000,31 +1000,27 @@ impl Client {
         )
     }
 
-    /// Find the original transaction in the pending local tx
-    /// queue.  Should be used for an MST case.  Takes pagination as
-    /// parameter.
+    /// Find the original transaction in the local pending tx queue.
+    /// Should be used for an MST case.
     ///
     /// # Errors
-    /// - if subscribing to websocket fails
-    pub fn get_original_transactions_with_pagination(
+    /// - if sending request fails
+    pub fn get_original_matching_transactions(
         &self,
         transaction: &SignedTransaction,
         retry_count: u32,
         retry_in: Duration,
-        pagination: Pagination,
     ) -> Result<Vec<SignedTransaction>> {
         let url = self
             .torii_url
             .join(crate::config::torii::MATCHING_PENDING_TRANSACTIONS)
             .expect("Valid URI");
-        let pagination = pagination.into_query_parameters();
         let body = transaction.encode();
 
         for _ in 0..retry_count {
             let response = DefaultRequestBuilder::new(HttpMethod::POST, url.clone())
                 .headers(self.headers.clone())
                 .header(http::header::CONTENT_TYPE, APPLICATION_JSON)
-                .params(pagination.clone())
                 .body(body.clone())
                 .build()?
                 .send()?;
@@ -1045,26 +1041,7 @@ impl Client {
                 ));
             }
         }
-        Ok(vec![])
-    }
-
-    /// Find the original transaction in the local pending tx queue.
-    /// Should be used for an MST case.
-    ///
-    /// # Errors
-    /// - if sending request fails
-    pub fn get_original_transactions(
-        &self,
-        transaction: &SignedTransaction,
-        retry_count: u32,
-        retry_in: Duration,
-    ) -> Result<Vec<SignedTransaction>> {
-        self.get_original_transactions_with_pagination(
-            transaction,
-            retry_count,
-            retry_in,
-            Pagination::default(),
-        )
+        Ok(Vec::new())
     }
 
     /// Get value of config on peer

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1006,7 +1006,7 @@ impl Client {
     ///
     /// # Errors
     /// - if subscribing to websocket fails
-    pub fn get_original_transaction_with_pagination(
+    pub fn get_original_transactions_with_pagination(
         &self,
         transaction: &SignedTransaction,
         retry_count: u32,
@@ -1015,7 +1015,7 @@ impl Client {
     ) -> Result<Vec<SignedTransaction>> {
         let url = self
             .torii_url
-            .join(crate::config::torii::PENDING_TRANSACTIONS)
+            .join(crate::config::torii::MATCHING_PENDING_TRANSACTIONS)
             .expect("Valid URI");
         let pagination = pagination.into_query_parameters();
         let body = transaction.encode();
@@ -1053,13 +1053,13 @@ impl Client {
     ///
     /// # Errors
     /// - if sending request fails
-    pub fn get_original_transaction(
+    pub fn get_original_transactions(
         &self,
         transaction: &SignedTransaction,
         retry_count: u32,
         retry_in: Duration,
     ) -> Result<Vec<SignedTransaction>> {
-        self.get_original_transaction_with_pagination(
+        self.get_original_transactions_with_pagination(
             transaction,
             retry_count,
             retry_in,

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -83,10 +83,9 @@ fn multisignature_transactions_should_wait_for_all_signatures() -> Result<()> {
     let instructions = [mint_asset];
     let transaction = client_2.build_transaction(instructions, UnlimitedMetadata::new())?;
     let transaction = client_2
-        .get_original_transactions(&transaction, 3, Duration::from_millis(100))?
-        .last()
-        .expect("Found no pending transaction for this account.")
-        .clone();
+        .get_original_matching_transactions(&transaction, 3, Duration::from_millis(100))?
+        .pop()
+        .expect("Found no pending transaction for this account.");
     client_2.submit_transaction(&client_2.sign_transaction(transaction)?)?;
     thread::sleep(pipeline_time);
     let assets = client_1

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -84,7 +84,9 @@ fn multisignature_transactions_should_wait_for_all_signatures() -> Result<()> {
     let transaction = client_2.build_transaction(instructions, UnlimitedMetadata::new())?;
     let transaction = client_2
         .get_original_transaction(&transaction, 3, Duration::from_millis(100))?
-        .expect("Found no pending transaction for this account.");
+        .last()
+        .expect("Found no pending transaction for this account.")
+        .clone();
     client_2.submit_transaction(&client_2.sign_transaction(transaction)?)?;
     thread::sleep(pipeline_time);
     let assets = client_1

--- a/client/tests/integration/multisignature_transaction.rs
+++ b/client/tests/integration/multisignature_transaction.rs
@@ -83,7 +83,7 @@ fn multisignature_transactions_should_wait_for_all_signatures() -> Result<()> {
     let instructions = [mint_asset];
     let transaction = client_2.build_transaction(instructions, UnlimitedMetadata::new())?;
     let transaction = client_2
-        .get_original_transaction(&transaction, 3, Duration::from_millis(100))?
+        .get_original_transactions(&transaction, 3, Duration::from_millis(100))?
         .last()
         .expect("Found no pending transaction for this account.")
         .clone();

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -263,7 +263,7 @@ fn submit(
     let transactions = if context.skip_mst_check() {
         vec![tx]
     } else {
-        match iroha_client.get_original_transactions(
+        match iroha_client.get_original_matching_transactions(
             &tx,
             RETRY_COUNT_MST,
             RETRY_IN_MST,

--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -263,7 +263,7 @@ fn submit(
     let transactions = if context.skip_mst_check() {
         vec![tx]
     } else {
-        match iroha_client.get_original_transaction(
+        match iroha_client.get_original_transactions(
             &tx,
             RETRY_COUNT_MST,
             RETRY_IN_MST,

--- a/config/src/torii.rs
+++ b/config/src/torii.rs
@@ -62,7 +62,7 @@ pub mod uri {
     /// The web socket uri used to subscribe to blocks stream.
     pub const BLOCKS_STREAM: &str = "block/stream";
     /// Get pending transactions.
-    pub const PENDING_TRANSACTION: &str = "pending_transaction";
+    pub const PENDING_TRANSACTIONS: &str = "pending_transactions";
     /// The URI for local config changing inspecting
     pub const CONFIGURATION: &str = "configuration";
     /// URI to report status for administration

--- a/config/src/torii.rs
+++ b/config/src/torii.rs
@@ -62,7 +62,7 @@ pub mod uri {
     /// The web socket uri used to subscribe to blocks stream.
     pub const BLOCKS_STREAM: &str = "block/stream";
     /// Get pending transactions.
-    pub const PENDING_TRANSACTIONS: &str = "pending_transactions";
+    pub const PENDING_TRANSACTION: &str = "pending_transaction";
     /// The URI for local config changing inspecting
     pub const CONFIGURATION: &str = "configuration";
     /// URI to report status for administration

--- a/config/src/torii.rs
+++ b/config/src/torii.rs
@@ -62,7 +62,7 @@ pub mod uri {
     /// The web socket uri used to subscribe to blocks stream.
     pub const BLOCKS_STREAM: &str = "block/stream";
     /// Get pending transactions.
-    pub const PENDING_TRANSACTIONS: &str = "pending_transactions";
+    pub const MATCHING_PENDING_TRANSACTIONS: &str = "matching_pending_transactions";
     /// The URI for local config changing inspecting
     pub const CONFIGURATION: &str = "configuration";
     /// URI to report status for administration

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -123,6 +123,19 @@ pub mod model {
         pub metadata: UnlimitedMetadata,
     }
 
+    impl TransactionPayload {
+        /// Check if two transactions are the same. Compare their contents excluding the creation time.
+        pub fn equals_excluding_creation_time(
+            first: &TransactionPayload,
+            second: &TransactionPayload,
+        ) -> bool {
+            first.authority() == second.authority()
+                && first.instructions() == second.instructions()
+                && first.time_to_live() == second.time_to_live()
+                && first.metadata().eq(second.metadata())
+        }
+    }
+
     /// Container for limits that transactions must obey.
     #[derive(
         Debug,

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -123,19 +123,6 @@ pub mod model {
         pub metadata: UnlimitedMetadata,
     }
 
-    impl TransactionPayload {
-        /// Check if two transactions are the same. Compare their contents excluding the creation time.
-        pub fn equals_excluding_creation_time(
-            first: &TransactionPayload,
-            second: &TransactionPayload,
-        ) -> bool {
-            first.authority() == second.authority()
-                && first.instructions() == second.instructions()
-                && first.time_to_live() == second.time_to_live()
-                && first.metadata().eq(second.metadata())
-        }
-    }
-
     /// Container for limits that transactions must obey.
     #[derive(
         Debug,

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -138,11 +138,10 @@ impl Torii {
                         ))
                         .and(body::versioned()),
                 )
-                .or(endpoint4(
+                .or(endpoint3(
                     routing::handle_pending_transactions,
                     warp::path(uri::MATCHING_PENDING_TRANSACTIONS)
                         .and(add_state!(self.queue, self.sumeragi))
-                        .and(routing::paginate())
                         .and(body::versioned()),
                 ))
                 .or(endpoint3(

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -90,17 +90,11 @@ impl Torii {
             .and_then(|| async { Ok::<_, Infallible>(routing::handle_health()) });
 
         let get_router = warp::get().and(
-            endpoint3(
-                routing::handle_pending_transactions,
-                warp::path(uri::PENDING_TRANSACTIONS)
-                    .and(add_state!(self.queue, self.sumeragi,))
-                    .and(routing::paginate()),
-            )
-            .or(warp::path(uri::CONFIGURATION)
+            warp::path(uri::CONFIGURATION)
                 .and(add_state!(self.kiso))
                 .and_then(|kiso| async move {
                     Ok::<_, Infallible>(WarpResult(routing::handle_get_configuration(kiso).await))
-                })),
+                }),
         );
 
         #[cfg(feature = "telemetry")]
@@ -144,6 +138,13 @@ impl Torii {
                         ))
                         .and(body::versioned()),
                 )
+                .or(endpoint4(
+                    routing::handle_pending_transactions,
+                    warp::path(uri::PENDING_TRANSACTION)
+                        .and(add_state!(self.queue, self.sumeragi))
+                        .and(routing::paginate())
+                        .and(warp::body::json()),
+                ))
                 .or(endpoint3(
                     routing::handle_queries,
                     warp::path(uri::QUERY)

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -143,7 +143,7 @@ impl Torii {
                     warp::path(uri::PENDING_TRANSACTION)
                         .and(add_state!(self.queue, self.sumeragi))
                         .and(routing::paginate())
-                        .and(warp::body::json()),
+                        .and(body::versioned()),
                 ))
                 .or(endpoint3(
                     routing::handle_queries,

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -140,7 +140,7 @@ impl Torii {
                 )
                 .or(endpoint4(
                     routing::handle_pending_transactions,
-                    warp::path(uri::PENDING_TRANSACTION)
+                    warp::path(uri::PENDING_TRANSACTIONS)
                         .and(add_state!(self.queue, self.sumeragi))
                         .and(routing::paginate())
                         .and(body::versioned()),

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -140,7 +140,7 @@ impl Torii {
                 )
                 .or(endpoint4(
                     routing::handle_pending_transactions,
-                    warp::path(uri::PENDING_TRANSACTIONS)
+                    warp::path(uri::MATCHING_PENDING_TRANSACTIONS)
                         .and(add_state!(self.queue, self.sumeragi))
                         .and(routing::paginate())
                         .and(body::versioned()),

--- a/torii/src/routing.rs
+++ b/torii/src/routing.rs
@@ -10,8 +10,7 @@ use eyre::{eyre, WrapErr};
 use futures::TryStreamExt;
 use iroha_config::client_api::ConfigurationDTO;
 use iroha_core::{
-    query::{pagination::Paginate, store::LiveQueryStoreHandle},
-    smartcontracts::query::ValidQueryRequest,
+    query::store::LiveQueryStoreHandle, smartcontracts::query::ValidQueryRequest,
     sumeragi::SumeragiHandle,
 };
 use iroha_data_model::{
@@ -162,14 +161,12 @@ fn transaction_payload_eq_excluding_creation_time(
 pub async fn handle_pending_transactions(
     queue: Arc<Queue>,
     sumeragi: SumeragiHandle,
-    pagination: Pagination,
     transaction: SignedTransaction,
 ) -> Result<Scale<Vec<SignedTransaction>>> {
     let query_response = sumeragi.apply_wsv(|wsv| {
         queue
             .all_transactions(wsv)
             .map(Into::into)
-            .paginate(pagination)
             .filter(|current_transaction: &SignedTransaction| {
                 transaction_payload_eq_excluding_creation_time(
                     current_transaction.payload(),

--- a/torii/src/routing.rs
+++ b/torii/src/routing.rs
@@ -152,7 +152,7 @@ pub async fn handle_pending_transactions(
     queue: Arc<Queue>,
     sumeragi: SumeragiHandle,
     pagination: Pagination,
-    payload: TransactionPayload,
+    transaction: SignedTransaction,
 ) -> Result<Scale<Option<SignedTransaction>>> {
     let query_response = sumeragi.apply_wsv(|wsv| {
         queue
@@ -162,7 +162,7 @@ pub async fn handle_pending_transactions(
             .find(|current_transaction: &SignedTransaction| {
                 TransactionPayload::equals_excluding_creation_time(
                     current_transaction.payload(),
-                    &payload,
+                    transaction.payload(),
                 )
             })
     });


### PR DESCRIPTION
## Description

Update endpoint that returned `Vec<SignedTransaction>` that were in a queue to return `Vec<SignedTransaction>` that are equal (by equality function) to our demanded transaction instead.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4183 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
It decreases the amount of traffic through the network.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
