### PR TITLE
[ci] #4501: Remove `iroha2` labeler matcher

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,6 @@
-iroha2:
-  - base-branch: ['main', 'stable']
-
 api-changes:
   - all:
-    - base-branch: '^main$'
+    - base-branch: 'main'
     - changed-files:
       - any-glob-to-any-file:
         - 'docs/source/references/schema.json'
@@ -12,7 +9,7 @@ api-changes:
 
 config-changes:
   - all:
-    - base-branch: '^main$'
+    - base-branch: 'main'
     - changed-files:
-      # TODO have templates actually reflect configrations #4288
+      # TODO have templates actually reflect configurations #4288
       - any-glob-to-any-file: 'configs/*.template.toml'


### PR DESCRIPTION
## Description

Stop labeling PRs with the `iroha2` label. 

### Linked issue

Linked to #4501.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
