### PR TITLE
build(Dockerfile): pin platform to `linux/amd64`, refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #base stage
-FROM archlinux:base-devel AS builder
+FROM --platform=linux/amd64 archlinux:base-devel AS builder
 
 # Force-sync packages, install archlinux-keyring, repopulate keys
 RUN pacman -Syy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-#base stage
 FROM --platform=linux/amd64 archlinux:base-devel AS builder
 
 ARG NIGHTLY_VERSION=2024-04-18
@@ -34,14 +33,15 @@ ENV PATH="$PATH:/x86_64-linux-musl-native/bin"
 ENV RUSTFLAGS="-C link-arg=-static"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/x86_64-linux-musl-native/bin/x86_64-linux-musl-gcc
 
-# builder stage
 WORKDIR /iroha
 COPY . .
-# FIXME: consider building only `irohad`, `iroha`, and `kagami`?
-RUN cargo build --target x86_64-unknown-linux-musl --profile deploy
+RUN cargo build \
+    -p irohad \
+    -p iroha_client_cli \
+    -p kagami \
+    --target x86_64-unknown-linux-musl \
+    --profile deploy
 
-
-# final image
 FROM alpine:3.20
 
 ARG STORAGE=/storage

--- a/configs/swarm/docker-compose.local.yml
+++ b/configs/swarm/docker-compose.local.yml
@@ -5,7 +5,6 @@ version: '3.8'
 services:
   irohad0:
     build: ../..
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed012082528CCC8727333530C8F6F19F70C23882DEB1BF2BA3BE4A6654C7E8A91A7731
@@ -34,7 +33,6 @@ services:
       start_period: 4s
   irohad1:
     build: ../..
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed012083C85E315776FD2DDC187ECB23E608F800B313A1D614B108078EC048D5013D2D
@@ -57,7 +55,6 @@ services:
       start_period: 4s
   irohad2:
     build: ../..
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed0120A37B7B758C952FE9429E9E35D1D71E2D8BB9364EDD077B5027ABAAC798D3230E
@@ -80,7 +77,6 @@ services:
       start_period: 4s
   irohad3:
     build: ../..
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed0120B23E14F659B91736AAB980B6ADDCE4B1DB8A138AB0267E049C082A744471714E

--- a/configs/swarm/docker-compose.single.yml
+++ b/configs/swarm/docker-compose.single.yml
@@ -5,7 +5,6 @@ version: '3.8'
 services:
   irohad0:
     build: ../..
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed012082528CCC8727333530C8F6F19F70C23882DEB1BF2BA3BE4A6654C7E8A91A7731

--- a/configs/swarm/docker-compose.yml
+++ b/configs/swarm/docker-compose.yml
@@ -5,7 +5,6 @@ version: '3.8'
 services:
   irohad0:
     image: hyperledger/iroha:dev
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed012082528CCC8727333530C8F6F19F70C23882DEB1BF2BA3BE4A6654C7E8A91A7731
@@ -34,7 +33,6 @@ services:
       start_period: 4s
   irohad1:
     image: hyperledger/iroha:dev
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed012083C85E315776FD2DDC187ECB23E608F800B313A1D614B108078EC048D5013D2D
@@ -57,7 +55,6 @@ services:
       start_period: 4s
   irohad2:
     image: hyperledger/iroha:dev
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed0120A37B7B758C952FE9429E9E35D1D71E2D8BB9364EDD077B5027ABAAC798D3230E
@@ -80,7 +77,6 @@ services:
       start_period: 4s
   irohad3:
     image: hyperledger/iroha:dev
-    platform: linux/amd64
     environment:
       CHAIN_ID: 00000000-0000-0000-0000-000000000000
       PUBLIC_KEY: ed0120B23E14F659B91736AAB980B6ADDCE4B1DB8A138AB0267E049C082A744471714E

--- a/tools/swarm/src/compose.rs
+++ b/tools/swarm/src/compose.rs
@@ -16,7 +16,7 @@ use serde::{ser::SerializeMap, Serialize, Serializer};
 
 use crate::{cli::SourceParsed, util::AbsolutePath};
 
-/// Config directory inside of the docker image
+/// Config directory inside the docker image
 const DIR_CONFIG_IN_DOCKER: &str = "/config";
 const GENESIS_KEYPAIR_SEED: &[u8; 7] = b"genesis";
 const GENESIS_SIGNED_FILE: &str = "/tmp/genesis.signed.scale";
