### PR TITLE
[refactor] #4291: update genesis config & schema

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -516,10 +516,11 @@ pub fn read_config_and_genesis<P: AsRef<Path>>(
     let genesis = if let Genesis::Full { key_pair, file } = &config.genesis {
         let raw_block = RawGenesisBlock::from_path(file)?;
 
-        Some(
-            GenesisNetwork::new(raw_block, &config.common.chain_id, key_pair)
-                .wrap_err("Failed to construct the genesis")?,
-        )
+        Some(GenesisNetwork::new(
+            raw_block,
+            &config.common.chain_id,
+            key_pair,
+        ))
     } else {
         None
     };
@@ -559,10 +560,11 @@ mod tests {
     }
 
     mod config_integration {
+        use std::path::PathBuf;
+
         use assertables::{assert_contains, assert_contains_as_result};
         use iroha_config::parameters::user::RootPartial as PartialUserConfig;
         use iroha_crypto::KeyPair;
-        use iroha_genesis::{ExecutorMode, ExecutorPath};
         use iroha_primitives::addr::socket_addr;
         use path_absolutize::Absolutize as _;
 
@@ -591,7 +593,7 @@ mod tests {
             // Given
 
             let genesis = RawGenesisBlockBuilder::default()
-                .executor(ExecutorMode::Path(ExecutorPath("./executor.wasm".into())))
+                .executor_file(PathBuf::from("./executor.wasm"))
                 .build();
 
             let config = {
@@ -649,7 +651,7 @@ mod tests {
             // Given
 
             let genesis = RawGenesisBlockBuilder::default()
-                .executor(ExecutorMode::Path(ExecutorPath("./executor.wasm".into())))
+                .executor_file(PathBuf::from("./executor.wasm"))
                 .build();
 
             let config = {

--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -36,7 +36,7 @@ fn query_requests(criterion: &mut Criterion) {
                 get_key_pair().public_key().clone(),
             )
             .finish_domain()
-            .executor(
+            .executor_blob(
                 construct_executor("../default_executor").expect("Failed to construct executor"),
             )
             .build(),
@@ -45,8 +45,7 @@ fn query_requests(criterion: &mut Criterion) {
             .genesis
             .key_pair()
             .expect("genesis config should be full, probably a bug"),
-    )
-    .expect("genesis creation failed");
+    );
 
     let builder = PeerBuilder::new()
         .with_config(configuration)
@@ -143,7 +142,7 @@ fn instruction_submits(criterion: &mut Criterion) {
                 configuration.common.key_pair.public_key().clone(),
             )
             .finish_domain()
-            .executor(
+            .executor_blob(
                 construct_executor("../default_executor").expect("Failed to construct executor"),
             )
             .build(),
@@ -152,8 +151,7 @@ fn instruction_submits(criterion: &mut Criterion) {
             .genesis
             .key_pair()
             .expect("config should be full; probably a bug"),
-    )
-    .expect("failed to create genesis");
+    );
     let builder = PeerBuilder::new()
         .with_config(configuration)
         .with_into_genesis(genesis);

--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -32,7 +32,9 @@ fn generate_genesis(num_domains: u32) -> RawGenesisBlock {
     }
 
     builder
-        .executor(construct_executor("../default_executor").expect("Failed to construct executor"))
+        .executor_blob(
+            construct_executor("../default_executor").expect("Failed to construct executor"),
+        )
         .build()
 }
 

--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -55,8 +55,7 @@ fn main_genesis() {
             .genesis
             .key_pair()
             .expect("should be available in the config; probably a bug"),
-    )
-    .expect("genesis creation failed");
+    );
 
     let builder = PeerBuilder::new()
         .with_into_genesis(genesis)

--- a/config/tests/fixtures/empty_ok_genesis.json
+++ b/config/tests/fixtures/empty_ok_genesis.json
@@ -1,4 +1,4 @@
 {
   "transactions": [],
-  "executor": "./executor.wasm"
+  "executor_file": "./executor.wasm"
 }

--- a/configs/swarm/genesis.json
+++ b/configs/swarm/genesis.json
@@ -184,5 +184,5 @@
       }
     ]
   ],
-  "executor": "./executor.wasm"
+  "executor_file": "./executor.wasm"
 }

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -1001,20 +1001,6 @@
     ]
   },
   "ExecutorEventSet": "u32",
-  "ExecutorMode": {
-    "Enum": [
-      {
-        "tag": "Path",
-        "discriminant": 0,
-        "type": "String"
-      },
-      {
-        "tag": "Inline",
-        "discriminant": 1,
-        "type": "Executor"
-      }
-    ]
-  },
   "Fail": {
     "Struct": [
       {
@@ -2864,18 +2850,6 @@
       }
     ]
   },
-  "RawGenesisBlock": {
-    "Struct": [
-      {
-        "name": "transactions",
-        "type": "Vec<Vec<InstructionBox>>"
-      },
-      {
-        "name": "executor",
-        "type": "ExecutorMode"
-      }
-    ]
-  },
   "Register<Account>": {
     "Struct": [
       {
@@ -4113,9 +4087,6 @@
   },
   "Vec<TransactionValue>": {
     "Vec": "TransactionValue"
-  },
-  "Vec<Vec<InstructionBox>>": {
-    "Vec": "Vec<InstructionBox>"
   },
   "Vec<u8>": {
     "Vec": "u8"

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = { workspace = true }
 once_cell = { workspace = true }
 tracing = { workspace = true }
 eyre = { workspace = true }
+
+[dev-dependencies]
+iroha_crypto = { workspace = true, features = ["rand"] }

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -7,7 +7,6 @@ use iroha_data_model::{
     query::QueryOutputBox,
     BatchedResponse,
 };
-use iroha_genesis::RawGenesisBlock;
 use iroha_schema::prelude::*;
 
 macro_rules! types {
@@ -52,9 +51,6 @@ pub fn build_schemas() -> MetaMap {
         // Block stream
         BlockMessage,
         BlockSubscriptionRequest,
-
-        // SDK devs want to know how to read serialized genesis block
-        RawGenesisBlock,
 
         // Never referenced, but present in type signature. Like `PhantomData<X>`
         MerkleTree<SignedTransaction>,
@@ -476,13 +472,6 @@ mod tests {
 
         insert_into_test_map!(Compact<u128>);
         insert_into_test_map!(Compact<u32>);
-
-        // NOTE: Coming from genesis
-        insert_into_test_map!(Vec<iroha_genesis::GenesisTransactionBuilder>);
-        insert_into_test_map!(iroha_genesis::GenesisTransactionBuilder);
-        insert_into_test_map!(iroha_genesis::RawGenesisBlock);
-        insert_into_test_map!(iroha_genesis::ExecutorMode);
-        insert_into_test_map!(iroha_genesis::ExecutorPath);
 
         map
     }


### PR DESCRIPTION
## Description

- remove inline executor mode
- rename field to `executor_file`
- remove genesis from schema (revert #1391).
  - **Why?**
  - Because it doesn't belong here. It's not a part of the data model, but rather of the configuration system. The original reasoning about "ease for SDK developers" doesn't work (genesis is JSON, but schema is about SCALE; types are straightforward).

### Linked issue

Closes #4291 
