### PR TITLE
fix(crypto): do not panic if the passed Ed25519Sha512 public key is of invalid length

### DIFF
--- a/crypto/src/signature/ed25519.rs
+++ b/crypto/src/signature/ed25519.rs
@@ -13,7 +13,10 @@ pub type PrivateKey = ed25519_dalek::SigningKey;
 #[cfg(not(feature = "std"))]
 use alloc::{format, string::ToString as _, vec::Vec};
 
-fn parse_fixed_size<T, E, F, const SIZE: usize>(payload: &[u8], f: F) -> Result<T, ParseError>
+fn parse_fixed_size<T, E, F, const SIZE: usize>(
+    payload: &[u8],
+    fixed_parser: F,
+) -> Result<T, ParseError>
 where
     F: FnOnce(&[u8; SIZE]) -> Result<T, E>,
     E: core::fmt::Display,
@@ -26,7 +29,7 @@ where
         ))
     })?;
 
-    f(&fixed_payload).map_err(|err| ParseError(err.to_string()))
+    fixed_parser(&fixed_payload).map_err(|err| ParseError(err.to_string()))
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Description

Change the conversion of unsized slice to array reference to be infallible and form a better error message.

This prevents a panic during `parity_scale_cli`'s type probing

### Linked issue

Closes #4649 

### Checklist

- [ ] make CI pass