### PR TITLE
feat: Add detect support for `parity_scale_decoder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,6 +4246,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "supports-color 2.1.0",
  "test_samples",
 ]
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -775,12 +775,12 @@ fn validate_try_bind_address(emitter: &mut Emitter<ConfigError>, value: &WithOri
 }
 
 #[allow(missing_docs)]
-pub fn is_colouring_supported() -> bool {
+pub fn is_coloring_supported() -> bool {
     supports_color::on(supports_color::Stream::Stdout).is_some()
 }
 
 fn default_terminal_colors_str() -> clap::builder::OsStr {
-    is_colouring_supported().to_string().into()
+    is_coloring_supported().to_string().into()
 }
 
 /// Iroha server CLI
@@ -1002,7 +1002,7 @@ mod tests {
     fn default_args() {
         let args = Args::try_parse_from(["test"]).unwrap();
 
-        assert_eq!(args.terminal_colors, is_colouring_supported());
+        assert_eq!(args.terminal_colors, is_coloring_supported());
         assert_eq!(args.submit_genesis, false);
     }
 
@@ -1015,7 +1015,7 @@ mod tests {
 
         assert_eq!(
             Args::try_parse_from(["test"])?.terminal_colors,
-            is_colouring_supported()
+            is_coloring_supported()
         );
         assert_eq!(try_with("--terminal-colors")?, true);
         assert_eq!(try_with("--terminal-colors=false")?, false);

--- a/tools/parity_scale_cli/Cargo.toml
+++ b/tools/parity_scale_cli/Cargo.toml
@@ -10,11 +10,6 @@ license.workspace = true
 [lints]
 workspace = true
 
-[features]
-# Disable colour for all program output.
-# Useful for Docker-based deployment and terminals without colour support.
-no_color = ["colored/no-color"]
-
 [dependencies]
 iroha_data_model = { workspace = true, features = ["http"] }
 iroha_primitives = { workspace = true }
@@ -24,12 +19,13 @@ iroha_crypto = { workspace = true }
 iroha_version = { workspace = true }
 iroha_genesis = { workspace = true }
 
-clap = { workspace = true, features = ["derive", "cargo"] }
+clap = { workspace = true, features = ["derive", "cargo", "env", "string"] }
 eyre = { workspace = true }
 parity-scale-codec = { workspace = true }
 colored = "2.1.0"
 serde_json = { workspace = true, features = ["std"]}
 serde = { workspace = true }
+supports-color = { workspace = true }
 
 [build-dependencies]
 iroha_data_model = { workspace = true }

--- a/tools/parity_scale_cli/README.md
+++ b/tools/parity_scale_cli/README.md
@@ -10,12 +10,6 @@ To build the tool, run:
 cargo build --bin parity_scale_cli
 ```
 
-If your terminal does not support colours, run:
-
-```bash
-cargo build --features no_color --bin parity_scale_cli
-```
-
 ## Usage
 
 Run Parity Scale Decoder Tool:

--- a/tools/parity_scale_cli/src/main.rs
+++ b/tools/parity_scale_cli/src/main.rs
@@ -79,7 +79,29 @@ where
 /// Parity Scale decoder tool for Iroha data types
 #[derive(Debug, Parser)]
 #[clap(version, about, author)]
-enum Args {
+struct Args {
+    #[clap(subcommand)]
+    command: Command,
+
+    /// Whether to enable ANSI colored output or not
+    ///
+    /// By default, Iroha determines whether the terminal supports colors or not.
+    ///
+    /// In order to disable this flag explicitly, pass `--terminal-colors=false`.
+    #[arg(
+        long,
+        env,
+        default_missing_value("true"),
+        default_value(default_terminal_colors_str()),
+        action(clap::ArgAction::Set),
+        require_equals(true),
+        num_args(0..=1),
+    )]
+    pub terminal_colors: bool,
+}
+
+#[derive(Debug, Parser)]
+enum Command {
     /// Show all available types
     ListTypes,
     /// Decode SCALE to Rust debug format from binary file
@@ -113,26 +135,34 @@ struct ScaleJsonArgs {
     type_name: String,
 }
 
+fn is_colouring_supported() -> bool {
+    supports_color::on(supports_color::Stream::Stdout).is_some()
+}
+
+fn default_terminal_colors_str() -> clap::builder::OsStr {
+    is_colouring_supported().to_string().into()
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
     let map = generate_map();
 
-    match args {
-        Args::ScaleToRust(decode_args) => {
+    match args.command {
+        Command::ScaleToRust(decode_args) => {
             let mut writer = BufWriter::new(io::stdout().lock());
             let decoder = ScaleToRustDecoder::new(decode_args, &map);
             decoder.decode(&mut writer)
         }
-        Args::ScaleToJson(args) => {
+        Command::ScaleToJson(args) => {
             let decoder = ScaleJsonDecoder::new(args, &map)?;
             decoder.scale_to_json()
         }
-        Args::JsonToScale(args) => {
+        Command::JsonToScale(args) => {
             let decoder = ScaleJsonDecoder::new(args, &map)?;
             decoder.json_to_scale()
         }
-        Args::ListTypes => {
+        Command::ListTypes => {
             let mut writer = BufWriter::new(io::stdout().lock());
             list_types(&map, &mut writer)
         }
@@ -382,5 +412,24 @@ mod tests {
             .json_to_scale(&json)
             .expect("Couldn't convert to SCALE");
         assert_eq!(scale_actual, scale_expected);
+    }
+
+    #[test]
+    fn terminal_colors_works_as_expected() -> eyre::Result<()> {
+        fn try_with(arg: &str) -> eyre::Result<bool> {
+            // Since arg contains enum Command and we must provide something for it, we use "list-types"
+            Ok(Args::try_parse_from(["test", arg, "list-types"])?.terminal_colors)
+        }
+
+        assert_eq!(
+            Args::try_parse_from(["test", "list-types"])?.terminal_colors,
+            is_colouring_supported()
+        );
+        assert_eq!(try_with("--terminal-colors")?, true);
+        assert_eq!(try_with("--terminal-colors=false")?, false);
+        assert_eq!(try_with("--terminal-colors=true")?, true);
+        assert!(try_with("--terminal-colors=random").is_err());
+
+        Ok(())
     }
 }

--- a/tools/parity_scale_cli/src/main.rs
+++ b/tools/parity_scale_cli/src/main.rs
@@ -135,12 +135,12 @@ struct ScaleJsonArgs {
     type_name: String,
 }
 
-fn is_colouring_supported() -> bool {
+fn is_coloring_supported() -> bool {
     supports_color::on(supports_color::Stream::Stdout).is_some()
 }
 
 fn default_terminal_colors_str() -> clap::builder::OsStr {
-    is_colouring_supported().to_string().into()
+    is_coloring_supported().to_string().into()
 }
 
 fn main() -> Result<()> {
@@ -423,7 +423,7 @@ mod tests {
 
         assert_eq!(
             Args::try_parse_from(["test", "list-types"])?.terminal_colors,
-            is_colouring_supported()
+            is_coloring_supported()
         );
         assert_eq!(try_with("--terminal-colors")?, true);
         assert_eq!(try_with("--terminal-colors=false")?, false);


### PR DESCRIPTION
## Description

<!-- Just describe what you did. -->
- add color detect support in partiy_scale_decoder
- fix typo (colour -> color) in cli

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4487

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits
Users don't have to rebuild `parity_scale_cli` when disabling terminal-colors. 
Which seems not happening right now since no color is used in parity_scale_cli for now.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [x] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
