### PR TITLE
[feature] #4116: Add test for plain == scale encoded verification for status request

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -176,12 +176,17 @@ pub struct StatusResponseHandler;
 
 impl StatusResponseHandler {
     fn handle(resp: &Response<Vec<u8>>) -> Result<Status> {
+        let slice = Self::handle_raw(resp)?;
+        serde_json::from_slice(slice).wrap_err("Failed to decode body")
+    }
+
+    fn handle_raw(resp: &Response<Vec<u8>>) -> Result<&Vec<u8>> {
         if resp.status() != StatusCode::OK {
             return Err(ResponseReport::with_msg("Unexpected status response", resp)
                 .unwrap_or_else(core::convert::identity)
                 .into());
         }
-        serde_json::from_slice(resp.body()).wrap_err("Failed to decode body")
+        Ok(resp.body())
     }
 }
 
@@ -1032,6 +1037,18 @@ impl Client {
         let req = self.prepare_status_request::<DefaultRequestBuilder>();
         let resp = req.build()?.send()?;
         StatusResponseHandler::handle(&resp)
+    }
+
+    /// Gets network status seen from the peer in scale encoding
+    ///
+    /// # Errors
+    /// Fails if sending request or decoding fails
+    pub fn get_status_scale_encoded(&self) -> Result<Vec<u8>> {
+        let req = self
+            .prepare_status_request::<DefaultRequestBuilder>()
+            .header(http::header::ACCEPT, "application/x-parity-scale");
+        let resp = req.build()?.send()?;
+        StatusResponseHandler::handle_raw(&resp).cloned()
     }
 
     /// Prepares http-request to implement [`Self::get_status`] on your own.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,15 +10,19 @@ mod query_builder;
 
 /// Module containing sample configurations for tests and benchmarks.
 pub mod samples {
+    use eyre::Result;
+    use iroha_telemetry::metrics::Status;
     use url::Url;
 
     use crate::{
+        client::{Client, StatusResponseHandler},
         config::{
             Config, DEFAULT_TRANSACTION_NONCE, DEFAULT_TRANSACTION_STATUS_TIMEOUT,
             DEFAULT_TRANSACTION_TIME_TO_LIVE,
         },
         crypto::KeyPair,
         data_model::ChainId,
+        http_default::DefaultRequestBuilder,
     };
 
     /// Get sample client configuration.
@@ -35,6 +39,16 @@ pub mod samples {
             transaction_status_timeout: DEFAULT_TRANSACTION_STATUS_TIMEOUT,
             transaction_add_nonce: DEFAULT_TRANSACTION_NONCE,
         }
+    }
+
+    /// Gets network status seen from the peer in json format
+    ///
+    /// # Errors
+    /// Fails if sending request or decoding fails
+    pub fn get_status_json(client: &Client) -> Result<Status> {
+        let req = client.prepare_status_request::<DefaultRequestBuilder>();
+        let resp = req.build()?.send()?;
+        StatusResponseHandler::handle(&resp)
     }
 }
 

--- a/client/tests/integration/mod.rs
+++ b/client/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod queries;
 mod roles;
 mod set_parameter;
 mod sorting;
