### PR TITLE
[chore]: Revert "Bump zeroize from 1.7.0 to 1.8.0 (#4506)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7269,9 +7269,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -75,7 +75,7 @@ rand_core = { version = "0.6.4", default-features = false, features = ["alloc"] 
 rand_chacha = { version = "0.3.1", default-features = false }
 
 
-zeroize = { version = "1.8.0", default-features = false }
+zeroize = { version = "1.7.0", default-features = false }
 arrayref = { version = "0.3.7", default-features = false }
 
 aead = { version = "0.5.2", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This version was [yanked](https://crates.io/crates/zeroize/1.8.0), it will break iroha builds when the lockfile gets updated (on any change in dependencies)