### PR TITLE
[ci]: Fix pprof-rs Dockerfile and workflow

### DIFF
--- a/.github/workflows/iroha2-profiling-image.yml
+++ b/.github/workflows/iroha2-profiling-image.yml
@@ -26,7 +26,9 @@ on:
 
 jobs:
   registry:
-    runs-on: [self-hosted, Linux, iroha2-dev-push]
+    runs-on: ubuntu-latest
+    container:
+      image: hyperledger/iroha2-ci:nightly-2023-06-25
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3

--- a/Dockerfile.glibc
+++ b/Dockerfile.glibc
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim AS builder
 
 # install required packages
 RUN apt-get update -y && \
-     apt-get install -y curl build-essential mold
+     apt-get install -y curl build-essential mold pkg-config libssl-dev
 
 # set up Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y


### PR DESCRIPTION
Backport of profiler `Dockerfile.glibc` and `iroha2-profiling-image.yml` (check https://github.com/hyperledger/iroha/pull/4220, https://github.com/hyperledger/iroha/pull/4221, https://github.com/hyperledger/iroha/pull/4250).