### PR TITLE
fix: remove serde(flatten) from SetKeyValue/RemoveKeyValue

### DIFF
--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -277,7 +277,6 @@ mod transparent {
         #[schema(bounds = "O: Identifiable, O::Id: IntoSchema")]
         pub struct SetKeyValue<O: Identifiable> {
             /// Where to set key value.
-            #[serde(flatten)]
             pub object_id: O::Id,
             /// Key.
             pub key: Name,
@@ -378,7 +377,6 @@ mod transparent {
         #[schema(bounds = "O: Identifiable, O::Id: IntoSchema")]
         pub struct RemoveKeyValue<O: Identifiable> {
             /// From where to remove key value.
-            #[serde(flatten)]
             pub object_id: O::Id,
             /// Key of the pair to remove.
             pub key: Name,


### PR DESCRIPTION
## Description

serde cannot flatten Strings and O::Id is always serialized as string. As a consequence it's impossible to serialize/deserialize SetKeyValue/RemoveKeyValue in genesis

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
