### PR TITLE
refactor!: revert `_ms` and `_bytes` suffixes in config

### DIFF
--- a/cli/src/samples.rs
+++ b/cli/src/samples.rs
@@ -66,7 +66,7 @@ pub fn get_config_toml(
         .write("private_key", ExposedPrivateKey(private_key))
         .write(["sumeragi", "trusted_peers"], peers)
         .write(["network", "address"], DEFAULT_P2P_ADDR)
-        .write(["network", "block_gossip_period"], 500)
+        .write(["network", "block_gossip_period_ms"], 500)
         .write(["network", "block_gossip_max_size"], 1)
         .write(["torii", "address"], DEFAULT_TORII_ADDR)
         .write(["chain_wide", "max_transactions_in_block"], 2)

--- a/client/examples/register_1000_triggers.rs
+++ b/client/examples/register_1000_triggers.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Increase executor limits for large genesis
     configuration.chain_wide.executor_runtime.fuel_limit = u64::MAX;
-    configuration.chain_wide.executor_runtime.max_memory_bytes = u32::MAX;
+    configuration.chain_wide.executor_runtime.max_memory = u32::MAX.into();
 
     let genesis = generate_genesis(1_000_u32, chain_id, &genesis_key_pair)?;
 

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -124,8 +124,8 @@ mod tests {
             private_key = "802640CCF31D85E3B32A4BEA59987CE0C78E3B8E2DB93881468AB2435FE45D5C9DCD53CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03"
 
             [transaction]
-            time_to_live = 100_000
-            status_timeout = 100_000
+            time_to_live_ms = 100_000
+            status_timeout_ms = 100_000
             nonce = false
         }
     }

--- a/client/src/config/user.rs
+++ b/client/src/config/user.rs
@@ -3,7 +3,7 @@
 use error_stack::{Report, ResultExt};
 use iroha_config_base::{
     attach::ConfigValueAndOrigin,
-    util::{Emitter, EmitterResultExt, HumanDuration},
+    util::{DurationMs, Emitter, EmitterResultExt},
     ReadConfig, WithOrigin,
 };
 use iroha_crypto::{KeyPair, PrivateKey, PublicKey};
@@ -55,8 +55,8 @@ impl Root {
                 },
             transaction:
                 Transaction {
-                    time_to_live: tx_ttl,
-                    status_timeout: tx_timeout,
+                    time_to_live_ms: tx_ttl,
+                    status_timeout_ms: tx_timeout,
                     nonce: tx_add_nonce,
                 },
         } = self;
@@ -122,9 +122,9 @@ pub struct Account {
 #[allow(missing_docs)]
 pub struct Transaction {
     #[config(default = "super::DEFAULT_TRANSACTION_TIME_TO_LIVE.into()")]
-    pub time_to_live: WithOrigin<HumanDuration>,
+    pub time_to_live_ms: WithOrigin<DurationMs>,
     #[config(default = "super::DEFAULT_TRANSACTION_STATUS_TIMEOUT.into()")]
-    pub status_timeout: WithOrigin<HumanDuration>,
+    pub status_timeout_ms: WithOrigin<DurationMs>,
     #[config(default = "super::DEFAULT_TRANSACTION_NONCE")]
     pub nonce: bool,
 }

--- a/config/base/src/util.rs
+++ b/config/base/src/util.rs
@@ -7,38 +7,37 @@ use drop_bomb::DropBomb;
 use error_stack::Report;
 use serde::{Deserialize, Serialize};
 
-/// [`Duration`], but can parse a human-readable string.
-/// TODO: currently deserializes just as [`Duration`]
+/// (De-)serialize [`Duration`] as a number of milliseconds
 #[serde_with::serde_as]
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, Ord, PartialOrd, Eq, PartialEq, Display)]
 #[display(fmt = "{_0:?}")]
