### PR TITLE
fix(kura): Inline kura initialization into constructor

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -255,11 +255,9 @@ impl Iroha<ToriiNotStarted> {
                 .into_non_empty_vec(),
         );
 
-        let kura = Kura::new(&config.kura).change_context(StartError::InitKura)?;
+        let (kura, block_count) = Kura::new(&config.kura).change_context(StartError::InitKura)?;
         let kura_thread_handler = Kura::start(Arc::clone(&kura));
         let live_query_store_handle = LiveQueryStore::from_config(config.live_query_store).start();
-
-        let block_count = kura.init().change_context(StartError::InitKura)?;
 
         let state = match try_read_snapshot(
             config.snapshot.store_dir.resolve_relative_path(),

--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -42,7 +42,7 @@ async fn measure_block_size_for_n_executors(n_executors: u32) {
         debug_output_new_blocks: false,
         store_dir: WithOrigin::inline(dir.path().to_path_buf()),
     };
-    let kura = iroha_core::kura::Kura::new(&cfg).unwrap();
+    let (kura, _) = iroha_core::kura::Kura::new(&cfg).unwrap();
     let _thread_handle = iroha_core::kura::Kura::start(kura.clone());
 
     let query_handle = LiveQueryStore::test().start();


### PR DESCRIPTION
## Description

Due `init` was separate functions error was introduced where `start` was called before initialization which cause panic in kura.

Fix for that is to inline `init` inside constructor.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4603 <!-- Replace with an actual number,  -->

### How to reproduce

1. start iroha
2. submit few blocks
3. restart iroha

Previously kura would crash, but iroha would continue working without ability to write new blocks to the disk.

<!-- Link if e.g. JIRA issue or  from another repository -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
