### PR TITLE
[ci]: Configure Sonarqube and Defectdojo in iroha2 CI

### DIFF
--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -43,7 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lints without features
@@ -51,32 +50,34 @@ jobs:
         run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
       - name: Lints with all features enabled
         if: always()
-        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet
+        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json &> clippy.json
       - name: Documentation
         if: always()
         run: cargo doc --no-deps --quiet
+      - name: Upload clippy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clippy.json
+          path: clippy.json
+
   python_static_analysis:
     runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
       - uses: actions/checkout@v4
-
       - name: Install dependencies using Poetry
         working-directory: client_cli/pytests
         run: |
           poetry install
-
       - name: Check code formatting with Black
         working-directory: client_cli/pytests
         run: |
           poetry run black --check .
-
       - name: Run mypy (Type Checker)
         working-directory: client_cli/pytests
         run: |
           poetry run mypy --explicit-package-bases .
-
       - name: Run flake8 (Linter)
         working-directory: client_cli/pytests
         run: |

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -40,36 +40,30 @@ jobs:
     container:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     steps:
-      - uses: actions/checkout@v3
-      # TODO Remove this step #2165
-      # - name: Adjust toolchain
-      #   run: |
-      #     rustup component add llvm-tools-preview
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with coverage
-        run: |
-          mold --run cargo llvm-cov clean --workspace
-          mold --run cargo llvm-cov --doc --no-report --all-features --workspace --no-fail-fast --ignore-filename-regex='(^client_cli/|main\.rs)'
-          mold --run cargo llvm-cov --no-report --ignore-filename-regex='(^client_cli/|main\.rs)' --all-features --workspace --no-fail-fast
+        run: mold --run cargo test --all-features --workspace --no-fail-fast
+        env:
+          RUSTFLAGS: "-C instrument-coverage"
+          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate lcov report
-        run: |
-          # generate report without tests
-          # https://github.com/taiki-e/cargo-llvm-cov#merge-coverages-generated-under-different-test-conditions
-          mold --run cargo llvm-cov --doctests --no-run --all-features --workspace --lcov --output-path lcov.info
+        if: always()
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli/*|**/main.rs" -o lcov.info
       - name: Upload coverage to coveralls.io
+        if: always()
         uses: coverallsapp/github-action@v2
         with:
           file: lcov.info
           compare-ref: ${{ github.base_ref }}
           compare-sha: ${{ github.event.pull_request.base.sha}}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      # (Temporally) Add the parallel coverage upload to Codecov to compare the results with Coveralls
-      # - name: Upload coverage to codecov.io
-      #   uses: codecov/codecov-action@v3.1.4
-      #   with:
-      #     files: lcov.info
-      #     commit_parent: ${{ github.event.pull_request.base.sha }}
-      #     fail_ci_if_error: false
+      - name: Upload lcov report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lcov.info
 
   integration:
     runs-on: [self-hosted, Linux, iroha2]
@@ -77,7 +71,7 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2024-01-12
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with no-default-features
         run: |

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -49,7 +49,7 @@ jobs:
           LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
       - name: Generate lcov report
         if: always()
-        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli/*|**/main.rs" -o lcov.info
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli" --ignore "**/main.rs" -o lcov.info
       - name: Upload coverage to coveralls.io
         if: always()
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -150,3 +150,51 @@ jobs:
         with:
           name: telemetry
           path: target/telemetry
+
+  sonarqube-defectdojo:
+    runs-on: ubuntu-latest
+    container:
+      image: hyperledger/iroha2-ci:nightly-2024-01-12
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download clippy report artifact
+        uses: dawidd6/action-download-artifact@v3.1.4
+        with:
+          workflow: iroha2-dev-pr-static.yml
+          name: clippy.json
+          search_artifacts: true
+      - name: Download lcov report artifact
+        uses: dawidd6/action-download-artifact@v3.1.4
+        with:
+          workflow: iroha2-dev-pr.yml
+          name: lcov.info
+          search_artifacts: true
+      - name: SonarQube
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dcommunity.rust.clippy.reportPaths=clippy.json
+            -Dcommunity.rust.lcov.reportPaths=lcov.info
+      - name: DefectDojo
+        id: defectdojo
+        uses: C4tWithShell/defectdojo-action@1.0.4
+        with:
+          token: ${{ secrets.DEFECTOJO_TOKEN }}
+          defectdojo_url: ${{ secrets.DEFECTOJO_URL }}
+          product_type: iroha2
+          engagement: ${{ github.ref_name }}
+          tools: "SonarQube API Import,Github Vulnerability Scan"
+          sonar_projectKey: hyperledger:iroha
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repository: ${{ github.repository }}
+          product: ${{ github.repository }}
+          environment: Test
+          reports: '{"Github Vulnerability Scan": "github.json"}'
+      - name: Show Defectdojo response
+        if: always()
+        run: |
+          set -e
+          printf '%s\n' '${{ steps.defectdojo.outputs.response }}'

