### PR TITLE
refactor(executor): Check custom visit functions in `#[derive(Visit)]`

### DIFF
--- a/smart_contract/executor/derive/src/default.rs
+++ b/smart_contract/executor/derive/src/default.rs
@@ -173,6 +173,21 @@ pub fn impl_derive_visit(emitter: &mut Emitter, input: &syn::DeriveInput) -> Tok
     })
     .collect();
 
+    for custom_fn_name in custom.as_ref().map_or(&[][..], |custom| &custom.0) {
+        let found = default_visit_sigs
+            .iter()
+            .any(|visit_sig| &visit_sig.ident == custom_fn_name);
+        if !found {
+            emit!(
+                emitter,
+                custom_fn_name.span(),
+                "Unknown custom visit function: {}",
+                custom_fn_name
+            );
+            return quote!();
+        }
+    }
+
     let visit_items = default_visit_sigs
         .iter()
         .map(|visit_sig| {

--- a/smart_contract/executor/derive/src/lib.rs
+++ b/smart_contract/executor/derive/src/lib.rs
@@ -34,7 +34,7 @@ mod validate;
 /// }
 ///
 /// #[entrypoint]
-/// pub fn validate_instruction(authority: AccountId, instruction: InstructionExpr, block_height: u64) -> Result {
+/// pub fn validate_instruction(authority: AccountId, instruction: InstructionBox, block_height: u64) -> Result {
 ///     todo!()
 /// }
 ///
@@ -237,9 +237,8 @@ pub fn derive_ref_into_domain_owner(input: TokenStream) -> Result<TokenStream> {
 /// this trait has a `iroha_executor::prelude::Visit` at least this one should be implemented as well.
 ///
 /// Emits a compile error if the struct didn't have all the expected fields with corresponding
-/// types, i.e. `verdict`: `iroha_executor::prelude::Result`, `block_height`: `u64` and
-/// `host`: `iroha_executor::smart_contract::Host`, though technically only `verdict` and
-/// `block_height` are needed. The types can be unqualified, but not aliased.
+/// types, i.e. `verdict`: `iroha_executor::prelude::Result` and `block_height`: `u64`.
+/// The types can be unqualified, but not aliased.
 #[manyhow]
 #[proc_macro_derive(Validate)]
 pub fn derive_validate(input: TokenStream) -> TokenStream {
@@ -261,21 +260,19 @@ pub fn derive_validate(input: TokenStream) -> TokenStream {
 /// implementation from `iroha_executor::default` module is used.
 ///
 /// Emits a compile error if the struct didn't have all the expected fields with corresponding
-/// types, i.e. `verdict`: `iroha_executor::prelude::Result`, `block_height`: `u64` and
-/// `host`: `iroha_executor::smart_contract::Host`, though technically only `verdict`
-/// is needed. The types can be unqualified, but not aliased.
+/// types, i.e. `verdict`: `iroha_executor::prelude::Result` and `block_height`: `u64`,
+/// though technically only `verdict` is needed. The types can be unqualified, but not aliased.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use iroha_executor::{smart_contract, prelude::*};
+/// use iroha_executor::prelude::*;
 ///
-/// #[derive(Constructor, Entrypoints, Validate, Visit)]
+/// #[derive(Constructor, ValidateEntrypoints, Validate, Visit)]
 /// #[visit(custom(visit_query)]
 /// pub struct Executor {
 ///    verdict: Result,
 ///    block_height: u64,
-///    host: smart_contract::Host,
 /// }
 ///
 /// // Custom visit function should supply a `&mut Executor` as first argument
@@ -308,21 +305,19 @@ pub fn derive_visit(input: TokenStream) -> TokenStream {
 /// supplying corresponding entrypoint function names inside of it.
 ///
 /// Emits a compile error if the struct didn't have all the expected fields with corresponding
-/// types, i.e. `verdict`: `iroha_executor::prelude::Result`, `block_height`: `u64` and
-/// `host`: `iroha_executor::smart_contract::Host`, though technically only `verdict`
-/// is needed. The types can be unqualified, but not aliased.
+/// types, i.e. `verdict`: `iroha_executor::prelude::Result` and `block_height`: `u64`,
+/// though technically only `verdict` is needed. The types can be unqualified, but not aliased.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use iroha_executor::{smart_contract, prelude::*};
+/// use iroha_executor::prelude::*;
 ///
-/// #[derive(Constructor, Entrypoints, Validate, Visit)]
+/// #[derive(Constructor, ValidateEntrypoints, Validate, Visit)]
 /// #[entrypoints(custom(validate_query))]
 /// pub struct Executor {
 ///    verdict: Result,
 ///    block_height: u64,
-///    host: smart_contract::Host,
 /// }
 /// ```
 #[manyhow]
@@ -345,8 +340,8 @@ pub fn derive_entrypoints(input: TokenStream) -> TokenStream {
 /// only the `block_height` needs to be supplied manually.
 ///
 /// Emits a compile error if the struct didn't have all the expected fields with corresponding
-/// types, i.e. `verdict`: `iroha_executor::prelude::Result`, `block_height`: `u64` and
-/// `host`: `iroha_executor::smart_contract::Host`. The types can be unqualified, but not aliased.
+/// types, i.e. `verdict`: `iroha_executor::prelude::Result` and `block_height`: `u64`.
+/// The types can be unqualified, but not aliased.
 #[manyhow]
 #[proc_macro_derive(Constructor)]
 pub fn derive_constructor(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
## Description

While working on #4599, I noticed that in custom executor it is possible to derive `Visit` with invalid `#[visit(custom())]` functions which will be ignored (only rustc error that function is unused). This PR adds check for custom visit function names to avoid potential bugs. Also I updated documentation of some proc-macros related to custom executor.

```rust
#[derive(Constructor, ValidateEntrypoints, Validate, Visit)]
#[visit(custom(visit_register_domain2))]  // typo in visit_register_domain
struct Executor {
    verdict: Result,
    block_height: u64,
}
fn visit_register_domain(...) { ... }
```

### Linked issue

### Benefits

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