-pub struct HumanDuration(#[serde_as(as = "serde_with::DurationMilliSeconds")] pub Duration);
+pub struct DurationMs(#[serde_as(as = "serde_with::DurationMilliSeconds")] pub Duration);
 
-impl HumanDuration {
+impl DurationMs {
     /// Get the [`Duration`]
     pub fn get(self) -> Duration {
         self.0
     }
 }
 
-impl From<Duration> for HumanDuration {
+impl From<Duration> for DurationMs {
     fn from(value: Duration) -> Self {
         Self(value)
     }
 }
 
-/// Representation of number of bytes, parseable from a human-readable string.
+/// A number of bytes
 #[derive(Debug, Copy, Clone, Deserialize, Serialize)]
-pub struct HumanBytes<T: num_traits::int::PrimInt>(pub T);
+pub struct Bytes<T: num_traits::int::PrimInt>(pub T);
 
-impl<T: num_traits::int::PrimInt> HumanBytes<T> {
+impl<T: num_traits::int::PrimInt> Bytes<T> {
     /// Get the number of bytes
     pub fn get(self) -> T {
         self.0
     }
 }
 
-impl<T: num_traits::int::PrimInt> From<T> for HumanBytes<T> {
+impl<T: num_traits::int::PrimInt> From<T> for Bytes<T> {
     fn from(value: T) -> Self {
         Self(value)
     }
@@ -238,10 +237,10 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_human_duration() {
+    fn deserialize_duration_ms() {
         #[derive(Deserialize)]
         struct Test {
-            value: HumanDuration,
+            value: DurationMs,
         }
 
         let Test { value } = toml::toml! {

--- a/config/base/tests/misc.rs
+++ b/config/base/tests/misc.rs
@@ -382,7 +382,7 @@ fn full_config_ok() {
 
                 [torii]
                 address = "127.0.0.2:1337"
-                max_content_length = 19
+                max_content_len = 19
 
                 [kura]
                 store_dir = "./my-storage"

--- a/config/src/parameters/actual.rs
+++ b/config/src/parameters/actual.rs
@@ -230,7 +230,6 @@ impl Default for ChainWide {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct WasmRuntime {
     pub fuel_limit: u64,
-    // TODO: wrap into a `Bytes` newtype
     pub max_memory_bytes: u32,
 }
 
@@ -238,7 +237,7 @@ impl Default for WasmRuntime {
     fn default() -> Self {
         Self {
             fuel_limit: defaults::chain_wide::WASM_FUEL_LIMIT,
-            max_memory_bytes: defaults::chain_wide::WASM_MAX_MEMORY_BYTES,
+            max_memory_bytes: defaults::chain_wide::WASM_MAX_MEMORY.get(),
         }
     }
 }

--- a/config/src/parameters/actual.rs
+++ b/config/src/parameters/actual.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use error_stack::{Result, ResultExt};
-use iroha_config_base::{read::ConfigReader, toml::TomlSource, WithOrigin};
+use iroha_config_base::{read::ConfigReader, toml::TomlSource, util::Bytes, WithOrigin};
 use iroha_crypto::{KeyPair, PublicKey};
 use iroha_data_model::{
     metadata::Limits as MetadataLimits, peer::PeerId, transaction::TransactionLimits, ChainId,
@@ -230,14 +230,14 @@ impl Default for ChainWide {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct WasmRuntime {
     pub fuel_limit: u64,
-    pub max_memory_bytes: u32,
+    pub max_memory: Bytes<u32>,
 }
 
 impl Default for WasmRuntime {
     fn default() -> Self {
         Self {
             fuel_limit: defaults::chain_wide::WASM_FUEL_LIMIT,
-            max_memory_bytes: defaults::chain_wide::WASM_MAX_MEMORY.get(),
+            max_memory: defaults::chain_wide::WASM_MAX_MEMORY,
         }
     }
 }
@@ -246,7 +246,7 @@ impl Default for WasmRuntime {
 #[allow(missing_docs)]
 pub struct Torii {
     pub address: WithOrigin<SocketAddr>,
-    pub max_content_len_bytes: u64,
+    pub max_content_len: Bytes<u64>,
 }
 
 /// Complete configuration needed to start regular telemetry.

--- a/config/src/parameters/defaults.rs
+++ b/config/src/parameters/defaults.rs
@@ -46,14 +46,15 @@ pub mod snapshot {
 }
 
 pub mod chain_wide {
+    use iroha_config_base::util::Bytes;
+
     use super::*;
 
     pub const MAX_TXS: NonZeroU32 = nonzero!(2_u32.pow(9));
     pub const BLOCK_TIME: Duration = Duration::from_secs(2);
     pub const COMMIT_TIME: Duration = Duration::from_secs(4);
     pub const WASM_FUEL_LIMIT: u64 = 55_000_000;
-    // TODO: wrap into a `Bytes` newtype
-    pub const WASM_MAX_MEMORY_BYTES: u32 = 500 * 2_u32.pow(20);
+    pub const WASM_MAX_MEMORY: Bytes<u32> = Bytes(500 * 2_u32.pow(20));
 
     /// Default estimation of consensus duration.
     pub const CONSENSUS_ESTIMATION: Duration =
@@ -82,7 +83,9 @@ pub mod chain_wide {
 pub mod torii {
     use std::time::Duration;
 
-    pub const MAX_CONTENT_LENGTH: u64 = 2_u64.pow(20) * 16;
+    use iroha_config_base::util::Bytes;
+
+    pub const MAX_CONTENT_LENGTH: Bytes<u64> = Bytes(2_u64.pow(20) * 16);
     pub const QUERY_IDLE_TIME: Duration = Duration::from_secs(30);
 }
 

--- a/config/src/parameters/defaults.rs
+++ b/config/src/parameters/defaults.rs
@@ -85,7 +85,7 @@ pub mod torii {
 
     use iroha_config_base::util::Bytes;
 
-    pub const MAX_CONTENT_LENGTH: Bytes<u64> = Bytes(2_u64.pow(20) * 16);
+    pub const MAX_CONTENT_LEN: Bytes<u64> = Bytes(2_u64.pow(20) * 16);
     pub const QUERY_IDLE_TIME: Duration = Duration::from_secs(30);
 }
 

--- a/config/src/parameters/user.rs
+++ b/config/src/parameters/user.rs
@@ -512,7 +512,7 @@ impl ChainWide {
 pub struct Torii {
     #[config(env = "API_ADDRESS")]
     pub address: WithOrigin<SocketAddr>,
-    #[config(default = "defaults::torii::MAX_CONTENT_LENGTH")]
+    #[config(default = "defaults::torii::MAX_CONTENT_LEN")]
     pub max_content_len: Bytes<u64>,
     #[config(default = "defaults::torii::QUERY_IDLE_TIME.into()")]
     pub query_idle_time_ms: DurationMs,

--- a/config/src/parameters/user.rs
+++ b/config/src/parameters/user.rs
@@ -21,7 +21,7 @@ use error_stack::{Result, ResultExt};
 use iroha_config_base::{
     attach::ConfigValueAndOrigin,
     env::FromEnvStr,
-    util::{Emitter, EmitterResultExt, HumanBytes, HumanDuration},
+    util::{Bytes, DurationMs, Emitter, EmitterResultExt},
     ReadConfig, WithOrigin,
 };
 use iroha_crypto::{PrivateKey, PublicKey};
@@ -275,14 +275,14 @@ pub struct Network {
     #[config(default = "defaults::network::BLOCK_GOSSIP_MAX_SIZE")]
     pub block_gossip_max_size: NonZeroU32,
     #[config(default = "defaults::network::BLOCK_GOSSIP_PERIOD.into()")]
-    pub block_gossip_period: HumanDuration,
+    pub block_gossip_period_ms: DurationMs,
     #[config(default = "defaults::network::TRANSACTION_GOSSIP_MAX_SIZE")]
     pub transaction_gossip_max_size: NonZeroU32,
     #[config(default = "defaults::network::TRANSACTION_GOSSIP_PERIOD.into()")]
-    pub transaction_gossip_period: HumanDuration,
+    pub transaction_gossip_period_ms: DurationMs,
     /// Duration of time after which connection with peer is terminated if peer is idle
     #[config(default = "defaults::network::IDLE_TIMEOUT.into()")]
-    pub idle_timeout: HumanDuration,
+    pub idle_timeout_ms: DurationMs,
 }
 
 impl Network {
@@ -296,10 +296,10 @@ impl Network {
         let Self {
             address,
             block_gossip_max_size,
-            block_gossip_period,
+            block_gossip_period_ms: block_gossip_period,
             transaction_gossip_max_size,
-            transaction_gossip_period,
-            idle_timeout,
+            transaction_gossip_period_ms: transaction_gossip_period,
+            idle_timeout_ms: idle_timeout,
         } = self;
 
         (
@@ -330,10 +330,10 @@ pub struct Queue {
     pub capacity_per_user: NonZeroUsize,
     /// The transaction will be dropped after this time if it is still in the queue.
     #[config(default = "defaults::queue::TRANSACTION_TIME_TO_LIVE.into()")]
-    pub transaction_time_to_live: HumanDuration,
+    pub transaction_time_to_live_ms: DurationMs,
     /// The threshold to determine if a transaction has been tampered to have a future timestamp.
     #[config(default = "defaults::queue::FUTURE_THRESHOLD.into()")]
-    pub future_threshold: HumanDuration,
+    pub future_threshold_ms: DurationMs,
 }
 
 impl Queue {
@@ -341,8 +341,8 @@ impl Queue {
         let Self {
             capacity,
             capacity_per_user,
-            transaction_time_to_live,
-            future_threshold,
+            transaction_time_to_live_ms: transaction_time_to_live,
+            future_threshold_ms: future_threshold,
         } = self;
         actual::Queue {
             capacity,
@@ -374,17 +374,17 @@ pub struct Telemetry {
     name: String,
     url: Url,
     #[serde(default)]
-    min_retry_period: TelemetryMinRetryPeriod,
+    min_retry_period_ms: TelemetryMinRetryPeriod,
     #[serde(default)]
     max_retry_delay_exponent: TelemetryMaxRetryDelayExponent,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone)]
-struct TelemetryMinRetryPeriod(HumanDuration);
+struct TelemetryMinRetryPeriod(DurationMs);
 
 impl Default for TelemetryMinRetryPeriod {
     fn default() -> Self {
-        Self(HumanDuration(defaults::telemetry::MIN_RETRY_PERIOD))
+        Self(DurationMs(defaults::telemetry::MIN_RETRY_PERIOD))
     }
 }
 
@@ -402,7 +402,7 @@ impl From<Telemetry> for actual::Telemetry {
         Telemetry {
             name,
             url,
-            min_retry_period: TelemetryMinRetryPeriod(HumanDuration(min_retry_period)),
+            min_retry_period_ms: TelemetryMinRetryPeriod(DurationMs(min_retry_period)),
             max_retry_delay_exponent: TelemetryMaxRetryDelayExponent(max_retry_delay_exponent),
         }: Telemetry,
     ) -> Self {
@@ -425,7 +425,7 @@ pub struct Snapshot {
     #[config(default, env = "SNAPSHOT_MODE")]
     pub mode: SnapshotMode,
     #[config(default = "defaults::snapshot::CREATE_EVERY.into()")]
-    pub create_every: HumanDuration,
+    pub create_every_ms: DurationMs,
     #[config(
         default = "PathBuf::from(defaults::snapshot::STORE_DIR)",
         env = "SNAPSHOT_STORE_DIR"
@@ -439,9 +439,9 @@ pub struct ChainWide {
     #[config(default = "defaults::chain_wide::MAX_TXS")]
     pub max_transactions_in_block: NonZeroU32,
     #[config(default = "defaults::chain_wide::BLOCK_TIME.into()")]
-    pub block_time: HumanDuration,
+    pub block_time_ms: DurationMs,
     #[config(default = "defaults::chain_wide::COMMIT_TIME.into()")]
-    pub commit_time: HumanDuration,
+    pub commit_time_ms: DurationMs,
     #[config(default = "defaults::chain_wide::TRANSACTION_LIMITS")]
     pub transaction_limits: TransactionLimits,
     #[config(default = "defaults::chain_wide::METADATA_LIMITS")]
@@ -458,17 +458,34 @@ pub struct ChainWide {
     pub ident_length_limits: LengthLimits,
     #[config(default = "defaults::chain_wide::WASM_FUEL_LIMIT")]
     pub executor_fuel_limit: u64,
-    #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY_BYTES")]
-    pub executor_max_memory: u32,
+    #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY")]
+    pub executor_max_memory_bytes: Bytes<u32>,
     #[config(default = "defaults::chain_wide::WASM_FUEL_LIMIT")]
     pub wasm_fuel_limit: u64,
-    #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY_BYTES")]
-    pub wasm_max_memory: u32,
+    #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY")]
+    pub wasm_max_memory_bytes: Bytes<u32>,
 }
 
 impl ChainWide {
     fn parse(self) -> actual::ChainWide {
         let Self {
+            max_transactions_in_block,
+            block_time_ms: DurationMs(block_time),
+            commit_time_ms: DurationMs(commit_time),
+            transaction_limits,
+            asset_metadata_limits,
+            trigger_metadata_limits,
+            asset_definition_metadata_limits,
+            account_metadata_limits,
+            domain_metadata_limits,
+            ident_length_limits,
+            executor_fuel_limit,
+            executor_max_memory_bytes,
+            wasm_fuel_limit,
+            wasm_max_memory_bytes,
+        } = self;
+
+        actual::ChainWide {
             max_transactions_in_block,
             block_time,
             commit_time,
@@ -479,30 +496,13 @@ impl ChainWide {
             account_metadata_limits,
             domain_metadata_limits,
             ident_length_limits,
-            executor_fuel_limit,
-            executor_max_memory,
-            wasm_fuel_limit,
-            wasm_max_memory,
-        } = self;
-
-        actual::ChainWide {
-            max_transactions_in_block,
-            block_time: block_time.get(),
-            commit_time: commit_time.get(),
-            transaction_limits,
-            asset_metadata_limits,
-            trigger_metadata_limits,
-            asset_definition_metadata_limits,
-            account_metadata_limits,
-            domain_metadata_limits,
-            ident_length_limits,
             executor_runtime: actual::WasmRuntime {
                 fuel_limit: executor_fuel_limit,
-                max_memory_bytes: executor_max_memory,
+                max_memory_bytes: executor_max_memory_bytes.get(),
             },
             wasm_runtime: actual::WasmRuntime {
                 fuel_limit: wasm_fuel_limit,
-                max_memory_bytes: wasm_max_memory,
+                max_memory_bytes: wasm_max_memory_bytes.get(),
             },
         }
     }
@@ -512,21 +512,21 @@ impl ChainWide {
 pub struct Torii {
     #[config(env = "API_ADDRESS")]
     pub address: WithOrigin<SocketAddr>,
-    #[config(default = "defaults::torii::MAX_CONTENT_LENGTH.into()")]
-    pub max_content_length: HumanBytes<u64>,
+    #[config(default = "defaults::torii::MAX_CONTENT_LENGTH")]
+    pub max_content_length_bytes: Bytes<u64>,
     #[config(default = "defaults::torii::QUERY_IDLE_TIME.into()")]
-    pub query_idle_time: HumanDuration,
+    pub query_idle_time_ms: DurationMs,
 }
 
 impl Torii {
     fn parse(self) -> (actual::Torii, actual::LiveQueryStore) {
         let torii = actual::Torii {
             address: self.address,
-            max_content_len_bytes: self.max_content_length.get(),
+            max_content_len_bytes: self.max_content_length_bytes.get(),
         };
 
         let query = actual::LiveQueryStore {
-            idle_time: self.query_idle_time.get(),
+            idle_time: self.query_idle_time_ms.get(),
         };
 
         (torii, query)

--- a/config/src/parameters/user.rs
+++ b/config/src/parameters/user.rs
@@ -459,11 +459,11 @@ pub struct ChainWide {
     #[config(default = "defaults::chain_wide::WASM_FUEL_LIMIT")]
     pub executor_fuel_limit: u64,
     #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY")]
-    pub executor_max_memory_bytes: Bytes<u32>,
+    pub executor_max_memory: Bytes<u32>,
     #[config(default = "defaults::chain_wide::WASM_FUEL_LIMIT")]
     pub wasm_fuel_limit: u64,
     #[config(default = "defaults::chain_wide::WASM_MAX_MEMORY")]
-    pub wasm_max_memory_bytes: Bytes<u32>,
+    pub wasm_max_memory: Bytes<u32>,
 }
 
 impl ChainWide {
@@ -480,9 +480,9 @@ impl ChainWide {
             domain_metadata_limits,
             ident_length_limits,
             executor_fuel_limit,
-            executor_max_memory_bytes,
+            executor_max_memory,
             wasm_fuel_limit,
-            wasm_max_memory_bytes,
+            wasm_max_memory,
         } = self;
 
         actual::ChainWide {
@@ -498,11 +498,11 @@ impl ChainWide {
             ident_length_limits,
             executor_runtime: actual::WasmRuntime {
                 fuel_limit: executor_fuel_limit,
-                max_memory_bytes: executor_max_memory_bytes.get(),
+                max_memory: executor_max_memory,
             },
             wasm_runtime: actual::WasmRuntime {
                 fuel_limit: wasm_fuel_limit,
-                max_memory_bytes: wasm_max_memory_bytes.get(),
+                max_memory: wasm_max_memory,
             },
         }
     }
@@ -513,7 +513,7 @@ pub struct Torii {
     #[config(env = "API_ADDRESS")]
     pub address: WithOrigin<SocketAddr>,
     #[config(default = "defaults::torii::MAX_CONTENT_LENGTH")]
-    pub max_content_length_bytes: Bytes<u64>,
+    pub max_content_len: Bytes<u64>,
     #[config(default = "defaults::torii::QUERY_IDLE_TIME.into()")]
     pub query_idle_time_ms: DurationMs,
 }
@@ -522,7 +522,7 @@ impl Torii {
     fn parse(self) -> (actual::Torii, actual::LiveQueryStore) {
         let torii = actual::Torii {
             address: self.address,
-            max_content_len_bytes: self.max_content_length_bytes.get(),
+            max_content_len: self.max_content_len,
         };
 
         let query = actual::LiveQueryStore {

--- a/config/tests/fixtures.rs
+++ b/config/tests/fixtures.rs
@@ -115,7 +115,9 @@ fn minimal_config_snapshot() {
                         path: "tests/fixtures/base.toml",
                     },
                 },
-                max_content_len_bytes: 16777216,
+                max_content_len: Bytes(
+                    16777216,
+                ),
             },
             kura: Kura {
                 init_mode: Strict,
@@ -229,11 +231,15 @@ fn minimal_config_snapshot() {
                 },
                 executor_runtime: WasmRuntime {
                     fuel_limit: 55000000,
-                    max_memory_bytes: 524288000,
+                    max_memory: Bytes(
+                        524288000,
+                    ),
                 },
                 wasm_runtime: WasmRuntime {
                     fuel_limit: 55000000,
-                    max_memory_bytes: 524288000,
+                    max_memory: Bytes(
+                        524288000,
+                    ),
                 },
             },
         }"#]].assert_eq(&format!("{config:#?}"));

--- a/config/tests/fixtures.rs
+++ b/config/tests/fixtures.rs
@@ -181,7 +181,7 @@ fn minimal_config_snapshot() {
             },
             snapshot: Snapshot {
                 mode: ReadWrite,
-                create_every: HumanDuration(
+                create_every_ms: DurationMs(
                     60s,
                 ),
                 store_dir: WithOrigin {

--- a/config/tests/fixtures/full.toml
+++ b/config/tests/fixtures/full.toml
@@ -10,15 +10,16 @@ signed_file = "genesis.signed.scale"
 
 [network]
 address = "localhost:3840"
-block_gossip_period = 10_000
+block_gossip_period_ms = 10_000
 block_gossip_max_size = 4
-transaction_gossip_period = 1_000
+transaction_gossip_period_ms = 1_000
 transaction_gossip_max_size = 500
+idle_timeout_ms = 10_000
 
 [torii]
 address = "localhost:5000"
-max_content_length = 16
-query_idle_time = 30_000
+max_content_length_bytes = 16_000
+query_idle_time_ms = 30_000
 
 [kura]
 init_mode = "strict"
@@ -41,18 +42,18 @@ format = "compact"
 [queue]
 capacity = 65536
 capacity_per_user = 65536
-transaction_time_to_live = 100
-future_threshold = 50
+transaction_time_to_live_ms = 100
+future_threshold_ms = 50
 
 [snapshot]
 mode = "read_write"
-create_every = 60_000
+create_every_ms = 60_000
 store_dir = "./storage/snapshot"
 
 [telemetry]
 name = "test"
 url = "http://test.com"
-min_retry_period = 5_000
+min_retry_period_ms = 5_000
 max_retry_delay_exponent = 4
 
 [dev_telemetry]
@@ -60,8 +61,8 @@ out_file = "./dev_telemetry.json"
 
 [chain_wide]
 max_transactions_in_block = 512
-block_time = 2_000
-commit_time = 4_000
+block_time_ms = 2_000
+commit_time_ms = 4_000
 transaction_limits = { max_instruction_number = 4096, max_wasm_size_bytes = 4194304 }
 asset_metadata_limits = { capacity = 1048576, max_entry_len = 4096 }
 asset_definition_metadata_limits = { capacity = 1048576, max_entry_len = 4096 }

--- a/config/tests/fixtures/full.toml
+++ b/config/tests/fixtures/full.toml
@@ -18,7 +18,7 @@ idle_timeout_ms = 10_000
 
 [torii]
 address = "localhost:5000"
-max_content_length_bytes = 16_000
+max_content_len = 16_000
 query_idle_time_ms = 30_000
 
 [kura]

--- a/configs/client.template.toml
+++ b/configs/client.template.toml
@@ -13,7 +13,7 @@
 # private_key =
 
 [transaction]
-# time_to_live = "100s"
-# status_timeout = "100s"
+# time_to_live_ms = 100_000
+# status_timeout_ms = 100_000
 ## Nonce is TODO describe what it is
 # nonce = false

--- a/configs/peer.template.toml
+++ b/configs/peer.template.toml
@@ -2,8 +2,11 @@
 
 ## You can use another TOML file to extend from.
 ## For a single file extension:
+
 # extends = "./base.toml"
+
 ## Or, for a chain of extensions:
+
 # extends = ["base-1.toml", "base-2.toml"]
 
 # chain =
@@ -16,16 +19,16 @@
 
 [network]
 # address =
-# block_gossip_period = "10s"
+# block_gossip_period_ms = 10_000
 # block_gossip_max_size = 4
-# transaction_gossip_period = "1s"
+# transaction_gossip_period_ms = 1_000
 # transaction_gossip_max_size = 500
-# idle_timeout = "60s"
+# idle_timeout_ms = 60_000
 
 [torii]
 # address =
-# max_content_length = "16mb"
-# query_idle_time = "30s"
+# max_content_length = 16_000_000
+# query_idle_time_ms = 30_000
 
 [kura]
 # init_mode = "strict"
@@ -44,18 +47,18 @@
 [queue]
 # capacity = 65536
 # capacity_per_user = 65536
-# transaction_time_to_live = "1day"
-# future_threshold = "1s"
+# transaction_time_to_live_ms = 86_400_000 # 1 day
+# future_threshold_ms = 1_000
 
 [snapshot]
 # mode = "read_write"
-# create_every = "1min"
+# create_every_ms = 60_000
 # store_dir = "./storage/snapshot"
 
 [telemetry]
 # name =
 # url =
-# min_retry_period = "1s"
+# min_retry_period_ms = 1_000
 # max_retry_delay_exponent = 4
 
 [dev_telemetry]

--- a/configs/peer.template.toml
+++ b/configs/peer.template.toml
@@ -27,7 +27,7 @@
 
 [torii]
 # address =
-# max_content_length = 16_000_000
+# max_content_len = 16_000_000
 # query_idle_time_ms = 30_000
 
 [kura]

--- a/core/benches/blocks/common.rs
+++ b/core/benches/blocks/common.rs
@@ -184,7 +184,7 @@ pub fn build_state(rt: &tokio::runtime::Handle, account_id: &AccountId) -> State
 
         state_block.config.transaction_limits = TransactionLimits::new(u64::MAX, u64::MAX);
         state_block.config.executor_runtime.fuel_limit = u64::MAX;
-        state_block.config.executor_runtime.max_memory_bytes = u32::MAX;
+        state_block.config.executor_runtime.max_memory = u32::MAX.into();
 
         let mut state_transaction = state_block.transaction();
         let path_to_executor = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -345,7 +345,7 @@ pub mod state {
     /// on any supported platform
     pub fn store_limits_from_config(config: &Config) -> StoreLimits {
         StoreLimitsBuilder::new()
-            .memory_size(config.max_memory_bytes as usize)
+            .memory_size(config.max_memory.get() as usize)
             .instances(1)
             .memories(1)
             .tables(1)

--- a/core/src/snapshot.rs
+++ b/core/src/snapshot.rs
@@ -120,7 +120,7 @@ impl SnapshotMaker {
             let latest_block_hash = state.view().latest_block_hash();
             Some(Self {
                 state,
-                create_every: config.create_every.get(),
+                create_every: config.create_every_ms.get(),
                 store_dir: config.store_dir.clone(),
                 latest_block_hash,
             })

--- a/tools/kagami/src/genesis/generate.rs
+++ b/tools/kagami/src/genesis/generate.rs
@@ -191,7 +191,7 @@ pub fn generate_default(
         )?
         .add_parameter(
             EXECUTOR_MAX_MEMORY,
-            Numeric::new(chain_wide_defaults::WASM_MAX_MEMORY_BYTES.into(), 0),
+            Numeric::new(chain_wide_defaults::WASM_MAX_MEMORY.get().into(), 0),
         )?
         .add_parameter(
             WASM_FUEL_LIMIT,
@@ -199,7 +199,7 @@ pub fn generate_default(
         )?
         .add_parameter(
             WASM_MAX_MEMORY,
-            Numeric::new(chain_wide_defaults::WASM_MAX_MEMORY_BYTES.into(), 0),
+            Numeric::new(chain_wide_defaults::WASM_MAX_MEMORY.get().into(), 0),
         )?
         .into_create_parameters();
 

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -52,7 +52,7 @@ pub struct Torii {
     notify_shutdown: Arc<Notify>,
     query_service: LiveQueryStoreHandle,
     kura: Arc<Kura>,
-    transaction_max_content_length: Bytes<u64>,
+    transaction_max_content_len: Bytes<u64>,
     address: SocketAddr,
     state: Arc<State>,
     #[cfg(feature = "telemetry")]
@@ -86,7 +86,7 @@ impl Torii {
             #[cfg(feature = "telemetry")]
             metrics_reporter,
             address: config.address.into_value(),
-            transaction_max_content_length: config.max_content_len,
+            transaction_max_content_len: config.max_content_len,
         }
     }
 
@@ -168,7 +168,7 @@ impl Torii {
                     warp::path(uri::TRANSACTION)
                         .and(add_state!(self.chain_id, self.queue, self.state.clone()))
                         .and(warp::body::content_length_limit(
-                            self.transaction_max_content_length.get(),
+                            self.transaction_max_content_len.get(),
                         ))
                         .and(body::versioned()),
                 )

--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use futures::{stream::FuturesUnordered, StreamExt};
-use iroha_config::parameters::actual::Torii as Config;
+use iroha_config::{base::util::Bytes, parameters::actual::Torii as Config};
 #[cfg(feature = "telemetry")]
 use iroha_core::metrics::MetricsReporter;
 use iroha_core::{
@@ -52,7 +52,7 @@ pub struct Torii {
     notify_shutdown: Arc<Notify>,
     query_service: LiveQueryStoreHandle,
     kura: Arc<Kura>,
-    transaction_max_content_length: u64,
+    transaction_max_content_length: Bytes<u64>,
     address: SocketAddr,
     state: Arc<State>,
     #[cfg(feature = "telemetry")]
@@ -86,7 +86,7 @@ impl Torii {
             #[cfg(feature = "telemetry")]
             metrics_reporter,
             address: config.address.into_value(),
-            transaction_max_content_length: config.max_content_len_bytes,
+            transaction_max_content_length: config.max_content_len,
         }
     }
 
@@ -168,7 +168,7 @@ impl Torii {
                     warp::path(uri::TRANSACTION)
                         .and(add_state!(self.chain_id, self.queue, self.state.clone()))
                         .and(warp::body::content_length_limit(
-                            self.transaction_max_content_length,
+                            self.transaction_max_content_length.get(),
                         ))
                         .and(body::versioned()),
                 )


### PR DESCRIPTION
## Description

Since there is still no consensus about using human readable types in configuration (#4294, #4295), I decided to at least make it explicit that they aren't supported.

- Reverted use of `_ms` suffix for millisecond numbers
- Used `_bytes` suffix for <code>torii.max_content_length<b>_bytes</b></code>
- Updated config templates
- Refactored internals:
  - Renamed `HumanDuration` to `DurationMs`, and `HumanBytes` to just `Bytes`
  - Chore refactors