### PR TITLE
ci: trigger PR CI on lockfile updates

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -7,6 +7,7 @@ on:
       - '**.rs'
       - '**.json'
       - '**.toml'
+      - '**.lock'
       - '.github/workflows/iroha2-dev-pr.yml'
 
 concurrency:


### PR DESCRIPTION
## Description

Trigger PR CI when `.lock` files are updated. 

### Benefits

pytests will run on dependabot version updates

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
