### PR TITLE
[documentation] #4234: Iroha 2 README YAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Iroha has the following features:
 5. Validation of business rules for transactions and queries in the system
 6. Multisignature transactions
 
-Iroha is _Crash Fault Tolerant_ and has its own consensus algorithm - [YAC](https://arxiv.org/pdf/1809.00554.pdf).
-It is replaced with a new algorithm, [Sumeragi](https://iroha.tech/#sumeragi) in [Iroha 2](https://github.com/hyperledger/iroha/tree/iroha2-dev).
+Iroha is _Crash Fault Tolerant_ and has its own consensus algorithm — [YAC](https://arxiv.org/pdf/1809.00554.pdf).
+In Iroha 2, it is replaced with a new algorithm — [Sumeragi](https://iroha.tech/#sumeragi).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Iroha has the following features:
 5. Validation of business rules for transactions and queries in the system
 6. Multisignature transactions
 
-Iroha is _Crash Fault Tolerant_ and has its own consensus algorithm - [YAC](https://arxiv.org/pdf/1809.00554.pdf)
+Iroha is _Crash Fault Tolerant_ and has its own consensus algorithm - [YAC](https://arxiv.org/pdf/1809.00554.pdf).
+It is replaced with a new algorithm, [Sumeragi](https://iroha.tech/#sumeragi) in [Iroha 2](https://github.com/hyperledger/iroha/tree/iroha2-dev).
 
 ## Documentation
 


### PR DESCRIPTION
A one-liner solution for https://github.com/hyperledger/iroha/issues/4234:

> It seems I1 README is being displayed. I intend to add a small link to iroha.tech and ignore a [whitepaper](https://github.com/hyperledger/iroha/blob/iroha2-dev/docs/source/iroha_2_whitepaper.md#28-consensus) as it may be revised.