### PR TITLE
[ci]: Add glibc image publishing workflow

### DIFF
--- a/.github/workflows/iroha2-ci-image.yml
+++ b/.github/workflows/iroha2-ci-image.yml
@@ -1,6 +1,11 @@
 name: I2::CI::Publish
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      IROHA2_CI_DOCKERFILE:
+        required: true
+        default: Dockerfile.build
 
 jobs:
   dockerhub:
@@ -17,6 +22,6 @@ jobs:
           push: true
           tags: hyperledger/iroha2-ci:nightly-2024-01-12
           labels: commit=${{ github.sha }}
-          file: Dockerfile.build
+          file: ${{ github.event.inputs.IROHA2_CI_DOCKERFILE }}
           # This context specification is required
           context: .

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -69,6 +69,13 @@ jobs:
           compare-ref: ${{ github.base_ref }}
           compare-sha: ${{ github.event.pull_request.base.sha}}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      # (Temporally) Add the parallel coverage upload to Codecov to compare the results with Coveralls
+      # - name: Upload coverage to codecov.io
+      #   uses: codecov/codecov-action@v3.1.4
+      #   with:
+      #     files: lcov.info
+      #     commit_parent: ${{ github.event.pull_request.base.sha }}
+      #     fail_ci_if_error: false
 
   integration:
     runs-on: [self-hosted, Linux, iroha2ci]

--- a/.github/workflows/iroha2-profiling-image.yml
+++ b/.github/workflows/iroha2-profiling-image.yml
@@ -1,0 +1,56 @@
+name: I2::Profiling::Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      IROHA2_IMAGE_TAG:
+        required: true
+        default: stable
+      IROHA2_IMAGE_RELEASE:
+        required: true
+      IROHA2_DOCKERFILE:
+        required: true
+        default: Dockerfile.glibc
+      IROHA2_PROFILE:
+        required: true
+        default: profiling
+      IROHA2_RUSTFLAGS:
+        required: false
+        default: -C force-frame-pointers=on --cfg wasm_profiling
+
+jobs:
+  registry:
+    runs-on: [self-hosted, Linux, iroha2-dev-push]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Soramitsu Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: docker.soramitsu.co.jp
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        if: always()
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      - name: Build and push iroha2:profiling-image
+        uses: docker/build-push-action@v5
+        if: always()
+        with:
+          push: true
+          tags: |
+            hyperledger/iroha2:${{ github.event.inputs.IROHA2_IMAGE_TAG }}-${{ github.event.inputs.IROHA2_IMAGE_RELEASE }}-profiling
+            docker.soramitsu.co.jp/iroha2/iroha2:${{ github.event.inputs.IROHA2_IMAGE_TAG }}-${{ github.event.inputs.IROHA2_IMAGE_RELEASE }}-profiling
+          labels: commit=${{ github.sha }}
+          build-args: |
+            "PROFILE=${{ github.event.inputs.IROHA2_PROFILE }}"
+            "RUSTFLAGS=${{ github.event.inputs.IROHA2_RUSTFLAGS }}"
+          file: ${{ github.event.inputs.IROHA2_DOCKERFILE }}
+          # This context specification is required
+          context: .


### PR DESCRIPTION
## Description
1. Add `I2::GLIBC::Publish` worflow
2. Update `I2::CI::Publish` to make this parameterized

### Linked issue
#4131 #4083 

### Benefits

1. Build and push iroha2 `glibc` image manually
2. Make `I2::CI::Publish` workflow parameterized

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
