### PR TITLE
[feature] #4350: Expose event set bitfields in schema

### DIFF
--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -543,13 +543,18 @@ mod executor {
     use iroha_data_model_derive::model;
 
     pub use self::model::*;
+    // this is used in no_std
+    #[allow(unused)]
+    use super::*;
 
     #[model]
     pub mod model {
-        #[cfg(not(feature = "std"))]
-        use alloc::{format, string::String, vec::Vec};
 
         use iroha_data_model_derive::EventSet;
+
+        // this is used in no_std
+        #[allow(unused)]
+        use super::*;
 
         #[derive(
             Debug,

--- a/data_model/src/events/data/mod.rs
+++ b/data_model/src/events/data/mod.rs
@@ -1,7 +1,7 @@
 //! Data events.
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::String, vec::Vec};
+use alloc::{format, string::String, vec, vec::Vec};
 
 pub use events::DataEvent;
 pub use filters::DataEventFilter;

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -94,7 +94,57 @@
       }
     ]
   },
-  "AccountEventSet": "u32",
+  "AccountEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "AnyAsset",
+          "mask": 1
+        },
+        {
+          "name": "Created",
+          "mask": 2
+        },
+        {
+          "name": "Deleted",
+          "mask": 4
+        },
+        {
+          "name": "AuthenticationAdded",
+          "mask": 8
+        },
+        {
+          "name": "AuthenticationRemoved",
+          "mask": 16
+        },
+        {
+          "name": "PermissionAdded",
+          "mask": 32
+        },
+        {
+          "name": "PermissionRemoved",
+          "mask": 64
+        },
+        {
+          "name": "RoleRevoked",
+          "mask": 128
+        },
+        {
+          "name": "RoleGranted",
+          "mask": 256
+        },
+        {
+          "name": "MetadataInserted",
+          "mask": 512
+        },
+        {
+          "name": "MetadataRemoved",
+          "mask": 1024
+        }
+      ]
+    }
+  },
   "AccountId": {
     "Struct": [
       {
@@ -310,7 +360,41 @@
       }
     ]
   },
-  "AssetDefinitionEventSet": "u32",
+  "AssetDefinitionEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Created",
+          "mask": 1
+        },
+        {
+          "name": "MintabilityChanged",
+          "mask": 2
+        },
+        {
+          "name": "OwnerChanged",
+          "mask": 4
+        },
+        {
+          "name": "Deleted",
+          "mask": 8
+        },
+        {
+          "name": "MetadataInserted",
+          "mask": 16
+        },
+        {
+          "name": "MetadataRemoved",
+          "mask": 32
+        },
+        {
+          "name": "TotalQuantityChanged",
+          "mask": 64
+        }
+      ]
+    }
+  },
   "AssetDefinitionId": {
     "Struct": [
       {
@@ -393,7 +477,37 @@
       }
     ]
   },
-  "AssetEventSet": "u32",
+  "AssetEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Created",
+          "mask": 1
+        },
+        {
+          "name": "Deleted",
+          "mask": 2
+        },
+        {
+          "name": "Added",
+          "mask": 4
+        },
+        {
+          "name": "Removed",
+          "mask": 8
+        },
+        {
+          "name": "MetadataInserted",
+          "mask": 16
+        },
+        {
+          "name": "MetadataRemoved",
+          "mask": 32
+        }
+      ]
+    }
+  },
   "AssetId": {
     "Struct": [
       {
@@ -631,7 +745,25 @@
       }
     ]
   },
-  "ConfigurationEventSet": "u32",
+  "ConfigurationEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Changed",
+          "mask": 1
+        },
+        {
+          "name": "Created",
+          "mask": 2
+        },
+        {
+          "name": "Deleted",
+          "mask": 4
+        }
+      ]
+    }
+  },
   "Container": {
     "Enum": [
       {
@@ -830,7 +962,41 @@
       }
     ]
   },
-  "DomainEventSet": "u32",
+  "DomainEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "AnyAccount",
+          "mask": 1
+        },
+        {
+          "name": "AnyAssetDefinition",
+          "mask": 2
+        },
+        {
+          "name": "Created",
+          "mask": 4
+        },
+        {
+          "name": "Deleted",
+          "mask": 8
+        },
+        {
+          "name": "MetadataInserted",
+          "mask": 16
+        },
+        {
+          "name": "MetadataRemoved",
+          "mask": 32
+        },
+        {
+          "name": "OwnerChanged",
+          "mask": 64
+        }
+      ]
+    }
+  },
   "DomainId": {
     "Struct": [
       {
@@ -1000,7 +1166,17 @@
       }
     ]
   },
