### PR TITLE
[chore] #4433: Reflect branch changes in files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,12 @@ New to our project? [Make your first contribution](#your-first-code-contribution
 ### TL;DR
 
 - Find [ZenHub](https://app.zenhub.com/workspaces/iroha-v2-60ddb820813b9100181fc060/board?repos=181739240).
-- Fork [Iroha](https://github.com/hyperledger/iroha/tree/iroha2-dev).
+- Fork [Iroha](https://github.com/hyperledger/iroha/tree/main).
 - Fix your issue of choice.
 - Ensure you follow our [style guides](#style-guides) for code and documentation.
 - Write [tests](https://doc.rust-lang.org/cargo/commands/cargo-test.html). Ensure they all pass (`cargo test --workspace`).
 - Perform pre-commit routine like formatting & artifacts regeneration (see [`pre-commit.sample`](./hooks/pre-commit.sample))
-- With the `upstream` set to track [Hyperledger Iroha repository](https://github.com/hyperledger/iroha), `git pull -r upstream iroha2-dev`, `git commit -s`, `git push <your-fork>`, and [create a pull request](https://github.com/hyperledger/iroha/compare) to the `iroha2-dev` branch. Ensure the PR has the `[type] #<issue number>: Description` [title](#pull-request-titles).
+- With the `upstream` set to track [Hyperledger Iroha repository](https://github.com/hyperledger/iroha), `git pull -r upstream main`, `git commit -s`, `git push <your-fork>`, and [create a pull request](https://github.com/hyperledger/iroha/compare) to the `main` branch. Ensure the PR has the `[type] #<issue number>: Description` [title](#pull-request-titles).
 
 ### Reporting Bugs
 
@@ -121,7 +121,7 @@ You, as part of the aforementioned community, should consider helping others too
 
 ## Pull Request Etiquette
 
-Please [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the [repository](https://github.com/hyperledger/iroha/tree/iroha2-dev) and [create a feature branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) for your contributions. When working with **PRs from forks**, check [this manual](https://help.github.com/articles/checking-out-pull-requests-locally).
+Please [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the [repository](https://github.com/hyperledger/iroha/tree/main) and [create a feature branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) for your contributions. When working with **PRs from forks**, check [this manual](https://help.github.com/articles/checking-out-pull-requests-locally).
 
 Working on code contribution:
 - Follow the [Rust Style Guide](#rust-style-guide) and the [Documentation Style Guide](#documentation-style-guide).
@@ -130,7 +130,7 @@ Working on code contribution:
 Committing your work:
 - Follow the [Git Style Guide](#git-workflow).
 - Squash your commits [either before](https://www.git-tower.com/learn/git/faq/git-squash/) or [during the merge](https://rietta.com/blog/github-merge-types/).
-- If during the preparation of your pull request your branch got out of date, rebase it locally with `git pull --rebase upstream iroha2-dev`. Alternatively, you may use the drop-down menu for the `Update branch` button and choose the `Update with rebase` option.
+- If during the preparation of your pull request your branch got out of date, rebase it locally with `git pull --rebase upstream main`. Alternatively, you may use the drop-down menu for the `Update branch` button and choose the `Update with rebase` option.
 
   In the interest of making this process easier for everyone, try not to have more than a handful of commits for a pull request, and avoid re-using feature branches.
 
@@ -187,8 +187,8 @@ To pass the *`check-PR-title`* check, the pull request should have the title tha
 
 ### Git Workflow
 
-- [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the [repository](https://github.com/hyperledger/iroha/tree/iroha2-dev) and [create a feature branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) for your contributions.
-- [Configure the remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork) to sync your fork with the [Hyperledger Iroha repository](https://github.com/hyperledger/iroha/tree/iroha2-dev).
+- [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the [repository](https://github.com/hyperledger/iroha/tree/main) and [create a feature branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository) for your contributions.
+- [Configure the remote](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork) to sync your fork with the [Hyperledger Iroha repository](https://github.com/hyperledger/iroha/tree/main).
 - Use the [Git Rebase Workflow](https://git-rebase.io/). Avoid using `git pull`. Use `git pull --rebase` instead.
 - Use the provided [git hooks](./hooks/) to ease the development process.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hyperledger Iroha
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![Rust](https://github.com/hyperledger/iroha/workflows/Rust/badge.svg?branch=iroha2-dev)
+![Rust](https://github.com/hyperledger/iroha/workflows/Rust/badge.svg?branch=main)
 
 Iroha is a simple and efficient blockchain ledger based on the **distributed ledger technology (DLT)**. Its design principles are inspired by the Japanese Kaizen principle of eliminating excesses (*muri*).
 

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,7 @@ Follow the [Iroha 2 tutorial](https://hyperledger.github.io/iroha-2-docs/guide/r
 Add the following to the manifest file of your Rust project:
 
 ```toml
-iroha_client = { git = "https://github.com/hyperledger/iroha", branch = "iroha2-dev" }
+iroha_client = { git = "https://github.com/hyperledger/iroha", branch = "main" }
 ```
 
 ## Examples

--- a/client/benches/tps/README.md
+++ b/client/benches/tps/README.md
@@ -6,9 +6,9 @@ Benchmark your code during development and get a statistical report with tps mea
 
 1. Establish a baseline:
 
-    Checkout the target branch (`iroha2-dev`):
+    Checkout the target branch (`main`):
     ```
-    git checkout iroha2-dev
+    git checkout main
     ```
     Then run:
     ```

--- a/docs/source/release_procedure.org
+++ b/docs/source/release_procedure.org
@@ -69,9 +69,7 @@ discretion.
 * Development
 
 The Iroha ledger is to accumulate committed changes into the
-=iroha2-dev= branch (until the announcement of the deprecation of
-Iroha v1, and renaming of the branches to fit the new pecking
-order). All commits must be signed-off (for reasons of legal
+=main= branch. All commits must be signed-off (for reasons of legal
 liability), and all merged commits must be merged with an "all green"
 continuous integration test report. Merging with unsatisfied
 requirements is left up to the technical lead's discretion, with them
@@ -98,7 +96,7 @@ conduct a pre-release sync meeting. The technical lead's
 responsibility is to then appraise all present of the main
 API-breaking changes that might require attention. In preparation, the
 technical lead is encouraged to walk through the differential of the
-current =iroha2-stable= branch and =iroha2-dev= to find any changes in
+current =stable= branch and =main= to find any changes in
 =schema.json= as well as other tell-tale signs of API breakage.
 
 Any major API breaking changes beyond this point are discouraged,
@@ -114,8 +112,8 @@ process]] must be invoked.
 
 The release window opening announcement is followed by the release of
 a =nightly= docker container through the continuous delivery
-system. Following that, a Pull Request from the =iroha2-dev= to the
-=iroha2-stable= (and =iroha2-lts= according to [[lts_selection.org]]) is
+system. Following that, a Pull Request from the =main= to the
+=stable= (and =iroha2-lts= according to [[lts_selection.org]]) is
 created, with the release checklist as the description. Points on the
 checklist are ticked off as soon as they are met.
 
@@ -135,7 +133,7 @@ the relevant chat.
 The following is a suggested version of the description of the pull
 request for the relevant branches.
 
-- [ ] The current =iroha2-dev= passes all Continuous integration
+- [ ] The current =main= passes all Continuous integration
   checks
 - [ ] The current =nightly= build was published and links provided to
   major SDK developers
@@ -164,7 +162,7 @@ through an architectural changes process called "request for comments"
 (RFC).  This entails:
 
 1. The proposer of the changes must open a pull request into the
-   =iroha2-dev= branch containing a file submitted to
+   =main= branch containing a file submitted to
    =docs/source/rfc/= in a format of their choosing (markdown, org,
    ReST), containing a detailed explanation of the changes.
 

--- a/macro/README.md
+++ b/macro/README.md
@@ -9,7 +9,7 @@ This crate contains macros and attributes for Iroha projects:
 Add the following to the manifest file of your Rust project:
 
 ```toml
-iroha_derive = { git = "https://github.com/hyperledger/iroha/", branch="iroha2-dev" }
+iroha_derive = { git = "https://github.com/hyperledger/iroha/", branch="main" }
 ```
 
 ## Examples

--- a/scripts/update_configs.sh
+++ b/scripts/update_configs.sh
@@ -17,9 +17,9 @@ if [ "$1" != "stable" ] && [ "$1" != "lts" ]; then
     echo $MSG && exit 1
 fi
 
-curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -o ./configs/client/$1/config.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/stable/configs/peer/config.json -o ./configs/client/$1/config.json
 curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-lts/configs/peer/config.json -o ./configs/client/$1/config.json
 
-curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/config.json -o ./configs/peer/$1/config.json
-curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/genesis.json -o ./configs/peer/$1/genesis.json
-curl https://raw.githubusercontent.com/hyperledger/iroha/iroha2-stable/configs/peer/executor.wasm -o ./configs/peer/$1/executor.wasm
+curl https://raw.githubusercontent.com/hyperledger/iroha/stable/configs/peer/config.json -o ./configs/peer/$1/config.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/stable/configs/peer/genesis.json -o ./configs/peer/$1/genesis.json
+curl https://raw.githubusercontent.com/hyperledger/iroha/stable/configs/peer/executor.wasm -o ./configs/peer/$1/executor.wasm


### PR DESCRIPTION
## Description

Replace references to `iroha2-dev` with `main`, and `iroha2-stable` with `stable`. Leave `iroha2-lts` untouched for now, delete later.

### Linked issue

Related to #4433.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up