### PR TITLE
[ci] #4303: Fix Docker Compose path for tests

### DIFF
--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  DOCKER_COMPOSE_PATH: configs/swarm
 
 jobs:
   registry:
@@ -32,16 +33,16 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Test docker-compose.single.yml before pushing
         run: |
-          docker compose -f docker-compose.single.yml up --wait || exit 1
-          docker compose -f docker-compose.single.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml down
       - name: Test docker-compose.local.yml before pushing
         run: |
-          docker compose -f docker-compose.local.yml up --wait || exit 1
-          docker compose -f docker-compose.local.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml down
       - name: Test docker-compose.yml before pushing
         run: |
-          docker compose -f docker-compose.yml up --wait || exit 1
-          docker compose -f docker-compose.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  DOCKER_COMPOSE_PATH: configs/swarm
 
 jobs:
   registry:
@@ -42,16 +43,16 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Test docker-compose.single.yml before pushing
         run: |
-          docker compose -f docker-compose.single.yml up --wait || exit 1
-          docker compose -f docker-compose.single.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml down
       - name: Test docker-compose.local.yml before pushing
         run: |
-          docker compose -f docker-compose.local.yml up --wait || exit 1
-          docker compose -f docker-compose.local.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml down
       - name: Test docker-compose.yml before pushing
         run: |
-          docker compose -f docker-compose.yml up --wait || exit 1
-          docker compose -f docker-compose.yml down
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Description
Fix Docker Compose path for tests after #4239 merge.

### Linked issue

#4303

Closes #4303

### Benefits

Make available to run Docker Compose files tests before image pushing.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
