### PR TITLE
fix: avoid early drop of `ConfigReader` in `iroha_client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
 name = "iroha"
 version = "2.0.0-pre-rc.21"
 dependencies = [
+ "assertables",
  "attohttpc",
  "base64 0.22.1",
  "color-eyre",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -96,6 +96,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 color-eyre = { workspace = true }
 tempfile = { workspace = true }
 hex = { workspace = true }
+assertables = { workspace = true }
 
 tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
 tracing-flame = "0.2.0"


### PR DESCRIPTION
## Description

Fixed usage of `ConfigReader` in `iroha_client`.

### Linked issue

Closes #4623
