### PR TITLE
[refactor] #3887: Hide an internal structure of the versioned structs.

### DIFF
--- a/client/benches/tps/utils.rs
+++ b/client/benches/tps/utils.rs
@@ -127,18 +127,8 @@ impl Config {
                     .next()
                     .expect("The block is not yet in WSV. Need more sleep?");
                 (
-                    block
-                        .payload()
-                        .transactions
-                        .iter()
-                        .filter(|tx| tx.error.is_none())
-                        .count(),
-                    block
-                        .payload()
-                        .transactions
-                        .iter()
-                        .filter(|tx| tx.error.is_some())
-                        .count(),
+                    block.transactions().filter(|tx| tx.error.is_none()).count(),
+                    block.transactions().filter(|tx| tx.error.is_some()).count(),
                 )
             })
             .fold((0, 0), |acc, pair| (acc.0 + pair.0, acc.1 + pair.1));

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -52,7 +52,7 @@ fn test_with_instruction_and_status_and_port(
     // Given
     let submitter = client;
     let transaction = submitter.build_transaction(instruction, UnlimitedMetadata::new());
-    let hash = transaction.payload().hash();
+    let hash = transaction.hash_of_payload();
     let mut handles = Vec::new();
     for listener in clients {
         let checker = Checker { listener, hash };

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -65,10 +65,10 @@ fn client_has_rejected_and_acepted_txs_should_return_tx_history() -> Result<()> 
 
     let mut prev_creation_time = core::time::Duration::from_millis(0);
     for tx in &transactions {
-        assert_eq!(tx.payload().authority(), &account_id);
+        assert_eq!(tx.as_ref().authority(), &account_id);
         //check sorted
-        assert!(tx.payload().creation_time() >= prev_creation_time);
-        prev_creation_time = tx.payload().creation_time();
+        assert!(tx.as_ref().creation_time() >= prev_creation_time);
+        prev_creation_time = tx.as_ref().creation_time();
     }
     Ok(())
 }

--- a/core/benches/blocks/common.rs
+++ b/core/benches/blocks/common.rs
@@ -46,7 +46,7 @@ pub fn create_block(
     .unwrap();
 
     // Verify that transactions are valid
-    for tx in &block.payload().transactions {
+    for tx in block.as_ref().transactions() {
         assert_eq!(tx.error, None);
     }
 

--- a/core/src/gossiper.rs
+++ b/core/src/gossiper.rs
@@ -126,10 +126,10 @@ impl TransactionGossiper {
                         tx,
                         err: crate::queue::Error::InBlockchain,
                     }) => {
-                        iroha_logger::debug!(tx_payload_hash = %tx.payload().hash(), "Transaction already in blockchain, ignoring...")
+                        iroha_logger::debug!(tx_payload_hash = %tx.as_ref().hash_of_payload(), "Transaction already in blockchain, ignoring...")
                     }
                     Err(crate::queue::Failure { tx, err }) => {
-                        iroha_logger::error!(?err, tx_payload_hash = %tx.payload().hash(), "Failed to enqueue transaction.")
+                        iroha_logger::error!(?err, tx_payload_hash = %tx.as_ref().hash_of_payload(), "Failed to enqueue transaction.")
                     }
                 },
                 Err(err) => iroha_logger::error!(%err, "Transaction rejected"),

--- a/core/src/kura.rs
+++ b/core/src/kura.rs
@@ -163,8 +163,7 @@ impl Kura {
             match block_store.read_block_data(block.start, &mut block_data_buffer) {
                 Ok(()) => match SignedBlock::decode_all_versioned(&block_data_buffer) {
                     Ok(decoded_block) => {
-                        if previous_block_hash != decoded_block.payload().header.previous_block_hash
-                        {
+                        if previous_block_hash != decoded_block.header().previous_block_hash {
                             error!("Block has wrong previous block hash. Not reading any blocks beyond this height.");
                             break;
                         }

--- a/core/src/smartcontracts/isi/block.rs
+++ b/core/src/smartcontracts/isi/block.rs
@@ -30,9 +30,7 @@ impl ValidQuery for FindAllBlockHeaders {
         wsv: &'wsv WorldStateView,
     ) -> Result<Box<dyn Iterator<Item = BlockHeader> + 'wsv>, QueryExecutionFail> {
         Ok(Box::new(
-            wsv.all_blocks()
-                .rev()
-                .map(|block| block.payload().header.clone()),
+            wsv.all_blocks().rev().map(|block| block.header().clone()),
         ))
     }
 }
@@ -47,6 +45,6 @@ impl ValidQuery for FindBlockHeaderByHash {
             .find(|block| block.hash() == hash)
             .ok_or_else(|| QueryExecutionFail::Find(FindError::Block(hash)))?;
 
-        Ok(block.payload().header.clone())
+        Ok(block.header().clone())
     }
 }

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -373,7 +373,7 @@ mod tests {
 
         assert_eq!(
             FindBlockHeaderByHash::new(block.hash()).execute(&wsv)?,
-            block.payload().header
+            *block.header()
         );
 
         assert!(
@@ -445,9 +445,9 @@ mod tests {
             Err(Error::Find(FindError::Transaction(_)))
         ));
 
-        let found_accepted = FindTransactionByHash::new(va_tx.hash()).execute(&wsv)?;
+        let found_accepted = FindTransactionByHash::new(va_tx.as_ref().hash()).execute(&wsv)?;
         if found_accepted.transaction.error.is_none() {
-            assert_eq!(va_tx.hash(), found_accepted.transaction.hash())
+            assert_eq!(va_tx.as_ref().hash(), found_accepted.as_ref().hash())
         }
         Ok(())
     }

--- a/core/src/sumeragi/message.rs
+++ b/core/src/sumeragi/message.rs
@@ -64,7 +64,7 @@ pub struct BlockSigned {
 
 impl From<ValidBlock> for BlockSigned {
     fn from(block: ValidBlock) -> Self {
-        let block_hash = block.payload().hash();
+        let block_hash = block.as_ref().hash_of_payload();
         let SignedBlock::V1(block) = block.into();
 
         Self {
@@ -86,12 +86,12 @@ pub struct BlockCommitted {
 
 impl From<CommittedBlock> for BlockCommitted {
     fn from(block: CommittedBlock) -> Self {
-        let block_hash = block.payload().hash();
-        let SignedBlock::V1(block) = block.into();
+        let block_hash = block.as_ref().hash_of_payload();
+        let block_signatures = block.as_ref().signatures().clone();
 
         Self {
             hash: block_hash,
-            signatures: block.signatures,
+            signatures: block_signatures,
         }
     }
 }

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -128,7 +128,7 @@ impl SumeragiHandle {
                 block_index += 1;
                 let mut block_txs_accepted = 0;
                 let mut block_txs_rejected = 0;
-                for tx in &block.payload().transactions {
+                for tx in block.transactions() {
                     if tx.error.is_none() {
                         block_txs_accepted += 1;
                     } else {
@@ -231,15 +231,15 @@ impl SumeragiHandle {
         mut current_topology: Topology,
     ) -> Topology {
         // NOTE: topology need to be updated up to block's view_change_index
-        current_topology.rotate_all_n(block.payload().header.view_change_index);
+        current_topology.rotate_all_n(block.header().view_change_index);
 
         let block = ValidBlock::validate(block.clone(), &current_topology, chain_id, wsv)
             .expect("Kura blocks should be valid")
             .commit(&current_topology)
             .expect("Kura blocks should be valid");
 
-        if block.payload().header.is_genesis() {
-            wsv.world_mut().trusted_peers_ids = block.payload().commit_topology.clone();
+        if block.as_ref().header().is_genesis() {
+            wsv.world_mut().trusted_peers_ids = block.as_ref().commit_topology().clone();
         }
 
         wsv.apply_without_execution(&block).expect(

--- a/core/src/sumeragi/network_topology.rs
+++ b/core/src/sumeragi/network_topology.rs
@@ -181,7 +181,7 @@ impl Topology {
         view_change_index: u64,
         new_peers: UniqueVec<PeerId>,
     ) -> Self {
-        let mut topology = Topology::new(block.payload().commit_topology.clone());
+        let mut topology = Topology::new(block.commit_topology().clone());
         let block_signees = block
             .signatures()
             .into_iter()

--- a/data_model/src/predicate.rs
+++ b/data_model/src/predicate.rs
@@ -1053,9 +1053,7 @@ pub mod value {
                 ValuePredicate::Numerical(pred) => pred.applies(input),
                 ValuePredicate::Display(pred) => pred.applies(&input.to_string()),
                 ValuePredicate::TimeStamp(pred) => match input {
-                    Value::Block(block) => {
-                        pred.applies(block.payload().header.timestamp().as_millis())
-                    }
+                    Value::Block(block) => pred.applies(block.header().timestamp().as_millis()),
                     _ => false,
                 },
                 ValuePredicate::Ipv4Addr(pred) => match input {

--- a/data_model/src/visit.rs
+++ b/data_model/src/visit.rs
@@ -154,7 +154,7 @@ pub fn visit_transaction<V: Visit + ?Sized>(
     authority: &AccountId,
     transaction: &SignedTransaction,
 ) {
-    match transaction.payload().instructions() {
+    match transaction.instructions() {
         Executable::Wasm(wasm) => visitor.visit_wasm(authority, wasm),
         Executable::Instructions(instructions) => {
             for isi in instructions {

--- a/smart_contract/executor/src/default.rs
+++ b/smart_contract/executor/src/default.rs
@@ -73,7 +73,7 @@ pub fn visit_transaction<V: Validate + ?Sized>(
     authority: &AccountId,
     transaction: &SignedTransaction,
 ) {
-    match transaction.payload().instructions() {
+    match transaction.instructions() {
         Executable::Wasm(wasm) => executor.visit_wasm(authority, wasm),
         Executable::Instructions(instructions) => {
             for isi in instructions {


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
Encapsulated the next structs:
* SignedTransactionV1
* SignedBlockV1

The next structs were changed:
* ValidBlock(pub(super) Signedblock)
* CommitedBlock(pub(super) ValidBlock)
<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #3887 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
