### PR TITLE
ci: fix `with_coverage`, isolate not `unstable` but `extra_functional`

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -70,7 +70,7 @@ jobs:
           path: lcov.info
 
   # include: client/tests/integration/
-  # exclude: "unstable_network"
+  # exclude: client/tests/integration/extra_functional
   integration:
     runs-on: [self-hosted, Linux, iroha2]
     container:
@@ -80,10 +80,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with no-default-features
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client integration -- --skip unstable_network
+        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client integration -- --skip extra_functional
 
-  # include: client/tests/integration/, "unstable_network"
-  unstable:
+  # include: client/tests/integration/extra_functional
+  extra_functional:
     runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-04-18
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client unstable_network
+        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client extra_functional
 
   # Run the job to check that the docker containers are properly buildable
   pr-generator-build:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -36,6 +36,7 @@ jobs:
         if: always()
         run: ./scripts/tests/consistency.sh docker-compose
 
+  # exclude: client/tests/integration/
   with_coverage:
     runs-on: [self-hosted, Linux, iroha2]
     container:
@@ -44,7 +45,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with coverage
-        run: mold --run cargo test --all-features --workspace --no-fail-fast
+        run: |
+          mold --run cargo test --all-features --no-fail-fast --workspace --exclude iroha_client
+          mold --run cargo test --all-features --no-fail-fast -p iroha_client -- --skip integration
         env:
           RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
@@ -66,6 +69,8 @@ jobs:
           name: lcov.info
           path: lcov.info
 
+  # include: client/tests/integration/
+  # exclude: "unstable_network"
   integration:
     runs-on: [self-hosted, Linux, iroha2]
     container:
@@ -75,10 +80,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with no-default-features
-        run: |
-          mold --run cargo test --test mod --no-default-features -- \
-          integration:: --skip unstable_network
+        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client integration -- --skip unstable_network
 
+  # include: client/tests/integration/, "unstable_network"
   unstable:
     runs-on: [self-hosted, Linux, iroha2]
     container:
@@ -88,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: mold --run cargo test -p iroha_client --tests --no-default-features unstable_network --quiet
+        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client unstable_network
 
   # Run the job to check that the docker containers are properly buildable
   pr-generator-build:

--- a/client/tests/mod.rs
+++ b/client/tests/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(not(coverage))]
 mod integration;

--- a/p2p/tests/mod.rs
+++ b/p2p/tests/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(not(coverage))]
 mod integration;


### PR DESCRIPTION
## Description

1. redefine `with_coverage` step to exclude client integration tests 
   - and to include p2p integration tests
2. expand the exception of the client integration tests from `unstable_network` to `extra_functional`

### Linked issue

1. closes https://github.com/hyperledger/iroha/issues/4488#issuecomment-2103228798
	- opens https://github.com/hyperledger/iroha/issues/4584
2. sometimes `integration` step fails due to some flaky `extra_functional` tests

### Benefits

2. isolation of flaky tests more in line with current realities

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
