### PR TITLE
refactor: fix application of the core chain-wide parameters; chores

### DIFF
--- a/config/src/parameters/actual.rs
+++ b/config/src/parameters/actual.rs
@@ -207,6 +207,11 @@ impl ChainWide {
     pub fn pipeline_time(&self) -> Duration {
         self.block_time + self.commit_time
     }
+
+    /// Estimates as `block_time + commit_time / 2`
+    pub fn consensus_estimation(&self) -> Duration {
+        self.block_time + (self.commit_time / 2)
+    }
 }
 
 impl Default for ChainWide {

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -317,14 +317,14 @@ pub mod isi {
             let parameter = self.parameter;
             let parameter_id = parameter.id.clone();
 
-            let world = &mut state_transaction.world;
-            if !world.parameters.swap_remove(&parameter) {
+            if !state_transaction.world.parameters.swap_remove(&parameter) {
                 return Err(FindError::Parameter(parameter_id).into());
             }
-
-            world.parameters.insert(parameter);
-
-            world.emit_events(Some(ConfigurationEvent::Changed(parameter_id)));
+            state_transaction.world.parameters.insert(parameter.clone());
+            state_transaction
+                .world
+                .emit_events(Some(ConfigurationEvent::Changed(parameter_id)));
+            state_transaction.try_apply_core_parameter(parameter);
 
             Ok(())
         }
@@ -340,16 +340,17 @@ pub mod isi {
             let parameter = self.parameter;
             let parameter_id = parameter.id.clone();
 
-            let world = &mut state_transaction.world;
-            if !world.parameters.insert(parameter) {
+            if !state_transaction.world.parameters.insert(parameter.clone()) {
                 return Err(RepetitionError {
                     instruction_type: InstructionType::NewParameter,
                     id: IdBox::ParameterId(parameter_id),
                 }
                 .into());
             }
-
-            world.emit_events(Some(ConfigurationEvent::Created(parameter_id)));
+            state_transaction
+                .world
+                .emit_events(Some(ConfigurationEvent::Created(parameter_id)));
+            state_transaction.try_apply_core_parameter(parameter);
 
             Ok(())
         }

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -359,20 +359,9 @@ impl Sumeragi {
     }
 
     fn update_params(&mut self, state_block: &StateBlock<'_>) {
-        use iroha_data_model::parameter::default::*;
-
-        if let Some(block_time) = state_block.world.query_param(BLOCK_TIME) {
-            self.block_time = Duration::from_millis(block_time);
-        }
-        if let Some(commit_time) = state_block.world.query_param(COMMIT_TIME_LIMIT) {
-            self.commit_time = Duration::from_millis(commit_time);
-        }
-        if let Some(max_txs_in_block) = state_block
-            .world
-            .query_param::<u32, _>(MAX_TRANSACTIONS_IN_BLOCK)
-        {
-            self.max_txs_in_block = max_txs_in_block as usize;
-        }
+        self.block_time = state_block.config.block_time;
+        self.commit_time = state_block.config.commit_time;
+        self.max_txs_in_block = state_block.config.max_transactions_in_block.get() as usize;
     }
 
     fn cache_transaction(&mut self, state_block: &StateBlock<'_>) {

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -127,8 +127,13 @@ impl BlockHeader {
     }
 
     /// Creation timestamp
-    pub fn timestamp(&self) -> Duration {
+    pub const fn timestamp(&self) -> Duration {
         Duration::from_millis(self.timestamp_ms)
+    }
+
+    /// Consensus estimation
+    pub const fn consensus_estimation(&self) -> Duration {
+        Duration::from_millis(self.consensus_estimation_ms)
     }
 }
 


### PR DESCRIPTION
## Description

While working on #4516, I experimented with extreme reduction of consensus timings, i.e. `block_time` and `commit_time`. Those are configured by `NewParameter` and `SetParameter` ISIs (until #4028). It turned out that there are a few issues in `iroha_core`:

- In some places it relies on hardcoded `DEFAULT_CONSENSUS_ESTIMATION` (4 seconds) for no reason, leading to some bugs, e.g. improper time triggers execution. I made it rely on the values in the actual State config.
- Config in the State was not updated immediately when relevant ISI executed, leading Iroha to ignore updates that actually affect its behaviour, which caused desynchronisation and unexpectedly long block times when the config values are small.

So, this PR "tightens" these gaps and makes parameters application preciser.

This PR doesn't introduce changes to the tests themselves, as I am still experimenting with it.

### Linked issue

None

### Benefits

More expected behaviour of the chain-wide parameters.

