### PR TITLE
[fix] #4311: fix pre-commit hook

### DIFF
--- a/hooks/pre-commit.sample
+++ b/hooks/pre-commit.sample
@@ -2,6 +2,6 @@
 set -e
 cargo +nightly fmt --all -- --check
 cargo +nightly lints clippy --workspace --benches --tests --examples --all-features
-cargo run --bin kagami -- genesis >configs/peer/genesis.json
+cargo run --bin kagami -- genesis --executor-path-in-genesis ./executor.wasm >configs/swarm/genesis.json
 cargo run --bin kagami -- schema >docs/source/references/schema.json
-git add configs/peer/genesis.json docs/source/references/schema.json
+git add configs/swarm/genesis.json docs/source/references/schema.json


### PR DESCRIPTION
## Description
the `pre-commit` hook still generates the genesis in `peer` even though it does not exist anymore after the big change in the configuration

### Linked issue

Closes #4311

### Checklist

- [X] I've read `CONTRIBUTING.md`
- [X] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
