### PR TITLE
[fix] #4397: Make queue tests use a mock time source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
  "iroha_primitives_derive",
  "iroha_schema",
  "parity-scale-codec",
+ "parking_lot",
  "serde",
  "serde_json",
  "serde_with",

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 default = ["std"]
 # Enable static linkage of the rust standard library.
 # Please refer to https://docs.rust-embedded.org/book/intro/no-std.html
-std = ["iroha_macro/std", "thiserror", "displaydoc/std", "iroha_numeric/std"]
+std = ["iroha_macro/std", "thiserror", "displaydoc/std", "iroha_numeric/std", "parking_lot"]
 # Replace structures and methods with FFI equivalents to facilitate dynamic linkage (mainly used in smartcontracts)
 #ffi_import = ["iroha_ffi", "iroha_numeric/ffi_import"]
 
@@ -41,6 +41,7 @@ smallvec = { version = "1.11.1", default-features = false, features = ["serde", 
 smallstr = { version = "0.3.0", default-features = false, features = ["serde", "union"] }
 thiserror = { workspace = true, optional = true }
 displaydoc = { workspace = true }
+parking_lot = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["alloc"] }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -21,6 +21,8 @@ pub mod must_use;
 pub mod numeric;
 pub mod riffle_iter;
 pub mod small;
+#[cfg(feature = "std")]
+pub mod time;
 pub mod unique_vec;
 
 mod ffi {

--- a/primitives/src/time.rs
+++ b/primitives/src/time.rs
@@ -1,0 +1,92 @@
+//! Provides a [`TimeSource`] - a mockable abstraction over [`std::time::SystemTime`]
+
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use parking_lot::Mutex;
+
+#[derive(Debug, Clone, Default)]
+enum TimeSourceInner {
+    /// The time will come from the system clock ([`std::time::SystemTime::now()`]
+    #[default]
+    SystemTime,
+    /// The time will come from the mock implementation
+    MockTime(Arc<Mutex<Duration>>),
+}
+
+/// A time source that either relies on [`std::time::SystemTime::now()`] or uses a mock clock that must be advanced manually
+#[derive(Debug, Clone, Default)]
+pub struct TimeSource(TimeSourceInner);
+
+impl TimeSource {
+    /// Creates a real [`TimeSource`] backed by [`std::time::SystemTime::now()`]
+    pub fn new_system() -> Self {
+        Self(TimeSourceInner::SystemTime)
+    }
+
+    /// Creates a mock [`TimeSource`] that must be advanced manually via [`MockTimeHandle`]
+    pub fn new_mock(start_unix_time: Duration) -> (MockTimeHandle, Self) {
+        let handle = MockTimeHandle::new(start_unix_time);
+
+        let source = handle.source();
+        (handle, source)
+    }
+
+    /// Returns the [`SystemTime`] corresponding to "now".
+    ///
+    /// It can either come from [`SystemTime::now()`] or from a mock time source
+    pub fn get_system_time(&self) -> SystemTime {
+        match &self.0 {
+            TimeSourceInner::SystemTime => SystemTime::now(),
+            TimeSourceInner::MockTime(time) => SystemTime::UNIX_EPOCH + *time.lock(),
+        }
+    }
+
+    /// Returns the duration since unix epoch corresponding to "now".
+    ///
+    /// It can either come from [`SystemTime::now()`] or from a mock time source
+    pub fn get_unix_time(&self) -> Duration {
+        match &self.0 {
+            TimeSourceInner::SystemTime => SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("Failed to get the current system time"),
+            TimeSourceInner::MockTime(time) => *time.lock(),
+        }
+    }
+}
+
+/// A handle that can be used to advance the mock [`TimeSource`].
+#[derive(Clone)]
+pub struct MockTimeHandle(Arc<Mutex<Duration>>);
+
+impl MockTimeHandle {
+    /// Creates a [`MockTimeHandle`] set to a specific unix timestamp.
+    pub fn new(start_unix_time: Duration) -> Self {
+        Self(Arc::new(Mutex::new(start_unix_time)))
+    }
+
+    /// Gets a [`TimeSource`] corresponding to this mock handle
+    pub fn source(&self) -> TimeSource {
+        TimeSource(TimeSourceInner::MockTime(self.0.clone()))
+    }
+
+    /// Set the mock time to a specific unix time value
+    pub fn set(&self, unix_time: Duration) {
+        let mut time = self.0.lock();
+        *time = unix_time;
+    }
+
+    /// Advance mock time
+    pub fn advance(&self, advance_time: Duration) {
+        let mut time = self.0.lock();
+        *time += advance_time;
+    }
+
+    /// Rewind mock time
+    pub fn rewind(&self, advance_time: Duration) {
+        let mut time = self.0.lock();
+        *time -= advance_time;
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a `TimeSource` to `iroha_primitives` - a mockable time source. It then proceeds to make the queue tests use the mock time source to make them deterministic.

### Linked issue

Closes #4397

### Benefits

- less flaky CI
- ability to mock transaction times (useful [here](https://github.com/hyperledger/iroha/pull/4382#discussion_r1540619904))

### Checklist

- [ ] make CI pass