### PR TITLE
[refactor] #4387: Send blocks to observing peers 

### DIFF
--- a/client/benches/tps/utils.rs
+++ b/client/benches/tps/utils.rs
@@ -151,7 +151,7 @@ type UnitName = u32;
 
 impl MeasurerUnit {
     /// Number of blocks that will be committed by [`Self::ready()`] call
-    const PREPARATION_BLOCKS_NUMBER: u32 = 3;
+    const PREPARATION_BLOCKS_NUMBER: u32 = 2;
 
     /// Submit initial transactions for measurement
     fn ready(self) -> Result<Self> {

--- a/core/src/gossiper.rs
+++ b/core/src/gossiper.rs
@@ -121,6 +121,12 @@ impl TransactionGossiper {
                     }) => {
                         iroha_logger::debug!(tx_payload_hash = %tx.as_ref().hash(), "Transaction already in blockchain, ignoring...")
                     }
+                    Err(crate::queue::Failure {
+                        tx,
+                        err: crate::queue::Error::IsInQueue,
+                    }) => {
+                        iroha_logger::debug!(tx_payload_hash = %tx.as_ref().hash(), "Transaction already in the queue, ignoring...")
+                    }
                     Err(crate::queue::Failure { tx, err }) => {
                         iroha_logger::error!(?err, tx_payload_hash = %tx.as_ref().hash(), "Failed to enqueue transaction.")
                     }


### PR DESCRIPTION
## Description

Send blocks to observing peers.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4387 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Observing peers are up to sync with voting peers. 

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
