### PR TITLE
ci: Remove coveralls

### DIFF
--- a/.github/workflows/iroha2-dev-code-quality.yml
+++ b/.github/workflows/iroha2-dev-code-quality.yml
@@ -3,75 +3,120 @@ name: I2::Dev::CodeQuality
 on:
   workflow_run:
     workflows: ["I2::Dev::Tests", "I2::Dev::Static"]
-    types: [in_progress]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.actor }}
   cancel-in-progress: true
 
 jobs:
-  workspace_analysis_clippy:
-    runs-on: ubuntu-latest
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Format
-        run: cargo fmt --all -- --check
-      - name: Lints without features
-        if: always()
-        run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
-      - name: Lints with all features enabled
-        if: always()
-        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json | tee clippy.json
-      - name: Documentation
-        if: always()
-        run: cargo doc --no-deps --quiet
-      - name: Upload clippy report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: clippy.json
-          path: clippy.json
+  # workspace_analysis_clippy:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Format
+  #       run: cargo fmt --all -- --check
+  #     - name: Lints without features
+  #       if: always()
+  #       run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
+  #     - name: Lints with all features enabled
+  #       if: always()
+  #       run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json | tee clippy.json
+  #     - name: Documentation
+  #       if: always()
+  #       run: cargo doc --no-deps --quiet
+  #     - name: Upload clippy report artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: clippy.json
+  #         path: clippy.json
 
-  # exclude: client/tests/integration/
-  with_coverage:
-    runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests, with coverage
-        run: |
-          mold --run cargo test --all-features --no-fail-fast --workspace --exclude iroha_client
-          mold --run cargo test --all-features --no-fail-fast -p iroha_client -- --skip integration
-        env:
-          RUSTFLAGS: "-C instrument-coverage"
-          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
-      - name: Generate lcov report
-        if: always()
-        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli" --ignore "**/main.rs" -o lcov.info
-      - name: Upload lcov report artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov.info
-          path: lcov.info
+  # # exclude: client/tests/integration/
+  # with_coverage:
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Run tests, with coverage
+  #       run: |
+  #         mold --run cargo test --all-features --no-fail-fast --workspace --exclude iroha_client
+  #         mold --run cargo test --all-features --no-fail-fast -p iroha_client -- --skip integration
+  #       env:
+  #         RUSTFLAGS: "-C instrument-coverage"
+  #         LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
+  #     - name: Generate lcov report
+  #       if: always()
+  #       run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli" --ignore "**/main.rs" -o lcov.info
+  #     - name: Upload lcov report artifact
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: lcov.info
+  #        path: lcov.info
 
   sonarqube-defectdojo:
-    if: ${{ always() }}
-    needs: [workspace_analysis_clippy, with_coverage]
+    #if: ${{ always() }}
+    #needs: [workspace_analysis_clippy, with_coverage]
     runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-04-18
     steps:
-      - uses: actions/checkout@v4
-      - name: Download clippy and lcov artifact reports
-        uses: actions/download-artifact@v4
+      # - uses: actions/checkout@v4
+      # - name: Download clippy and lcov artifact reports
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     path: lints
+      #     merge-multiple: true
+      - name: Download clippy report
+        uses: actions/github-script@v7
         with:
-          path: lints
-          merge-multiple: true
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clippy.json"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/clippy.json.zip, Buffer.from(download.data));
+      - name: Download lcov report
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "lcov.info"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/lcov.info.zip, Buffer.from(download.data));
+      - name: Unzip reports
+        run: |
+          unzip clippy.json.zip
+          unzip lcov.info.zip
       - name: SonarQube
         uses: sonarsource/sonarqube-scan-action@master
         env:
@@ -79,8 +124,8 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         with:
           args: >
-            -Dcommunity.rust.clippy.reportPaths=lints/clippy.json
-            -Dcommunity.rust.lcov.reportPaths=lints/lcov.info
+            -Dcommunity.rust.clippy.reportPaths=clippy.json
+            -Dcommunity.rust.lcov.reportPaths=lcov.info
       - name: DefectDojo
         id: defectdojo
         uses: C4tWithShell/defectdojo-action@1.0.4
@@ -90,7 +135,7 @@ jobs:
           product_type: iroha2
           engagement: ${{ github.ref_name }}
           tools: "SonarQube API Import,Github Vulnerability Scan"
-          sonar_projectKey: hyperledger:iroha
+          sonar_projectKey: bastos525:soramitsu-iroha
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_repository: ${{ github.repository }}
           product: ${{ github.repository }}