@@ -25,7 +25,6 @@ kagami genesis sign /config/genesis.json --public-key $$GENESIS_PUBLIC_KEY --pri
 irohad --submit-genesis
 ""#;
 const DOCKER_COMPOSE_VERSION: &str = "3.8";
-const PLATFORM_ARCHITECTURE: &str = "linux/amd64";
 
 #[derive(Serialize, Debug)]
 pub struct DockerCompose {
@@ -76,18 +75,6 @@ impl Serialize for DockerComposeVersion {
     }
 }
 
-#[derive(Debug)]
-struct PlatformArchitecture;
-
-impl Serialize for PlatformArchitecture {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(PLATFORM_ARCHITECTURE)
-    }
-}
-
 pub struct DockerComposeServiceBuilder {
     chain_id: ChainId,
     peer: Peer,
@@ -103,7 +90,6 @@ pub struct DockerComposeServiceBuilder {
 pub struct DockerComposeService {
     #[serde(flatten)]
     source: ServiceSource,
-    platform: PlatformArchitecture,
     environment: FullPeerEnv,
     ports: Vec<PairColon<u16, u16>>,
     volumes: Vec<PairColon<String, String>>,
@@ -183,7 +169,6 @@ impl DockerComposeServiceBuilder {
 
         DockerComposeService {
             source,
-            platform: PlatformArchitecture,
             command,
             init: AlwaysTrue,
             volumes: volumes.into_iter().map(|(a, b)| PairColon(a, b)).collect(),
@@ -633,7 +618,6 @@ mod tests {
                 map.insert(
                     "iroha0".to_owned(),
                     DockerComposeService {
-                        platform: PlatformArchitecture,
                         source: ServiceSource::Build(PathBuf::from(".")),
                         environment: CompactPeerEnv {
                             chain_id,
@@ -673,7 +657,6 @@ mod tests {
             services:
               iroha0:
                 build: .
-                platform: linux/amd64
                 environment:
                   CHAIN_ID: 00000000-0000-0000-0000-000000000000
                   PUBLIC_KEY: ed012039E5BF092186FACC358770792A493CA98A83740643A3D41389483CF334F748C8
@@ -757,7 +740,6 @@ mod tests {
             services:
               irohad0:
                 build: ./iroha-cloned
-                platform: linux/amd64
                 environment:
                   CHAIN_ID: 00000000-0000-0000-0000-000000000000
                   PUBLIC_KEY: ed0120AB0B22BC053C954A4CA7CF451872E9C5B971F0DA5D92133648226D02E3ABB611
@@ -786,7 +768,6 @@ mod tests {
                   start_period: 4s
               irohad1:
                 build: ./iroha-cloned
-                platform: linux/amd64
                 environment:
                   CHAIN_ID: 00000000-0000-0000-0000-000000000000
                   PUBLIC_KEY: ed0120ACD30C7213EF11C4EC1006C6039E4089FC39C9BD211F688B866BCA59C8073883
@@ -809,7 +790,6 @@ mod tests {
                   start_period: 4s
               irohad2:
                 build: ./iroha-cloned
-                platform: linux/amd64
                 environment:
                   CHAIN_ID: 00000000-0000-0000-0000-000000000000
                   PUBLIC_KEY: ed0120222832FD8DF02882F07C13554DBA5BAE10C07A97E4AE7C2114DC05E95C3E6E32
@@ -832,7 +812,6 @@ mod tests {
                   start_period: 4s
               irohad3:
                 build: ./iroha-cloned
-                platform: linux/amd64
                 environment:
                   CHAIN_ID: 00000000-0000-0000-0000-000000000000
                   PUBLIC_KEY: ed0120FB35DF84B28FAF8BB5A24D6910EFD7D7B22101EB99BFC74C4213CB1E7215F91B


### PR DESCRIPTION
## Description

Since the Dockerfile only supports building for `linux/amd64`, let's pin it for now before we introduce multi-arch builds. Unused (seemingly) dependencies and unnecessary `RUN` layers have been removed/compressed.

### Linked issue

Related to #4687.

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Docker builds should be faster, unneeded stuff doesn't clutter the Dockerfile.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
