### PR TITLE
Hide the versioned struct fields from the public API

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1658,11 +1658,11 @@ mod tests {
         let tx2 = {
             let mut tx =
                 TransactionBuilder::new(client.chain_id.clone(), client.account_id.clone())
-                    .with_executable(tx1.payload().instructions.clone())
-                    .with_metadata(tx1.payload().metadata.clone());
+                    .with_executable(tx1.transaction().payload.instructions.clone())
+                    .with_metadata(tx1.transaction().payload.metadata.clone());
 
-            tx.set_creation_time(tx1.payload().creation_time_ms);
-            if let Some(nonce) = tx1.payload().nonce {
+            tx.set_creation_time(tx1.transaction().payload.creation_time_ms);
+            if let Some(nonce) = tx1.transaction().payload.nonce {
                 tx.set_nonce(nonce);
             }
             if let Some(transaction_ttl) = client.transaction_ttl {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1626,6 +1626,55 @@ mod tests {
     const ENCRYPTED_CREDENTIALS: &str = "bWFkX2hhdHRlcjppbG92ZXRlYQ==";
 
     #[test]
+    fn txs_same_except_for_nonce_have_different_hashes() {
+        let (public_key, private_key) = KeyPair::generate().unwrap().into();
+
+        let cfg = ConfigurationProxy {
+            chain_id: Some(ChainId::new("0")),
+            public_key: Some(public_key),
+            private_key: Some(private_key),
+            account_id: Some(
+                "alice@wonderland"
+                    .parse()
+                    .expect("This account ID should be valid"),
+            ),
+            torii_api_url: Some(format!("http://{DEFAULT_API_ADDR}").parse().unwrap()),
+            add_transaction_nonce: Some(true),
+            ..ConfigurationProxy::default()
+        }
+            .build()
+            .expect("Client config should build as all required fields were provided");
+        let client = Client::new(&cfg).expect("Invalid client configuration");
+
+        let build_transaction = || {
+            client
+                .build_transaction(Vec::<InstructionBox>::new(), UnlimitedMetadata::new())
+                .unwrap()
+        };
+        let tx1 = build_transaction();
+        let tx2 = build_transaction();
+        assert_ne!(tx1.transaction().payload.hash(), tx2.transaction().payload.hash());
+
+        let tx2 = {
+            let mut tx =
+                TransactionBuilder::new(client.chain_id.clone(), client.account_id.clone())
+                    .with_executable(tx1.payload().instructions.clone())
+                    .with_metadata(tx1.payload().metadata.clone());
+
+            tx.set_creation_time(tx1.payload().creation_time_ms);
+            if let Some(nonce) = tx1.payload().nonce {
+                tx.set_nonce(nonce);
+            }
+            if let Some(transaction_ttl) = client.transaction_ttl {
+                tx.set_ttl(transaction_ttl);
+            }
+
+            client.sign_transaction(tx).unwrap()
+        };
+        assert_eq!(tx1.transaction().payload.hash(), tx2.transaction().payload.hash());
+    }
+
+    #[test]
     fn authorization_header() {
         let basic_auth = BasicAuth {
             web_login: WebLogin::from_str(LOGIN).expect("Failed to create valid `WebLogin`"),

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -52,7 +52,7 @@ fn test_with_instruction_and_status_and_port(
     // Given
     let submitter = client;
     let transaction = submitter.build_transaction(instruction, UnlimitedMetadata::new())?;
-    let hash = transaction.payload().hash();
+    let hash = transaction.hash_payload();
     let mut handles = Vec::new();
     for listener in clients {
         let checker = Checker { listener, hash };

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -52,7 +52,7 @@ fn test_with_instruction_and_status_and_port(
     // Given
     let submitter = client;
     let transaction = submitter.build_transaction(instruction, UnlimitedMetadata::new())?;
-    let hash = transaction.hash_payload();
+    let hash = transaction.transaction().payload.hash();
     let mut handles = Vec::new();
     for listener in clients {
         let checker = Checker { listener, hash };

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -903,7 +903,7 @@ mod tests {
             .with_executable(tx.0.transaction().payload.instructions.clone());
 
             new_tx
-                .set_creation_time(tx.0.hash_payload().creation_time_ms + 2 * future_threshold_ms);
+                .set_creation_time(tx.0.transaction().payload.creation_time_ms + 2 * future_threshold_ms);
 
             let new_tx = new_tx.sign(alice_key).expect("Failed to sign.");
             let limits = TransactionLimits {

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -900,9 +900,10 @@ mod tests {
                 chain_id.clone(),
                 AccountId::from_str(alice_id).expect("Valid"),
             )
-            .with_executable(tx.0.payload().instructions.clone());
+            .with_executable(tx.0.hash_payload().instructions.clone());
 
-            new_tx.set_creation_time(tx.0.payload().creation_time_ms + 2 * future_threshold_ms);
+            new_tx
+                .set_creation_time(tx.0.hash_payload().creation_time_ms + 2 * future_threshold_ms);
 
             let new_tx = new_tx.sign(alice_key).expect("Failed to sign.");
             let limits = TransactionLimits {

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -900,7 +900,7 @@ mod tests {
                 chain_id.clone(),
                 AccountId::from_str(alice_id).expect("Valid"),
             )
-            .with_executable(tx.0.hash_payload().instructions.clone());
+            .with_executable(tx.0.transaction().payload.instructions.clone());
 
             new_tx
                 .set_creation_time(tx.0.hash_payload().creation_time_ms + 2 * future_threshold_ms);

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -165,9 +165,9 @@ pub mod model {
     #[ffi_type]
     pub struct SignedTransactionV1 {
         /// [`iroha_crypto::SignatureOf`]<[`TransactionPayload`]>.
-        pub(super) signatures: SignaturesOf<TransactionPayload>,
+        pub signatures: SignaturesOf<TransactionPayload>,
         /// [`Transaction`] payload.
-        pub(super) payload: TransactionPayload,
+        pub payload: TransactionPayload,
     }
 
     /// Transaction Value used in Instructions and Queries
@@ -259,17 +259,16 @@ declare_versioned!(SignedTransaction 1..2, Debug, Display, Clone, PartialEq, Eq,
 declare_versioned!(SignedTransaction 1..2, Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, FromVariant, IntoSchema);
 
 impl SignedTransaction {
-    /// Return transaction payload
-    // FIXME: Leaking concrete type TransactionPayload from Versioned container. Payload should be versioned
-    pub fn payload(&self) -> &TransactionPayload {
+    /// Define the version of SignedTransaction
+    /// Created to provide access to the transaction payload
+    // TODO: Make a correct implementation
+    pub fn transaction(&self) -> &SignedTransactionV1 {
         let SignedTransaction::V1(tx) = self;
-        &tx.payload
+        tx
     }
-
     /// Return transaction signatures
     pub fn signatures(&self) -> &SignaturesOf<TransactionPayload> {
-        let SignedTransaction::V1(tx) = self;
-        &tx.signatures
+        &self.transaction().signatures
     }
 
     /// Calculate transaction [`Hash`](`iroha_crypto::HashOf`).
@@ -303,7 +302,7 @@ impl SignedTransaction {
     #[cfg(feature = "std")]
     #[cfg(feature = "transparent_api")]
     pub fn merge_signatures(&mut self, other: Self) -> bool {
-        if self.payload().hash() != other.payload().hash() {
+        if self.transaction().payload != other.transaction().payload {
             return false;
         }
 
@@ -340,7 +339,7 @@ impl TransactionValue {
     /// [`Transaction`] payload.
     #[inline]
     pub fn payload(&self) -> &TransactionPayload {
-        self.value.payload()
+        &self.value.transaction().payload
     }
 
     /// [`iroha_crypto::SignatureOf`]<[`TransactionPayload`]>.

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -260,7 +260,7 @@ declare_versioned!(SignedTransaction 1..2, Debug, Display, Clone, PartialEq, Eq,
 
 impl SignedTransaction {
     /// Define the version of SignedTransaction
-    /// Created to provide access to the transaction payload
+    /// Created to provide access to the transaction payload only to internal libs
     // TODO: Make a correct implementation
     pub fn transaction(&self) -> &SignedTransactionV1 {
         let SignedTransaction::V1(tx) = self;
@@ -302,7 +302,7 @@ impl SignedTransaction {
     #[cfg(feature = "std")]
     #[cfg(feature = "transparent_api")]
     pub fn merge_signatures(&mut self, other: Self) -> bool {
-        if self.transaction().payload != other.transaction().payload {
+        if self.transaction().payload.hash() != other.transaction().payload.hash() {
             return false;
         }
 

--- a/data_model/src/visit.rs
+++ b/data_model/src/visit.rs
@@ -154,7 +154,7 @@ pub fn visit_transaction<V: Visit + ?Sized>(
     authority: &AccountId,
     transaction: &SignedTransaction,
 ) {
-    match transaction.payload().instructions() {
+    match transaction.transaction().payload.instructions() {
         Executable::Wasm(wasm) => visitor.visit_wasm(authority, wasm),
         Executable::Instructions(instructions) => {
             for isi in instructions {

--- a/smart_contract/executor/src/default.rs
+++ b/smart_contract/executor/src/default.rs
@@ -73,7 +73,7 @@ pub fn visit_transaction<V: Validate + ?Sized>(
     authority: &AccountId,
     transaction: &SignedTransaction,
 ) {
-    match transaction.payload().instructions() {
+    match transaction.transaction().payload.instructions() {
         Executable::Wasm(wasm) => executor.visit_wasm(authority, wasm),
         Executable::Instructions(instructions) => {
             for isi in instructions {

--- a/torii/src/routing.rs
+++ b/torii/src/routing.rs
@@ -169,8 +169,8 @@ pub async fn handle_pending_transactions(
             .map(Into::into)
             .filter(|current_transaction: &SignedTransaction| {
                 transaction_payload_eq_excluding_creation_time(
-                    current_transaction.payload(),
-                    transaction.payload(),
+                    &current_transaction.transaction().payload,
+                    &transaction.transaction().payload,
                 )
             })
             .collect()


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->

* SignedTransaction:
Payload is hidden by transparent API
(method transaction() returns a SignedTransactionV1 struct, which fields are hidden by transparent API)

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

* Closes #3887  <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