--- a/.github/workflows/iroha2-dev-code-quality.yml
+++ b/.github/workflows/iroha2-dev-code-quality.yml
@@ -114,10 +114,12 @@ jobs:
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/lcov.info.zip, Buffer.from(download.data));
       - name: Unzip reports
+        if: always()
         run: |
           unzip clippy.json.zip
           unzip lcov.info.zip
       - name: SonarQube
+        if: always()
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -127,6 +129,7 @@ jobs:
             -Dcommunity.rust.clippy.reportPaths=clippy.json
             -Dcommunity.rust.lcov.reportPaths=lcov.info
       - name: DefectDojo
+        if: always()
         id: defectdojo
         uses: C4tWithShell/defectdojo-action@1.0.4
         with:

--- a/.github/workflows/iroha2-dev-code-quality.yml
+++ b/.github/workflows/iroha2-dev-code-quality.yml
@@ -3,10 +3,10 @@ name: I2::Dev::CodeQuality
 on:
   workflow_run:
     workflows: ["I2::Dev::Tests", "I2::Dev::Static"]
-    types: [requested]
+    types: [in_progress]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.actor }}
   cancel-in-progress: true
 
 jobs:
@@ -52,14 +52,6 @@ jobs:
       - name: Generate lcov report
         if: always()
         run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli" --ignore "**/main.rs" -o lcov.info
-      - name: Upload coverage to coveralls.io
-        if: always()
-        uses: coverallsapp/github-action@v2
-        with:
-          file: lcov.info
-          compare-ref: ${{ github.base_ref }}
-          compare-sha: ${{ github.event.pull_request.base.sha}}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload lcov report artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -104,8 +96,3 @@ jobs:
           product: ${{ github.repository }}
           environment: Test
           reports: '{"Github Vulnerability Scan": "github.json"}'
-      - name: Show Defectdojo response
-        if: always()
-        run: |
-          set -e
-          printf '%s\n' '${{ steps.defectdojo.outputs.response }}'

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -2,7 +2,7 @@ name: I2::Dev::Static
 
 on:
   pull_request:
-    branches: [main]
+    branches: [i2/sonar-CI-checks]
     paths:
       - '**.rs'
       - '**.json'
@@ -18,59 +18,83 @@ env:
   RUSTUP_TOOLCHAIN: nightly-2024-04-18
 
 jobs:
-  smart_contracts_analysis:
+  # smart_contracts_analysis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Default executor format
+  #       run: |
+  #         cd ./default_executor
+  #         mold --run cargo fmt --all -- --check
+  #     - name: Integration tests smart contracts format
+  #       run: |
+  #         cd ./client/tests/integration/smartcontracts
+  #         mold --run cargo fmt --all -- --check
+
+  workspace_analysis_clippy:
     runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-04-18
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - name: Default executor format
-        run: |
-          cd ./default_executor
-          mold --run cargo fmt --all -- --check
-      - name: Integration tests smart contracts format
-        run: |
-          cd ./client/tests/integration/smartcontracts
-          mold --run cargo fmt --all -- --check
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Lints without features
+        if: always()
+        run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
+      - name: Lints with all features enabled
+        if: always()
+        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json | tee clippy.json
+      - name: Documentation
+        if: always()
+        run: cargo doc --no-deps --quiet
+      - name: Upload clippy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clippy.json
+          path: lints/
 
