### PR TITLE
Fixing warning in command SubtractAssetQuantity, removing unnecessarily includes, small documentation change

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -167,6 +167,7 @@ Git Style Guide
 -  First line of commit message must contain summary of work done,
    second line must contain empty line, third and other lines can
    contain list of commit changes
+-  When merging to destination branche: use **Squash and merge**
 
 C++ Style Guide
 ~~~~~~~~~~~~~~~

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -45,8 +45,8 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod tidy -e # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
+RUN go mod init # according to: https://golangdocs.com/create-go-modules
 
 ## pip3 contains fresher versions of packages than apt
 RUN pip3 install --no-cache-dir cmake ninja

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -44,9 +44,10 @@ RUN curl https://dl.google.com/go/go1.17.2.linux-$(dpkg --print-architecture).ta
 ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
+RUN go install github.com/golang/protobuf/protoc-gen-go
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
-RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules
+# RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules
 
 ## pip3 contains fresher versions of packages than apt
 RUN pip3 install --no-cache-dir cmake ninja

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -45,7 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod download github.com/golang/protobuf
+RUN go mod tidy # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## pip3 contains fresher versions of packages than apt

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -45,6 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
+RUN go mod download github.com/golang/protobuf
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## pip3 contains fresher versions of packages than apt

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
-RUN go mod init # according to: https://golangdocs.com/create-go-modules
+RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules
 
 ## pip3 contains fresher versions of packages than apt
 RUN pip3 install --no-cache-dir cmake ninja

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -44,7 +44,7 @@ RUN curl https://dl.google.com/go/go1.17.2.linux-$(dpkg --print-architecture).ta
 ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
-RUN go install github.com/golang/protobuf/protoc-gen-go
+RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 # RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -45,7 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod tidy # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
+RUN go mod tidy -e # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## pip3 contains fresher versions of packages than apt

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -44,9 +44,9 @@ RUN curl -fL https://golang.org/dl/go1.17.2.linux-$(dpkg --print-architecture).t
 ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
+RUN go install github.com/golang/protobuf/protoc-gen-go
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
-RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules
 
 ## Rust-lang stuff for iroha+ursa
 ENV RUSTUP_HOME=/opt/rust

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -fL https://golang.org/dl/go1.17.2.linux-$(dpkg --print-architecture).t
 ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
-RUN go install github.com/golang/protobuf/protoc-gen-go
+RUN go install github.com/golang/protobuf/protoc-gen-go@latest
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -45,7 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod download github.com/golang/protobuf
+RUN go mod tidy # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## Rust-lang stuff for iroha+ursa

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -45,6 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
+RUN go mod download github.com/golang/protobuf
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## Rust-lang stuff for iroha+ursa

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
-RUN go mod init # according to: https://golangdocs.com/create-go-modules
+RUN go mod init $(go env GOPATH) # according to: https://golangdocs.com/create-go-modules
 
 ## Rust-lang stuff for iroha+ursa
 ENV RUSTUP_HOME=/opt/rust

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -45,7 +45,7 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod tidy # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
+RUN go mod tidy -e # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
 
 ## Rust-lang stuff for iroha+ursa

--- a/docker/iroha-builder/Dockerfile
+++ b/docker/iroha-builder/Dockerfile
@@ -45,8 +45,8 @@ ENV GOPATH=/opt/gopath
 RUN mkdir ${GOPATH}
 ENV PATH=${PATH}:/opt/go/bin:${GOPATH}/bin
 RUN go get github.com/golang/protobuf/protoc-gen-go
-RUN go mod tidy -e # according to: https://stackoverflow.com/questions/67203641/missing-go-sum-entry-for-module-providing-package-package-name
 RUN export PATH="$PATH:$(go env GOPATH)/bin" # according to: https://grpc.io/docs/languages/go/quickstart/
+RUN go mod init # according to: https://golangdocs.com/create-go-modules
 
 ## Rust-lang stuff for iroha+ursa
 ENV RUSTUP_HOME=/opt/rust

--- a/irohad/model/commands/subtract_asset_quantity.hpp
+++ b/irohad/model/commands/subtract_asset_quantity.hpp
@@ -37,7 +37,7 @@ namespace iroha {
 
       SubtractAssetQuantity(const std::string &asset_id,
                             const std::string &amount,
-                            const std::string &title)
+                            const std::string &description)
           : asset_id(asset_id), amount(amount), description(description) {}
     };
   }  // namespace model

--- a/shared_model/backend/protobuf/impl/proto_block_factory.cpp
+++ b/shared_model/backend/protobuf/impl/proto_block_factory.cpp
@@ -5,8 +5,6 @@
 
 #include "backend/protobuf/proto_block_factory.hpp"
 
-#include <sstream>
-
 #include <boost/assert.hpp>
 #include "backend/protobuf/block.hpp"
 

--- a/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
+++ b/test/framework/integration_framework/fake_peer/behaviour/honest.cpp
@@ -7,16 +7,9 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
-#include "backend/protobuf/proto_proposal_factory.hpp"
-#include "backend/protobuf/transaction.hpp"
 #include "common/bind.hpp"
-#include "common/result.hpp"
 #include "framework/integration_framework/fake_peer/block_storage.hpp"
-#include "framework/integration_framework/fake_peer/proposal_storage.hpp"
-#include "interfaces/iroha_internal/transaction_batch.hpp"
 #include "logger/logger.hpp"
-#include "module/shared_model/builders/protobuf/proposal.hpp"
-#include "validators/default_validator.hpp"
 
 using namespace iroha::expected;
 


### PR DESCRIPTION
## Description
After successful merges:  https://github.com/hyperledger/iroha/pull/4003 and https://github.com/hyperledger/iroha/pull/4032 I was compiling entire Iroha 1.

1. I've noticed some warning, which may cause that the command is not working properly.
2. I've also corrected warnings connected with unused includes.
3. I remember that many times I was asking @6r1d how to merge approved Pull Request, he suggested that this information should be in CONTRIBUTION.rst - so I've added its.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
1. Fix of undetected bug
2. Faster compilation time and less warnings from IDE
3. No more questions to @6r1d about what button to press:)

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md` - I even edited the file:D
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later) - we will see
- [ ] (optional) I've written unit tests for the code changes - not required
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
