### PR TITLE
Update CODEOWNERS: remove Kshitij Roodkee

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @s8sato @mversic @arjentix @SamHSmith @outoftardis @Erigara @0x009922 @DCNick3 @vamuzing @Asem-Abdelhady @horizenight
+*   @s8sato @mversic @arjentix @SamHSmith @outoftardis @Erigara @0x009922 @DCNick3 @vamuzing @Asem-Abdelhady


### PR DESCRIPTION
As @0x009922 requested Kshitij Roodkee to be removed from `CODEOWNERS`: Kshitij would contribute, but he's busy with his new internship, as far as I am aware.