-  python_static_analysis:
-    runs-on: ubuntu-latest
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies using Poetry for client_cli/pytests
-        working-directory: client_cli/pytests
-        run: |
-          poetry lock --no-update
-          poetry install
-      - name: Install dependencies using Poetry for torii/pytests
-        working-directory: torii/pytests
-        run: |
-          poetry lock --no-update
-          poetry install
-      - name: Check code formatting with Black in client_cli/pytests
-        working-directory: client_cli/pytests
-        run: |
-          poetry run black --check .
-      - name: Check code formatting with Black in torii/pytests
-        working-directory: torii/pytests
-        run: |
-          poetry run black --check .
-      - name: Run mypy (Type Checker) in client_cli/pytests
-        working-directory: client_cli/pytests
-        run: |
-          poetry run mypy --explicit-package-bases --ignore-missing-imports .
-      - name: Run mypy (Type Checker) in torii/pytests
-        working-directory: torii/pytests
-        run: |
-          poetry run mypy --explicit-package-bases --ignore-missing-imports .
-      - name: Run flake8 (Linter) in client_cli/pytests
-        working-directory: client_cli/pytests
-        run: |
-          poetry run flake8 . --max-line-length=110 --ignore=F401,W503,E203
-      - name: Run flake8 (Linter) in torii/pytests
-        working-directory: torii/pytests
-        run: |
-          poetry run flake8 . --max-line-length=110 --ignore=F401,W503,E203
+  # python_static_analysis:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install dependencies using Poetry for client_cli/pytests
+  #       working-directory: client_cli/pytests
+  #       run: |
+  #         poetry lock --no-update
+  #         poetry install
+  #     - name: Install dependencies using Poetry for torii/pytests
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry lock --no-update
+  #         poetry install
+  #     - name: Check code formatting with Black in client_cli/pytests
+  #       working-directory: client_cli/pytests
+  #       run: |
+  #         poetry run black --check .
+  #     - name: Check code formatting with Black in torii/pytests
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry run black --check .
+  #     - name: Run mypy (Type Checker) in client_cli/pytests
+  #       working-directory: client_cli/pytests
+  #       run: |
+  #         poetry run mypy --explicit-package-bases --ignore-missing-imports .
+  #     - name: Run mypy (Type Checker) in torii/pytests
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry run mypy --explicit-package-bases --ignore-missing-imports .
+  #     - name: Run flake8 (Linter) in client_cli/pytests
+  #       working-directory: client_cli/pytests
+  #       run: |
+  #         poetry run flake8 . --max-line-length=110 --ignore=F401,W503,E203
+  #     - name: Run flake8 (Linter) in torii/pytests
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry run flake8 . --max-line-length=110 --ignore=F401,W503,E203

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -2,7 +2,7 @@ name: I2::Dev::Static
 
 on:
   pull_request:
-    branches: [i2/sonar-CI-checks]
+    branches: [i2/remove-coveralls]
     paths:
       - '**.rs'
       - '**.json'

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -2,7 +2,7 @@ name: I2::Dev::Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [i2/remove-coveralls]
     paths:
       - '**.rs'
       - '**.json'

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -20,119 +20,144 @@ env:
   CLIENT_CLI_DIR: "/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/test"
 
 jobs:
-  consistency:
+  # consistency:
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Check genesis.json
+  #       if: always()
+  #       run: ./scripts/tests/consistency.sh genesis
+  #     - name: Check schema.json
+  #       if: always()
+  #       run: ./scripts/tests/consistency.sh schema
+  #     - name: Check Docker Compose configurations
+  #       if: always()
+  #       run: ./scripts/tests/consistency.sh docker-compose
+
+  # # include: client/tests/integration/
+  # # exclude: client/tests/integration/extra_functional
+  # integration:
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   timeout-minutes: 30
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Run tests, with no-default-features
+  #       run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client integration -- --skip extra_functional
+
+  # exclude: client/tests/integration/
+  with_coverage:
     runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-04-18
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - name: Check genesis.json
-        if: always()
-        run: ./scripts/tests/consistency.sh genesis
-      - name: Check schema.json
-        if: always()
-        run: ./scripts/tests/consistency.sh schema
-      - name: Check Docker Compose configurations
-        if: always()
-        run: ./scripts/tests/consistency.sh docker-compose
-
-  # include: client/tests/integration/
-  # exclude: client/tests/integration/extra_functional
-  integration:
-    runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests, with no-default-features
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client integration -- --skip extra_functional
-
-  # include: client/tests/integration/extra_functional
-  extra_functional:
-    runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client extra_functional
-
-  # Run the job to check that the docker containers are properly buildable
-  pr-generator-build:
-    # Job will only execute if the head of the pull request is a branch for PR-generator case
-    if: startsWith(github.head_ref, 'iroha2-pr-deploy/')
-    runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    steps:
-      - uses: actions/checkout@v4
-      - name: Login to Soramitsu Harbor
-        uses: docker/login-action@v3
-        with:
-          registry: docker.soramitsu.co.jp
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_TOKEN }}
-      - name: Set up Docker Buildx
-        id: buildx
-        if: always()
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-      - name: Build and push iroha2:dev image
-        uses: docker/build-push-action@v4
-        if: always()
-        with:
-          push: true
-          tags: docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
-          labels: commit=${{ github.sha }}
-          build-args: TAG=dev
-          file: Dockerfile
-          # This context specification is required
-          context: .
-
-  torii-api-and-client-cli-tests:
-    runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Build binaries
+      - name: Run tests, with coverage
         run: |