--- a/.github/workflows/iroha2-no-incorrect-image.yml
+++ b/.github/workflows/iroha2-no-incorrect-image.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: "3.11"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: pip install -r .github/scripts/ci_test/requirements.txt --no-input
       - name: Check containers on iroha2 stable branch

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 ENV PATH=$POETRY_HOME/bin:$PATH
 
-RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 \
+RUN pacman -Syu rustup mold musl rust-musl openssl libgit2 jq \
     git docker docker-buildx docker-compose \
     python python-pip --noconfirm --disable-download-timeout && \
     curl -sSL https://install.python-poetry.org | python3 -
@@ -20,11 +20,11 @@ RUN poetry install
 
 RUN rustup toolchain install nightly-2024-01-12-x86_64-unknown-linux-gnu
 RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
-RUN rustup component add llvm-tools-preview clippy
+RUN rustup component add clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install cargo-llvm-cov
+RUN cargo install grcov
 
 # TODO: Figure out a way to pull in libgit2, which doesn't crash if this useless variable is gone.
 RUN git config --global --add safe.directory .

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -20,7 +20,7 @@ RUN poetry install
 
 RUN rustup toolchain install nightly-2024-01-12-x86_64-unknown-linux-gnu
 RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
-RUN rustup component add clippy
+RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 ENV PATH=$POETRY_HOME/bin:$PATH
 
-RUN pacman -Syu rustup mold openssl libgit2 git docker \
+RUN pacman -Syu rustup mold openssl libgit2 git docker jq \
     docker-buildx docker-compose glibc lib32-glibc \
     python python-pip --noconfirm --disable-download-timeout && \
     curl -sSL https://install.python-poetry.org | python3 -
@@ -20,11 +20,11 @@ RUN poetry install
 
 RUN rustup toolchain install nightly-2024-01-12_64-unknown-linux-gnu
 RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
-RUN rustup component add llvm-tools-preview clippy
+RUN rustup component add clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install cargo-llvm-cov
+RUN cargo install grcov
 
 # TODO: Figure out a way to pull in libgit2, which doesn't crash if this useless variable is gone.
 RUN git config --global --add safe.directory .

--- a/Dockerfile.build.glibc
+++ b/Dockerfile.build.glibc
@@ -20,7 +20,7 @@ RUN poetry install
 
 RUN rustup toolchain install nightly-2024-01-12_64-unknown-linux-gnu
 RUN rustup default nightly-2024-01-12-x86_64-unknown-linux-gnu
-RUN rustup component add clippy
+RUN rustup component add llvm-tools-preview clippy
 RUN rustup component add rust-src
 RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.projectKey=hyperledger:iroha


### PR DESCRIPTION
## Description
1. Substitute `llvm-cov` coverage tool by `grcov` (only `grcov` generates coverage reports that are compatible with Sonarqube).
2. Add jobs and steps into workflows to set up `lcov` and `clippy` reports uploading to Sonarqube and Defectdojo.
3. Bump `actions/checkout` somewhere.
4. Update `Dockerfiles.build`.

### Benefits
iroha2 dev code will be analyzed in Sonarqube and Defectdojo tools. Links to services URL will be provide in DM. It has access via corporate LDAP account.

### Note
It would be much better to send generared `clippy` and `lcov` reports from PR workflow where are they actually are generated. But we can't do it since GitHub actions security policies. So, we might try at least to upload them during pushing to dev branch. Hopefully, `dawidd6/action-download-artifact` has a magic to search for the latest uploaded artifact from the particular workflow.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