+mod status_response;
 mod transfer_asset;
 mod triggers;
 mod tx_chain_id;

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -1,0 +1,54 @@
+use std::str::FromStr as _;
+
+use eyre::Result;
+use iroha_client::data_model::prelude::*;
+use iroha_telemetry::metrics::Status;
+use parity_scale_codec::DecodeAll;
+use test_network::*;
+
+fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
+    lhs.peers == rhs.peers
+        && lhs.blocks == rhs.blocks
+        && lhs.txs_accepted == rhs.txs_accepted
+        && lhs.txs_rejected == rhs.txs_rejected
+        && lhs.view_changes == rhs.view_changes
+}
+
+#[test]
+fn json_and_scale_statuses_equality() -> Result<()> {
+    let (_rt, network, client) = Network::start_test_with_runtime(1, Some(10_945));
+    wait_for_genesis_committed(&network.clients(), 0);
+
+    let json_status_zero = client.get_status().unwrap();
+
+    let scale_status_zero = client.get_status_scale_encoded().unwrap();
+    let scale_status_zero_decoded: Status =
+        DecodeAll::decode_all(&mut scale_status_zero.as_slice())?;
+
+    assert!(
+        status_eq_excluding_uptime_and_queue(&json_status_zero, &scale_status_zero_decoded),
+        "get_status() result is not equal to decoded get_status_scale_encoded()"
+    );
+
+    let coins = ["xor", "btc", "eth", "doge"];
+
+    for coin in coins {
+        let asset_definition_id = AssetDefinitionId::from_str(&format!("{}#wonderland", coin))?;
+        let create_asset =
+            Register::asset_definition(AssetDefinition::quantity(asset_definition_id.clone()));
+        client.submit_blocking(create_asset)?;
+    }
+
+    let json_status_coins = client.get_status().unwrap();
+
+    let scale_status_coins = client.get_status_scale_encoded().unwrap();
+    let scale_status_coins_decoded: Status =
+        DecodeAll::decode_all(&mut scale_status_coins.as_slice())?;
+
+    assert!(
+        status_eq_excluding_uptime_and_queue(&json_status_coins, &scale_status_coins_decoded),
+        "get_status() result is not equal to decoded get_status_scale_encoded()"
+    );
+
+    Ok(())
+}

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -16,7 +16,7 @@ fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
 
 #[test]
 fn json_and_scale_statuses_equality() -> Result<()> {
-    let (_rt, network, client) = Network::start_test_with_runtime(1, Some(10_945));
+    let (_rt, network, client) = Network::start_test_with_runtime(1, Some(10_935));
     wait_for_genesis_committed(&network.clients(), 0);
 
     let json_status_zero = client.get_status().unwrap();

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -16,7 +16,7 @@ fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
 
 #[test]
 fn json_and_scale_statuses_equality() -> Result<()> {
-    let (_rt, network, client) = Network::start_test_with_runtime(1, Some(10_935));
+    let (_rt, network, client) = Network::start_test_with_runtime(2, Some(11_200));
     wait_for_genesis_committed(&network.clients(), 0);
 
     let json_status_zero = client.get_status().unwrap();

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -29,11 +29,19 @@ fn json_and_scale_statuses_equality() -> Result<()> {
 
     let coins = ["xor", "btc", "eth", "doge"];
 
+    let domain_id: DomainId = "test_domain".parse().expect("Should be valid");
+    let account_id = AccountId::new(domain_id, "test_account".parse().expect("Should be valid"));
+
     for coin in coins {
         let asset_definition_id = AssetDefinitionId::from_str(&format!("{coin}#wonderland"))?;
         let create_asset =
-            Register::asset_definition(AssetDefinition::quantity(asset_definition_id.clone()));
-        client.submit_blocking(create_asset)?;
+            Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
+        let mint_asset = Mint::asset_numeric(
+            1234u32,
+            AssetId::new(asset_definition_id, account_id.clone()),
+        );
+        let instructions: [InstructionBox; 2] = [create_asset.into(), mint_asset.into()];
+        client.submit_all(instructions)?;
     }
 
     let json_status_coins = get_status_json(&client).unwrap();

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr as _;
 
 use eyre::Result;
-use iroha_client::data_model::prelude::*;
+use iroha_client::{data_model::prelude::*, samples::get_status_json};
 use iroha_telemetry::metrics::Status;
-use parity_scale_codec::DecodeAll;
 use test_network::*;
 
 fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
@@ -19,11 +18,9 @@ fn json_and_scale_statuses_equality() -> Result<()> {
     let (_rt, network, client) = Network::start_test_with_runtime(2, Some(11_200));
     wait_for_genesis_committed(&network.clients(), 0);
 
-    let json_status_zero = client.get_status().unwrap();
+    let json_status_zero = get_status_json(&client).unwrap();
 
-    let scale_status_zero = client.get_status_scale_encoded().unwrap();
-    let scale_status_zero_decoded: Status =
-        DecodeAll::decode_all(&mut scale_status_zero.as_slice())?;
+    let scale_status_zero_decoded = client.get_status().unwrap();
 
     assert!(
         status_eq_excluding_uptime_and_queue(&json_status_zero, &scale_status_zero_decoded),
@@ -33,17 +30,15 @@ fn json_and_scale_statuses_equality() -> Result<()> {
     let coins = ["xor", "btc", "eth", "doge"];
 
     for coin in coins {
-        let asset_definition_id = AssetDefinitionId::from_str(&format!("{}#wonderland", coin))?;
+        let asset_definition_id = AssetDefinitionId::from_str(&format!("{coin}#wonderland"))?;
         let create_asset =
             Register::asset_definition(AssetDefinition::quantity(asset_definition_id.clone()));
         client.submit_blocking(create_asset)?;
     }
 
-    let json_status_coins = client.get_status().unwrap();
+    let json_status_coins = get_status_json(&client).unwrap();
 
-    let scale_status_coins = client.get_status_scale_encoded().unwrap();
-    let scale_status_coins_decoded: Status =
-        DecodeAll::decode_all(&mut scale_status_coins.as_slice())?;
+    let scale_status_coins_decoded = client.get_status().unwrap();
 
     assert!(
         status_eq_excluding_uptime_and_queue(&json_status_coins, &scale_status_coins_decoded),

--- a/telemetry/src/metrics.rs
+++ b/telemetry/src/metrics.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use parity_scale_codec::{Compact, Encode};
+use parity_scale_codec::{Compact, Decode, Encode};
 use prometheus::{
     core::{AtomicU64, GenericGauge, GenericGaugeVec},
     Encoder, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts, Registry,
@@ -32,8 +32,19 @@ impl Encode for Uptime {
     }
 }
 
+impl Decode for Uptime {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let (secs, nanos) = <(Compact<u64>, u32)>::decode(input)?;
+        Ok(Self(
+            Duration::from_secs(secs.0) + Duration::from_nanos(nanos.into()),
+        ))
+    }
+}
+
 /// Response body for GET status request
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Encode)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, Encode, Decode)]
 pub struct Status {
     /// Number of currently connected peers excluding the reporting peer
     #[codec(compact)]


### PR DESCRIPTION
## Description

While checking #4116 I found helpful to verify that scale encoded response was equal to plain with this test.
It also might come in handy when we eventually move from warp to something like axum.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Relates to  #4116 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->


### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
