### PR TITLE
fix: Fix invalid value for profile.profiling.debug in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,4 +261,4 @@ lto = true
 
 [profile.profiling]
 inherits = "release"
-debug = "limited"
+debug = true


### PR DESCRIPTION
The  key in the Cargo.toml  file was assigned an invalid value, causing the manifest parsing to fail. This commit updates the value to a valid boolean () to resolve the issue.

Fixes #4677

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4677

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Installation succeeds with `cargo build`.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [x] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