-          cargo build -p iroha_client_cli -p kagami -p iroha
-      - name: Setup test Iroha 2 environment on the bare metal
-        run: |
-          pip3 install -r scripts/requirements.txt --no-input --break-system-packages
-          ./scripts/test_env.py setup
-      - name: Mark binaries as executable
-        run: |
-          chmod +x ${{ env.CLIENT_CLI_DIR }}
-      - name: Install torii api dependencies using Poetry
-        working-directory: torii/pytests
-        run: |
-          poetry install
-      - name: Run torii api tests
-        working-directory: torii/pytests
-        run: |
-          poetry run pytest
-      - name: Install client cli dependencies using Poetry
-        working-directory: client_cli/pytests
-        run: |
-          poetry install
-      - name: Run client cli tests
-        working-directory: client_cli/pytests
+          mold --run cargo test --all-features --no-fail-fast --workspace --exclude iroha_client
+          mold --run cargo test --all-features --no-fail-fast -p iroha_client -- --skip integration
         env:
-          # prepared by `test_env.py`
-          CLIENT_CLI_BINARY: ../../test/iroha_client_cli
-          CLIENT_CLI_CONFIG: ../../test/client.toml
-        run: |
-          poetry run pytest
-      - name: Cleanup test environment
-        run: |
-          ./scripts/test_env.py cleanup
+          RUSTFLAGS: "-C instrument-coverage"
+          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
+      - name: Generate lcov report
+        if: always()
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/client_cli" --ignore "**/main.rs" -o lcov.info
+      - name: Upload lcov report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lints/
+
+# # include: client/tests/integration/extra_functional
+  # extra_functional:
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   timeout-minutes: 60
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Run tests
+  #       run: mold --run cargo test --no-default-features --no-fail-fast -p iroha_client extra_functional
+
+  # # Run the job to check that the docker containers are properly buildable
+  # pr-generator-build:
+  #   # Job will only execute if the head of the pull request is a branch for PR-generator case
+  #   if: startsWith(github.head_ref, 'iroha2-pr-deploy/')
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Login to Soramitsu Harbor
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: docker.soramitsu.co.jp
+  #         username: ${{ secrets.HARBOR_USERNAME }}
+  #         password: ${{ secrets.HARBOR_TOKEN }}
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       if: always()
+  #       uses: docker/setup-buildx-action@v2
+  #       with:
+  #         install: true
+  #     - name: Build and push iroha2:dev image
+  #       uses: docker/build-push-action@v4
+  #       if: always()
+  #       with:
+  #         push: true
+  #         tags: docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
+  #         labels: commit=${{ github.sha }}
+  #         build-args: TAG=dev
+  #         file: Dockerfile
+  #         # This context specification is required
+  #         context: .
+
+  # torii-api-and-client-cli-tests:
+  #   runs-on: [self-hosted, Linux, iroha2]
+  #   container:
+  #     image: hyperledger/iroha2-ci:nightly-2024-04-18
+  #   timeout-minutes: 60
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Build binaries
+  #       run: |
+  #         cargo build -p iroha_client_cli -p kagami -p iroha
+  #     - name: Setup test Iroha 2 environment on the bare metal
+  #       run: |
+  #         pip3 install -r scripts/requirements.txt --no-input --break-system-packages
+  #         ./scripts/test_env.py setup
+  #     - name: Mark binaries as executable
+  #       run: |
+  #         chmod +x ${{ env.CLIENT_CLI_DIR }}
+  #     - name: Install torii api dependencies using Poetry
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry install
+  #     - name: Run torii api tests
+  #       working-directory: torii/pytests
+  #       run: |
+  #         poetry run pytest
+  #     - name: Install client cli dependencies using Poetry
+  #       working-directory: client_cli/pytests
+  #       run: |
+  #         poetry install
+  #     - name: Run client cli tests
+  #       working-directory: client_cli/pytests
+  #       env:
+  #         # prepared by `test_env.py`
+  #         CLIENT_CLI_BINARY: ../../test/iroha_client_cli
+  #         CLIENT_CLI_CONFIG: ../../test/client.toml
+  #       run: |
+  #         poetry run pytest
+  #     - name: Cleanup test environment
+  #       run: |
+  #         ./scripts/test_env.py cleanup

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.projectKey=hyperledger:iroha
+sonar.projectKey=bastos525:soramitsu-iroha


### PR DESCRIPTION
## Description
1. Remove `coveralls` tool for coverage since it's useless while having it in the workflow trigger type (btw, it's possible to fix it). However, coverage is uploading in Sonarqube now.
2. Modify concurrency.

### Benefits

Remove `coveralls` that doesn't work.
Reduce the possible amount of parallel runs of `I2::Dev::CodeQuality` workflow.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
