### PR TITLE
[fix] #4397: Revert changes to transaction_time_to_live

### DIFF
--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -675,7 +675,7 @@ pub mod tests {
         ));
         let state_view = state.view();
         let queue = Queue::test(Config {
-            transaction_time_to_live: Duration::from_millis(300),
+            transaction_time_to_live: Duration::from_millis(200),
             ..config_factory()
         });
         for _ in 0..(max_txs_in_block - 1) {
@@ -688,7 +688,7 @@ pub mod tests {
         queue
             .push(accepted_tx("alice@wonderland", &alice_key), &state_view)
             .expect("Failed to push tx into queue");
-        std::thread::sleep(Duration::from_millis(201));
+        std::thread::sleep(Duration::from_millis(101));
         assert_eq!(
             queue
                 .collect_transactions_for_block(&state_view, max_txs_in_block)
@@ -699,7 +699,7 @@ pub mod tests {
         queue
             .push(accepted_tx("alice@wonderland", &alice_key), &state_view)
             .expect("Failed to push tx into queue");
-        std::thread::sleep(Duration::from_millis(310));
+        std::thread::sleep(Duration::from_millis(210));
         assert_eq!(
             queue
                 .collect_transactions_for_block(&state_view, max_txs_in_block)


### PR DESCRIPTION
## Description

An attempt to resolve #4397. Needs CI runs to be sure that it actually helps.

If this doesn't help, a mock time source will.

Result: 2 failures out of 5 runs.

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4397

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
