### PR TITLE
[fix] #4332: Remove corresponding triggers on `Unregister<Domain>`

### DIFF
--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -119,7 +119,16 @@ pub mod isi {
         ) -> Result<(), Error> {
             let domain_id = self.object_id;
 
+            let triggers_in_domain = state_transaction
+                .world()
+                .triggers()
+                .inspect_by_domain_id(&domain_id, |trigger_id, _| trigger_id.clone())
+                .collect::<Vec<_>>();
+
             let world = &mut state_transaction.world;
+            triggers_in_domain.iter().for_each(|trigger_id| {
+                assert!(world.triggers.remove(trigger_id));
+            });
             if world.domains.remove(domain_id.clone()).is_none() {
                 return Err(FindError::Domain(domain_id).into());
             }


### PR DESCRIPTION
### Description of the Change

Triggers that are living in a domain are now deleted when that domain is deleted.

Closes #4332 

### Benefits

Fixes the bug.

### Possible Drawbacks 
None

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
