### PR TITLE
[refactor] #3240: Guard against secrets leakage

### DIFF
--- a/config/tests/fixtures.rs
+++ b/config/tests/fixtures.rs
@@ -63,9 +63,7 @@ fn minimal_config_snapshot() -> Result<()> {
                             "ed01208BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB",
                         ),
                     ),
-                    private_key: ed25519(
-                        "8F4C15E5D664DA3F13778801D23D4E89B76E94C1B94B389544168B6CB894F84F8BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB",
-                    ),
+                    private_key: "[REDACTED PrivateKey]",
                 },
                 p2p_address: 127.0.0.1:1337,
             },
@@ -309,9 +307,7 @@ fn full_envs_set_is_consumed() -> Result<()> {
                 ),
             ),
             private_key: Some(
-                ed25519(
-                    "8F4C15E5D664DA3F13778801D23D4E89B76E94C1B94B389544168B6CB894F84F8BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB",
-                ),
+                "[REDACTED PrivateKey]",
             ),
             genesis: GenesisPartial {
                 public_key: Some(
@@ -322,9 +318,7 @@ fn full_envs_set_is_consumed() -> Result<()> {
                     ),
                 ),
                 private_key: Some(
-                    ed25519(
-                        "8F4C15E5D664DA3F13778801D23D4E89B76E94C1B94B389544168B6CB894F84F8BA62848CF767D72E7F7F4B9D2D7BA07FEE33760F79ABE5597A51520E292A0CB",
-                    ),
+                    "[REDACTED PrivateKey]",
                 ),
                 file: None,
             },

--- a/crypto/src/secrecy.rs
+++ b/crypto/src/secrecy.rs
@@ -1,0 +1,36 @@
+//! This is analogue of `secrecy` crate,
+//! but it requires `ZeroizeOnDrop` trait instead of `Zeroize`.
+
+use zeroize::ZeroizeOnDrop;
+
+#[derive(Clone)]
+pub struct Secret<S>
+where
+    S: ZeroizeOnDrop + Clone,
+{
+    inner_secret: S,
+}
+
+impl<S> Secret<S>
+where
+    S: ZeroizeOnDrop + Clone,
+{
+    pub fn new(secret: S) -> Self {
+        Self {
+            inner_secret: secret,
+        }
+    }
+}
+
+pub trait ExposeSecret<S> {
+    fn expose_secret(&self) -> &S;
+}
+
+impl<S> ExposeSecret<S> for Secret<S>
+where
+    S: ZeroizeOnDrop + Clone,
+{
+    fn expose_secret(&self) -> &S {
+        &self.inner_secret
+    }
+}

--- a/crypto/src/signature/ed25519.rs
+++ b/crypto/src/signature/ed25519.rs
@@ -59,7 +59,9 @@ mod test {
 
     use self::Ed25519Sha512;
     use super::*;
-    use crate::{signature::ed25519, Algorithm, KeyGenOption, PrivateKey, PublicKey};
+    use crate::{
+        secrecy::Secret, signature::ed25519, Algorithm, KeyGenOption, PrivateKey, PublicKey,
+    };
 
     const MESSAGE_1: &[u8] = b"This is a dummy message for use with tests";
     const SIGNATURE_1: &str = "451b5b8e8725321541954997781de51f4142e4a56bab68d24f6a6b92615de5eefb74134138315859a32c7cf5fe5a488bc545e2e08e5eedfd1fb10188d532d808";
@@ -86,7 +88,7 @@ mod test {
         let (p1, s1) = key_pair_factory();
 
         assert_eq!(
-            PrivateKey(Box::new(crate::PrivateKeyInner::Ed25519(s1))),
+            PrivateKey(Box::new(Secret::new(crate::PrivateKeyInner::Ed25519(s1)))),
             PrivateKey::from_hex(Algorithm::Ed25519, PRIVATE_KEY).unwrap()
         );
         assert_eq!(

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -67,7 +67,8 @@ impl Signature {
 
     /// Creates new signature by signing payload via [`KeyPair::private_key`].
     pub fn new(key_pair: &KeyPair, payload: &[u8]) -> Self {
-        let signature = match key_pair.private_key.0.borrow() {
+        use crate::secrecy::ExposeSecret;
+        let signature = match key_pair.private_key.0.expose_secret() {
             crate::PrivateKeyInner::Ed25519(sk) => ed25519::Ed25519Sha512::sign(payload, sk),
             crate::PrivateKeyInner::Secp256k1(sk) => {
                 secp256k1::EcdsaSecp256k1Sha256::sign(payload, sk)


### PR DESCRIPTION
## Description

* Added `Secret` to `PrivateKey`. Access to inner `PrivateKeyInner` now requires import of `ExposeSecret` trait via `expose_secret` method
* `Display`, `Debug` and `Serialize` implementations for `PrivateKey` now returns `"[REDACTED]"`
* Added `ExposedPrivateKey` wrapper which can be formatted and serialized as usual
* Note that I don't used `secrecy` crate because it requires to implement `Zeroize` trait, but inner key struct (`ed25519_dalek::SigningKey`) implement only `ZeroizeOnDrop`, and not `Zeroize`. So I used modified version of `Secret` which requires `ZeroizeOnDrop` instead of `Zeroize`. This potentially could be controversal, so any suggestions are welcome

### Linked issue

Closes #3240

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