-  "ExecutorEventSet": "u32",
+  "ExecutorEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Upgraded",
+          "mask": 1
+        }
+      ]
+    }
+  },
   "Fail": {
     "Struct": [
       {
@@ -2364,7 +2540,21 @@
       }
     ]
   },
-  "PeerEventSet": "u32",
+  "PeerEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Added",
+          "mask": 1
+        },
+        {
+          "name": "Removed",
+          "mask": 2
+        }
+      ]
+    }
+  },
   "PeerId": {
     "Struct": [
       {
@@ -3145,7 +3335,29 @@
       }
     ]
   },
-  "RoleEventSet": "u32",
+  "RoleEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Created",
+          "mask": 1
+        },
+        {
+          "name": "Deleted",
+          "mask": 2
+        },
+        {
+          "name": "PermissionRemoved",
+          "mask": 4
+        },
+        {
+          "name": "PermissionAdded",
+          "mask": 8
+        }
+      ]
+    }
+  },
   "RoleId": {
     "Struct": [
       {
@@ -3863,7 +4075,29 @@
       }
     ]
   },
-  "TriggerEventSet": "u32",
+  "TriggerEventSet": {
+    "Bitmap": {
+      "repr": "u32",
+      "masks": [
+        {
+          "name": "Created",
+          "mask": 1
+        },
+        {
+          "name": "Deleted",
+          "mask": 2
+        },
+        {
+          "name": "Extended",
+          "mask": 4
+        },
+        {
+          "name": "Shortened",
+          "mask": 8
+        }
+      ]
+    }
+  },
   "TriggerId": {
     "Struct": [
       {

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -145,6 +145,8 @@ pub enum Metadata {
     Option(core::any::TypeId),
     /// Result
     Result(ResultMeta),
+    /// A bitmap: integer where bits have a specific meaning
+    Bitmap(BitmapMeta),
 }
 
 /// Array metadata
@@ -237,6 +239,25 @@ pub enum IntMode {
     FixedWidth,
     /// Scale compact
     Compact,
+}
+
+/// Bitmap metadata
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BitmapMeta {
+    /// Underlying integer type
+    pub repr: core::any::TypeId,
+    /// Masks, specifying the meaning of the bits
+    pub masks: Vec<BitmapMask>,
+}
+
+/// Bitmap mask
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct BitmapMask {
+    /// Symbolic name of the mask
+    pub name: String,
+    /// Mask value
+    // while we can technically have masks with multiple bits set or intersecting masks, we currently only emit single-bit disjoint masks
+    pub mask: u64,
 }
 
 /// Compact predicate. Just for documentation purposes

--- a/schema/src/serialize.rs
+++ b/schema/src/serialize.rs
@@ -214,6 +214,24 @@ impl PartialEq for WithContext<'_, '_, FixedMeta> {
     }
 }
 
+impl Serialize for WithContext<'_, '_, BitmapMeta> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("repr", self.type_name(self.data.repr))?;
+        map.serialize_entry("masks", &self.data.masks)?;
+        map.end()
+    }
+}
+impl PartialEq for WithContext<'_, '_, BitmapMeta> {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_name(self.data.repr) == other.type_name(other.data.repr)
+            && self.data.masks == other.data.masks
+    }
+}
+
 impl Serialize for WithContext<'_, '_, Metadata> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         macro_rules! match_variants {
@@ -253,7 +271,7 @@ impl Serialize for WithContext<'_, '_, Metadata> {
             };
         }
 
-        match_variants!(Struct, Enum, FixedPoint, Array, Vec, Map, Result)
+        match_variants!(Struct, Enum, FixedPoint, Array, Vec, Map, Result, Bitmap)
     }
 }
 impl PartialEq for WithContext<'_, '_, Metadata> {
@@ -288,7 +306,7 @@ impl PartialEq for WithContext<'_, '_, Metadata> {
             };
         }
 
-        match_variants!(Tuple, Struct, Enum, FixedPoint, Array, Vec, Map, Result)
+        match_variants!(Tuple, Struct, Enum, FixedPoint, Array, Vec, Map, Result, Bitmap)
     }
 }
 


### PR DESCRIPTION
## Description

Add a new kind of schema metadata - BitmapMeta - and use it to expose `*EventSet` bitfields in schema

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4350 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->


### Checklist

- [ ] make ci pass