### PR TITLE
fix: don't clear events buffer on wsv clone

### DIFF
--- a/core/src/wsv.rs
+++ b/core/src/wsv.rs
@@ -377,7 +377,7 @@ impl Clone for WorldStateView {
             config: self.config,
             block_hashes: self.block_hashes.clone(),
             transactions: self.transactions.clone(),
-            events_buffer: Vec::new(),
+            events_buffer: self.events_buffer.clone(),
             new_tx_amounts: Arc::clone(&self.new_tx_amounts),
             engine: self.engine.clone(),
             kura: Arc::clone(&self.kura),


### PR DESCRIPTION
## Description

When 2 transactions follow each other and the 2nd fails the events from the 1st are not emitted

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
