### PR TITLE
feat(client cli): extend client cli to request json queries

### DIFF
--- a/client_cli/README.md
+++ b/client_cli/README.md
@@ -45,7 +45,7 @@ iroha [OPTIONS] <SUBCOMMAND>
 | `blocks`  | Get block stream from Iroha peer                                                                                                            |
 | `domain`  | Execute commands related to domains: register a new one, list all domains                                                                   |
 | `events`  | Get event stream from Iroha peer                                                                                                            |
-| `json`    | Submit multi-instructions as JSON                                                                                                           |
+| `json`    | Submit multi-instructions or request query as JSON                                                                                                           |
 | `peer`    | Execute commands related to peer administration and networking                                                                              |
 | `wasm`    | Execute commands related to WASM                                                                                                            |
 | `help`    | Print the help message for `iroha` and/or the current subcommand other than `help` subcommand                                    |
@@ -183,5 +183,11 @@ The reference implementation of the Rust client, `iroha`, is often used for diag
 To test transactions in the JSON format (used in the genesis block and by other SDKs), pipe the transaction into the client and add the `json` subcommand to the arguments:
 
 ```bash
-cat /path/to/file.json | ./iroha json
+cat /path/to/file.json | ./iroha json transaction
+```
+
+### Request arbitrary query 
+
+```bash 
+echo '{ "FindAllParameters": null }' | ./iroha --config client.toml json query
 ```


### PR DESCRIPTION
## Description

Extend `json` subcommand to allow pass json queries.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Examples

```bash
echo '{"FindAllParameters": null }' | ./iroha --config client.toml json query
```

### Benefits

Simplify troubleshooting.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
