### PR TITLE
[ci]: Migrate to AWS spot runners CI

### DIFF
--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -81,5 +81,3 @@ jobs:
         working-directory: client_cli/pytests
         run: |
           poetry run flake8 . --max-line-length=110 --ignore=F401,W503,E203
-
-

--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   consistency:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
@@ -36,7 +36,7 @@ jobs:
         run: ./scripts/tests/consistency.sh docker-compose
 
   with_coverage:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
@@ -72,7 +72,7 @@ jobs:
       #     fail_ci_if_error: false
 
   integration:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 30
@@ -85,7 +85,7 @@ jobs:
           integration:: --skip unstable_network
 
   unstable:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
@@ -99,7 +99,7 @@ jobs:
   pr-generator-build:
     # Job will only execute if the head of the pull request is a branch for PR-generator case
     if: startsWith(github.head_ref, 'iroha2-pr-deploy/')
-    runs-on: [self-hosted, Linux, iroha2-dev-push]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
@@ -129,7 +129,7 @@ jobs:
           context: .
 
   client-cli-tests:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   registry:
-    runs-on: [self-hosted, Linux, iroha2-dev-push]
+    runs-on: [self-hosted, Linux, iroha2]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/iroha2-profiling-image.yml
+++ b/.github/workflows/iroha2-profiling-image.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   registry:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:

--- a/.github/workflows/iroha2-release-pr.yml
+++ b/.github/workflows/iroha2-release-pr.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   client-cli-tests:
-    runs-on: [self-hosted, Linux, iroha2ci]
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 60
@@ -59,7 +59,7 @@ jobs:
         run: bash -c './scripts/tests/panic_on_invalid_genesis.sh'
 
   bench:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
@@ -75,7 +75,7 @@ jobs:
   # ------------------------------ SDK tests go here ------------------------
 
   java-api:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
@@ -129,7 +129,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   long:
-    runs-on: ubuntu-latest #[self-hosted, Linux]
+    runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:


### PR DESCRIPTION
## Description
Migrate to AWS spot runners for some heavy CI jobs.

### Benefits

Make available CI runners after deprivation of instances from other cloud provider.

### Note
Merge it at `23-26.02.2024`

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
