### PR TITLE
fix: remove serde(flatten) from SetKeyValue/RemoveKeyValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 
+## [2.0.0-pre-rc.21.2] - 2024-05-03
+
+### Fixed
+
+- remove serde(flatten) from SetKeyValue/RemoveKeyValue (#4546)
+
 ## [2.0.0-pre-rc.21.1] - 2024-05-01
+
+### Fixed
 
 - add RawGenesisBlock to schema (#4538)
 - remove nested option on `TransactionEventFilter::block_height` (#4538)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "iroha"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "assertables",
  "clap",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_client"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "attohttpc",
  "base64",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_client_cli"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_config"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_config_base"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "drop_bomb",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_core"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "async-trait",
  "byte-unit",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_core_wasm_codec_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_crypto"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "aead",
  "amcl",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "base64",
  "criterion",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "derive_more",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "impls",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_executor_derive",
  "iroha_schema",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_ffi"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "getset",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_ffi_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "getset",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_futures"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_futures_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_genesis"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "eyre",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_logger"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "color-eyre",
  "console-subscriber",
@@ -3114,14 +3114,14 @@ dependencies = [
 
 [[package]]
 name = "iroha_macro"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_derive",
 ]
 
 [[package]]
 name = "iroha_macro_utils"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_numeric"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_p2p"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_numeric",
  "iroha_primitives",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "impls",
  "iroha_schema_derive",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "iroha_schema",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_gen"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_crypto",
  "iroha_data_model",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "derive_more",
  "getrandom",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_smart_contract_utils"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_data_model",
  "parity-scale-codec",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_swarm"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_core",
  "iroha_macro_utils",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_torii"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "async-trait",
  "displaydoc",
@@ -3366,14 +3366,14 @@ dependencies = [
 
 [[package]]
 name = "iroha_torii_const"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_primitives",
 ]
 
 [[package]]
 name = "iroha_torii_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_trigger"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_smart_contract",
  "iroha_smart_contract_utils",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_trigger_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_version"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_data_model",
  "iroha_logger",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_version_derive"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "darling",
  "iroha_macro",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_builder"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "eyre",
  "path-absolutize",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_builder_cli"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_codec"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "iroha_core_wasm_codec_derive",
  "parity-scale-codec",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_wasm_test_runner"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "anyhow",
  "wasmtime",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kagami"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "color-eyre",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "kura_inspector"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "iroha_core",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "parity_scale_decoder"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "clap",
  "colored",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "test_network"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 dependencies = [
  "eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2021"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 # TODO: teams are being deprecated update the authors URL
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 
@@ -15,45 +15,45 @@ categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
 iroha = { path = "cli" }
-iroha_torii = { version = "=2.0.0-pre-rc.21.1", path = "torii" }
-iroha_torii_derive = { version = "=2.0.0-pre-rc.21.1", path = "torii/derive" }
-iroha_torii_const = { version = "=2.0.0-pre-rc.21.1", path = "torii/const" }
-iroha_macro_utils = { version = "=2.0.0-pre-rc.21.1", path = "macro/utils" }
-iroha_telemetry = { version = "=2.0.0-pre-rc.21.1", path = "telemetry" }
-iroha_telemetry_derive = { version = "=2.0.0-pre-rc.21.1", path = "telemetry/derive" }
-iroha_p2p = { version = "=2.0.0-pre-rc.21.1", path = "p2p" }
-iroha_core = { version = "=2.0.0-pre-rc.21.1 ", path = "core" }
-iroha_primitives = { version = "=2.0.0-pre-rc.21.1", path = "primitives", default-features = false }
-iroha_primitives_derive = { version = "=2.0.0-pre-rc.21.1", path = "primitives/derive" }
-iroha_data_model = { version = "=2.0.0-pre-rc.21.1", path = "data_model", default-features = false }
-iroha_data_model_derive = { version = "=2.0.0-pre-rc.21.1", path = "data_model/derive" }
-iroha_client = { version = "=2.0.0-pre-rc.21.1", path = "client" }
-iroha_config = { version = "=2.0.0-pre-rc.21.1", path = "config" }
-iroha_config_base = { version = "=2.0.0-pre-rc.21.1", path = "config/base" }
-iroha_schema_gen = { version = "=2.0.0-pre-rc.21.1", path = "schema/gen" }
-iroha_schema = { version = "=2.0.0-pre-rc.21.1", path = "schema", default-features = false }
-iroha_schema_derive = { version = "=2.0.0-pre-rc.21.1", path = "schema/derive" }
-iroha_logger = { version = "=2.0.0-pre-rc.21.1", path = "logger" }
-iroha_crypto = { version = "=2.0.0-pre-rc.21.1", path = "crypto", default-features = false }
-iroha_macro = { version = "=2.0.0-pre-rc.21.1", path = "macro", default-features = false }
-iroha_derive = { version = "=2.0.0-pre-rc.21.1", path = "macro/derive" }
-iroha_futures = { version = "=2.0.0-pre-rc.21.1", path = "futures" }
-iroha_futures_derive = { version = "=2.0.0-pre-rc.21.1", path = "futures/derive" }
-iroha_genesis = { version = "=2.0.0-pre-rc.21.1", path = "genesis" }
-iroha_ffi = { version = "=2.0.0-pre-rc.21.1", path = "ffi" }
-iroha_ffi_derive = { version = "=2.0.0-pre-rc.21.1", path = "ffi/derive" }
-iroha_version = { version = "=2.0.0-pre-rc.21.1", path = "version", default-features = false }
-iroha_version_derive = { version = "=2.0.0-pre-rc.21.1", path = "version/derive", default-features = false }
-iroha_wasm_codec = { version = "=2.0.0-pre-rc.21.1", path = "wasm_codec" }
-iroha_wasm_builder = { version = "=2.0.0-pre-rc.21.1", path = "wasm_builder" }
+iroha_torii = { version = "=2.0.0-pre-rc.21.2", path = "torii" }
+iroha_torii_derive = { version = "=2.0.0-pre-rc.21.2", path = "torii/derive" }
+iroha_torii_const = { version = "=2.0.0-pre-rc.21.2", path = "torii/const" }
+iroha_macro_utils = { version = "=2.0.0-pre-rc.21.2", path = "macro/utils" }
+iroha_telemetry = { version = "=2.0.0-pre-rc.21.2", path = "telemetry" }
+iroha_telemetry_derive = { version = "=2.0.0-pre-rc.21.2", path = "telemetry/derive" }
+iroha_p2p = { version = "=2.0.0-pre-rc.21.2", path = "p2p" }
+iroha_core = { version = "=2.0.0-pre-rc.21.2 ", path = "core" }
+iroha_primitives = { version = "=2.0.0-pre-rc.21.2", path = "primitives", default-features = false }
+iroha_primitives_derive = { version = "=2.0.0-pre-rc.21.2", path = "primitives/derive" }
+iroha_data_model = { version = "=2.0.0-pre-rc.21.2", path = "data_model", default-features = false }
+iroha_data_model_derive = { version = "=2.0.0-pre-rc.21.2", path = "data_model/derive" }
+iroha_client = { version = "=2.0.0-pre-rc.21.2", path = "client" }
+iroha_config = { version = "=2.0.0-pre-rc.21.2", path = "config" }
+iroha_config_base = { version = "=2.0.0-pre-rc.21.2", path = "config/base" }
+iroha_schema_gen = { version = "=2.0.0-pre-rc.21.2", path = "schema/gen" }
+iroha_schema = { version = "=2.0.0-pre-rc.21.2", path = "schema", default-features = false }
+iroha_schema_derive = { version = "=2.0.0-pre-rc.21.2", path = "schema/derive" }
+iroha_logger = { version = "=2.0.0-pre-rc.21.2", path = "logger" }
+iroha_crypto = { version = "=2.0.0-pre-rc.21.2", path = "crypto", default-features = false }
+iroha_macro = { version = "=2.0.0-pre-rc.21.2", path = "macro", default-features = false }
+iroha_derive = { version = "=2.0.0-pre-rc.21.2", path = "macro/derive" }
+iroha_futures = { version = "=2.0.0-pre-rc.21.2", path = "futures" }
+iroha_futures_derive = { version = "=2.0.0-pre-rc.21.2", path = "futures/derive" }
+iroha_genesis = { version = "=2.0.0-pre-rc.21.2", path = "genesis" }
+iroha_ffi = { version = "=2.0.0-pre-rc.21.2", path = "ffi" }
+iroha_ffi_derive = { version = "=2.0.0-pre-rc.21.2", path = "ffi/derive" }
+iroha_version = { version = "=2.0.0-pre-rc.21.2", path = "version", default-features = false }
+iroha_version_derive = { version = "=2.0.0-pre-rc.21.2", path = "version/derive", default-features = false }
+iroha_wasm_codec = { version = "=2.0.0-pre-rc.21.2", path = "wasm_codec" }
+iroha_wasm_builder = { version = "=2.0.0-pre-rc.21.2", path = "wasm_builder" }
 
-iroha_smart_contract = { version = "=2.0.0-pre-rc.21.1", path = "smart_contract" }
-iroha_smart_contract_derive = { version = "=2.0.0-pre-rc.21.1", path = "smart_contract/derive" }
-iroha_smart_contract_utils = { version = "=2.0.0-pre-rc.21.1", path = "smart_contract/utils" }
-iroha_executor_derive = { version = "=2.0.0-pre-rc.21.1", path = "smart_contract/executor/derive" }
-iroha_trigger_derive = { version = "=2.0.0-pre-rc.21.1", path = "smart_contract/trigger/derive" }
+iroha_smart_contract = { version = "=2.0.0-pre-rc.21.2", path = "smart_contract" }
+iroha_smart_contract_derive = { version = "=2.0.0-pre-rc.21.2", path = "smart_contract/derive" }
+iroha_smart_contract_utils = { version = "=2.0.0-pre-rc.21.2", path = "smart_contract/utils" }
+iroha_executor_derive = { version = "=2.0.0-pre-rc.21.2", path = "smart_contract/executor/derive" }
+iroha_trigger_derive = { version = "=2.0.0-pre-rc.21.2", path = "smart_contract/trigger/derive" }
 
-test_network = { version = "=2.0.0-pre-rc.21.1", path = "core/test_network" }
+test_network = { version = "=2.0.0-pre-rc.21.2", path = "core/test_network" }
 proc-macro2 = "1.0.81"
 syn = { version = "2.0.60", default-features = false }
 quote = "1.0.36"

--- a/client/tests/integration/smartcontracts/Cargo.toml
+++ b/client/tests/integration/smartcontracts/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2021"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 # TODO: teams are being deprecated update the authors URL
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 
@@ -28,10 +28,10 @@ opt-level = "z"     # Optimize for size vs speed with "s"/"z"(removes vectorizat
 codegen-units = 1   # Further reduces binary size but increases compilation time
 
 [workspace.dependencies]
-iroha_smart_contract = { version = "=2.0.0-pre-rc.21.1", path = "../../../../smart_contract", features = ["debug"]}
-iroha_trigger = { version = "=2.0.0-pre-rc.21.1", path = "../../../../smart_contract/trigger", features = ["debug"]}
-iroha_executor = { version = "=2.0.0-pre-rc.21.1", path = "../../../../smart_contract/executor" }
-iroha_schema = { version = "=2.0.0-pre-rc.21.1", path = "../../../../schema" }
+iroha_smart_contract = { version = "=2.0.0-pre-rc.21.2", path = "../../../../smart_contract", features = ["debug"]}
+iroha_trigger = { version = "=2.0.0-pre-rc.21.2", path = "../../../../smart_contract/trigger", features = ["debug"]}
+iroha_executor = { version = "=2.0.0-pre-rc.21.2", path = "../../../../smart_contract/executor" }
+iroha_schema = { version = "=2.0.0-pre-rc.21.2", path = "../../../../schema" }
 
 parity-scale-codec = { version = "3.2.1", default-features = false }
 anyhow = { version = "1.0.71", default-features = false }

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -280,7 +280,6 @@ mod transparent {
         #[schema(bounds = "O: Identifiable, O::Id: IntoSchema")]
         pub struct SetKeyValue<O: Identifiable> {
             /// Where to set key value.
-            #[serde(flatten)]
             pub object_id: O::Id,
             /// Key.
             pub key: Name,
@@ -381,7 +380,6 @@ mod transparent {
         #[schema(bounds = "O: Identifiable, O::Id: IntoSchema")]
         pub struct RemoveKeyValue<O: Identifiable> {
             /// From where to remove key value.
-            #[serde(flatten)]
             pub object_id: O::Id,
             /// Key of the pair to remove.
             pub key: Name,

--- a/default_executor/Cargo.toml
+++ b/default_executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "iroha_default_executor"
 
 edition = "2021"
-version = "2.0.0-pre-rc.21.1"
+version = "2.0.0-pre-rc.21.2"
 # TODO: teams are being deprecated update the authors URL
 authors = ["Iroha 2 team <https://github.com/orgs/soramitsu/teams/iroha2>"]
 
@@ -24,7 +24,7 @@ opt-level = "z"     # Optimize for size vs speed with "s"/"z"(removes vectorizat
 codegen-units = 1   # Further reduces binary size but increases compilation time
 
 [dependencies]
-iroha_executor = { version = "2.0.0-pre-rc.21.1", path = "../smart_contract/executor", features = ["debug"] }
+iroha_executor = { version = "2.0.0-pre-rc.21.2", path = "../smart_contract/executor", features = ["debug"] }
 getrandom = { version = "0.2", features = ["custom"] }
 
 lol_alloc = "0.4.0"

--- a/wasm_codec/Cargo.toml
+++ b/wasm_codec/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-iroha_core_wasm_codec_derive = { version = "=2.0.0-pre-rc.21.1", path = "derive" }
+iroha_core_wasm_codec_derive = { version = "=2.0.0-pre-rc.21.2", path = "derive" }
 
 thiserror = { workspace = true }
 wasmtime = { workspace = true }


### PR DESCRIPTION
## Description

serde cannot flatten `String`s and `O::Id` is always serialized as string. As a consequence it's impossible to serialize/deserialize `SetKeyValue`/`RemoveKeyValue` in genesis

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
