### PR TITLE
chore: use temporary `displaydoc` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const#ff2f562740a478e05551881f7355941c62dbfcc2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,7 +2782,7 @@ dependencies = [
  "color-eyre",
  "criterion",
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "error-stack",
  "eyre",
  "futures-util",
@@ -2838,7 +2848,7 @@ dependencies = [
  "assertables",
  "cfg-if",
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "error-stack",
  "expect-test",
  "hex",
@@ -2906,7 +2916,7 @@ dependencies = [
  "crossbeam-queue",
  "dashmap",
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "eyre",
  "futures",
  "hex",
@@ -2963,7 +2973,7 @@ dependencies = [
  "curve25519-dalek",
  "derive_more",
  "digest",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "ed25519-dalek",
  "elliptic-curve",
  "getset",
@@ -3000,7 +3010,7 @@ dependencies = [
  "base64 0.22.1",
  "criterion",
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "getset",
  "iroha_crypto",
  "iroha_data_model_derive",
@@ -3190,7 +3200,7 @@ name = "iroha_numeric"
 version = "2.0.0-pre-rc.21"
 dependencies = [
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "iroha_ffi",
  "iroha_schema",
  "parity-scale-codec",
@@ -3208,7 +3218,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "futures",
  "iroha_config",
  "iroha_config_base",
@@ -3229,7 +3239,7 @@ name = "iroha_primitives"
 version = "2.0.0-pre-rc.21"
 dependencies = [
  "derive_more",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "iroha_ffi",
  "iroha_macro",
  "iroha_numeric",
@@ -3395,7 +3405,7 @@ name = "iroha_torii"
 version = "2.0.0-pre-rc.21"
 dependencies = [
  "async-trait",
- "displaydoc",
+ "displaydoc 0.2.4 (git+https://github.com/akonradi-signal/displaydoc.git?branch=anonymous-const)",
  "eyre",
  "futures",
  "iroha_config",
@@ -7135,7 +7145,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
+ "displaydoc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2",
  "indexmap 2.2.6",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,8 @@ assertables = "7"
 eyre = "0.6.12"
 color-eyre = "0.6.3"
 thiserror = { version = "1.0.61", default-features = false }
-displaydoc = { version = "0.2.4", default-features = false }
+# FIXME: temporary, until fix in the upstream https://github.com/yaahc/displaydoc/issues/46
+displaydoc = { git = "https://github.com/akonradi-signal/displaydoc.git", branch = "anonymous-const", default-features = false }
 error-stack = "0.4.1"
 
 cfg-if = "1.0.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -57,7 +57,7 @@ hex = { workspace = true, features = ["alloc", "serde"] }
 getset = { workspace = true }
 
 thiserror = { version = "1.0.61", optional = true }
-displaydoc = { version = "0.2.4", default-features = false }
+displaydoc = { workspace = true }
 
 digest = { version = "0.10.7", default-features = false, features = ["alloc"] }
 blake2 = { version = "0.10.6", default-features = false }


### PR DESCRIPTION
## Description

Use the fix from https://github.com/yaahc/displaydoc/pull/47 until it is merged into the upstream.

### Linked issue

Closes #4567

### Benefits

Reduces warnings noise
