### PR TITLE
[fix] #4307: Pad `r` and `s` to 32 bytes in `secp256k1_sign` test

### DIFF
--- a/crypto/src/signature/secp256k1.rs
+++ b/crypto/src/signature/secp256k1.rs
@@ -241,8 +241,9 @@ mod test {
 
             // serialize the key
             let mut res = Vec::new();
-            res.extend(r.to_vec());
-            res.extend(s.to_vec());
+            // padding because EcdsaSecp256k1Sha256::verify requires a slice of length 64
+            res.extend(r.to_vec_padded(32).expect("r fits into 32 bytes"));
+            res.extend(s.to_vec_padded(32).expect("s fits into 32 bytes"));
             res
         };
 


### PR DESCRIPTION
## Description

Currently, the `signature::secp256k1::test::secp256k1_sign` test fails intermittently due to `r` sometimes producing a vector of 31 bytes instead of 32, which makes `EcdsaSecp256k1Sha256::verify` fail on the total `r + s` length check (==64). 

Maybe it's possible that `s` does the same, so I padded `s` too to be safe – but I don't have the cryptography background to confirm that (failing cases have pointed to `r` only). I'm also unaware if it's possible for `r` or `s` to be >32 bytes long.

### Linked issue

Closes #4307.

### Benefits

Test should no longer be flaky.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up
### 