### PR TITLE
[ci]: Unsync auto-labels. Fix `config-changes` condition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,4 +14,5 @@ config-changes:
   - all:
     - base-branch: '^iroha2-dev$'
     - changed-files:
-      - any-glob-to-any-file: 'configs/**'
+      # TODO have templates actually reflect configrations #4288
+      - any-glob-to-any-file: 'configs/*.template.toml'

--- a/.github/workflows/iroha2-label.yml
+++ b/.github/workflows/iroha2-label.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - id: label-the-PR
       uses: actions/labeler@v5
-      with:
-        sync-labels: true
     - uses: mshick/add-pr-comment@v2
       if: contains(steps.label-the-PR.outputs.all-labels, 'config-changes')
       with:


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

1. The bot was observed to remove a label manually added to PR: https://github.com/hyperledger/iroha/pull/4309#issuecomment-1958760549
2. At the same time, the bot was observed to notify false-positive `config-changes` due to its wrong definition
	- Closes #4278
<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

1. Always prioritize manual labeling/unlabeling
2. Necessary and sufficient `config-changes` notifications

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
