### PR TITLE
[feature] #4089: Add profiling support to iroha

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 **/target
-Dockerfile
+Dockerfile*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,45 @@ tokio-console http://127.0.0.1:5555
 
 </details>
 
+### Profiling
+
+<details> <summary> Expand to learn ho to profile iroha. </summary>
+
+To optimize performance it's useful to profile iroha.
+
+To do that you should compile iroha with `profiling` profile and with `wasm_profiling` compilation flag: 
+
+```bash
+RUSTFLAGS="-C force-frame-pointers=on --cfg wasm_profiling" cargo build --profile profiling
+```
+
+Then start iroha and attach profiler of your choice to the iroha pid.
+
+Alternatively it's possible to build iroha inside docker with profiler support and profile iroha this way.
+
+```bash
+docker build -f Dockerfile.glibc --build-arg="PROFILE=profiling" --build-arg='RUSTFLAGS=-C force-frame-pointers=on --cfg wasm_profiling' -t iroha2:profiling .
+```
+
+E.g. using perf (available only on linux):
+
+```bash
+# to capture profile
+sudo perf record -g -p <PID>
+# to analyze profile
+sudo perf report
+```
+
+To be able to observe profile of the executor during iroha profiling, executor should be compiled without stripping symbols.
+It can be done by running:
+
+```bash
+# compile executor without optimizations
+cargo run --bin iroha_wasm_builder_cli -- build ./path/to/executor --outfile executor.wasm
+```
+
+</details>
+
 ## Style Guides
 
 Please follow these guidelines when you make code contributions to our project:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,3 +253,7 @@ members = [
 inherits = "release"
 strip = "symbols"
 lto = true
+
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -1,16 +1,13 @@
-#base stage
-FROM archlinux:base-devel AS builder
+# base stage
+FROM debian:bookworm-slim AS builder
 
-# Force-sync packages, install archlinux-keyring, repopulate keys
-RUN pacman -Syy
-RUN pacman -S archlinux-keyring --noconfirm --disable-download-timeout
-RUN rm -rf /etc/pacman.d/gnupg/* && pacman-key --init && pacman-key --populate archlinux
+# install required packages
+RUN apt-get update -y && \
+     apt-get install -y curl build-essential mold
 
-# Install updates
-RUN pacman -Syu --noconfirm --disable-download-timeout
-
-# Set up Rust toolchain
-RUN pacman -S rustup mold wget --noconfirm --disable-download-timeout
+# set up Rust toolchain
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup toolchain install nightly-2024-01-12
 RUN rustup default nightly-2024-01-12
 RUN rustup target add wasm32-unknown-unknown
@@ -19,15 +16,16 @@ RUN rustup component add rust-src
 # builder stage
 WORKDIR /iroha
 COPY . .
-RUN mold --run cargo build --target x86_64-unknown-linux-gnu --profile deploy
+ARG PROFILE="deploy"
+ARG RUSTFLAGS=""
+RUN RUSTFLAGS="${RUSTFLAGS}" mold --run cargo build --target x86_64-unknown-linux-gnu --profile "${PROFILE}"
 
 # final image
-FROM alpine:3.18
+FROM debian:bookworm-slim
 
-ENV  GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
-ENV  GLIBC_VERSION=2.35-r1
+ARG PROFILE="deploy"
 ARG  STORAGE=/storage
-ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-gnu/deploy
+ARG  TARGET_DIR=/iroha/target/x86_64-unknown-linux-gnu/${PROFILE}
 ENV  BIN_PATH=/usr/local/bin/
 ENV  CONFIG_DIR=/config
 ENV  IROHA2_CONFIG_PATH=$CONFIG_DIR/config.json
@@ -39,12 +37,9 @@ ENV  UID=1001
 ENV  GID=1001
 
 RUN  set -ex && \
-     apk --update add libstdc++ curl ca-certificates gcompat && \
-     for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
-         do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-     apk add --force-overwrite --allow-untrusted /tmp/*.apk && \
-     rm -v /tmp/*.apk && \
-     addgroup -g $GID $USER && \
+     apt-get update -y && \
+     apt-get install -y curl ca-certificates && \
+     addgroup --gid $GID $USER && \
      adduser \
      --disabled-password \
      --gecos "" \

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -274,6 +274,10 @@ fn create_config() -> Result<Config> {
         .consume_fuel(true)
         .cache_config_load_default()
         .map_err(Error::Initialization)?;
+    #[cfg(wasm_profiling)]
+    {
+        config.profiler(wasmtime::ProfilingStrategy::PerfMap);
+    }
     Ok(config)
 }
 


### PR DESCRIPTION
## Description

Add compilation profile `profiling` which preserve some debuginfo + force frame pointers (used by porfilers to symbolize functions in the stack trace).

Add dockerfile with profiling support (used glibc instead of musl to be able to integrate with parca).  

Add support to profile running wasm smartcontracts.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4083 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits 

Data driven approach to optimization.

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
