### PR TITLE
[refactor] #4290: Replace `parse_display` crate with `strum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,10 +3007,10 @@ dependencies = [
  "iroha_ffi",
  "iroha_macro_utils",
  "manyhow",
- "parse-display",
  "proc-macro2",
  "quote",
  "rustc-hash",
+ "strum 0.25.0",
  "syn 2.0.41",
  "trybuild",
 ]
@@ -4156,32 +4156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
-dependencies = [
- "once_cell",
- "parse-display-derive",
- "regex",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax 0.7.5",
- "structmeta",
- "syn 2.0.41",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4707,12 +4681,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -5325,29 +5293,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.41",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.41",
-]
 
 [[package]]
 name = "strum"

--- a/ffi/derive/Cargo.toml
+++ b/ffi/derive/Cargo.toml
@@ -24,7 +24,7 @@ manyhow = { workspace = true }
 darling = { workspace = true }
 rustc-hash = { workspace = true }
 
-parse-display = "0.8.2"
+strum = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 iroha_ffi = { workspace = true }

--- a/ffi/derive/src/attr_parse/getset.rs
+++ b/ffi/derive/src/attr_parse/getset.rs
@@ -2,15 +2,15 @@
 
 use std::{collections::hash_map::Entry, str::FromStr};
 
-use parse_display::{Display, FromStr};
 use proc_macro2::Span;
 use rustc_hash::{FxHashMap, FxHashSet};
+use strum::{Display, EnumString};
 use syn::{parse::ParseStream, punctuated::Punctuated, Attribute, Token};
 
 use crate::attr_parse::derive::{Derive, DeriveAttrs};
 
 /// Type of accessor method derived for a structure
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, FromStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumString)]
 pub enum GetSetDerive {
     Setters,
     Getters,
@@ -104,8 +104,8 @@ impl syn::parse::Parse for SpannedGetSetOptions {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Display, FromStr)]
-#[display(style = "snake_case")]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Display, EnumString)]
+#[strum(serialize_all = "snake_case")]
 pub enum GetSetGenMode {
     Get,
     GetCopy,

--- a/ffi/derive/src/attr_parse/repr.rs
+++ b/ffi/derive/src/attr_parse/repr.rs
@@ -5,8 +5,8 @@
 use std::str::FromStr;
 
 use darling::{error::Accumulator, util::SpannedValue, FromAttributes};
-use parse_display::{Display, FromStr};
 use proc_macro2::{Delimiter, Span};
+use strum::{Display, EnumString};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -14,8 +14,8 @@ use syn::{
     Attribute, Meta, Token,
 };
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, FromStr)]
-#[display(style = "lowercase")]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum ReprPrimitive {
     U8,
     U16,


### PR DESCRIPTION
## Description

Remove the `parse_display` dependency since `strum` provides the needed derives.

### Linked issue

Closes #4290.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up
