### PR TITLE
fix: Make `iroha_smart_contract_utils` `log` and `dbg` functions work outside of wasm

### DIFF
--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -33,4 +33,4 @@ jobs:
         run: cargo install --path tools/wasm_test_runner
       - name: Run smart contract tests on WebAssembly VM
         working-directory: smart_contract
-        run: mold --run cargo test --release --tests --target wasm32-unknown-unknown --no-fail-fast --quiet
+        run: mold --run cargo test -p iroha_smart_contract -p iroha_smart_contract_utils --release --tests --target wasm32-unknown-unknown --no-fail-fast --quiet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
 name = "iroha_smart_contract_utils"
 version = "2.0.0-pre-rc.21"
 dependencies = [
+ "cfg-if",
  "iroha_data_model",
  "parity-scale-codec",
  "webassembly-test",

--- a/smart_contract/utils/Cargo.toml
+++ b/smart_contract/utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 debug = []
 
 [dependencies]
+cfg-if.workspace = true
 iroha_data_model.workspace = true
 
 parity-scale-codec.workspace = true

--- a/smart_contract/utils/src/debug.rs
+++ b/smart_contract/utils/src/debug.rs
@@ -23,9 +23,12 @@ mod host {
     }
 }
 
-/// Print `obj` in debug representation to the stdout.
+/// Print `obj` in debug representation.
 ///
-/// Do nothing if `debug` feature is not specified
+/// When running as a wasm smart contract, prints to host's stdout.
+/// Does nothing unless `debug` feature is enabled.
+///
+/// When running outside of wasm, always prints the output to stderr
 #[allow(unused_variables)]
 pub fn dbg<T: Debug + ?Sized>(obj: &T) {
     cfg_if! {

--- a/smart_contract/utils/src/lib.rs
+++ b/smart_contract/utils/src/lib.rs
@@ -1,5 +1,7 @@
 //! Crate with utilities for implementing smart contract FFI
-#![no_std]
+// do not use `no_std` when not running in wasm
+// this is useful to implement `dbg` and `log` functions for host-side tests
+#![cfg_attr(target_family = "wasm", no_std)]
 #![allow(unsafe_code)]
 
 extern crate alloc;

--- a/smart_contract/utils/src/log.rs
+++ b/smart_contract/utils/src/log.rs
@@ -20,6 +20,11 @@ mod host {
 }
 
 /// Log `obj` with desired log level
+///
+/// When running as a wasm smart contract,
+///   prints to the host logging system with the corresponding level.
+///
+/// When running outside of wasm, prints the output along with its level to stderr
 pub fn log<T: alloc::string::ToString + ?Sized>(log_level: Level, obj: &T) {
     cfg_if! {
         if #[cfg(not(target_family = "wasm"))] {


### PR DESCRIPTION
## Description

This PR adds support for `iroha_smart_contract_utils`'s `log` and `dbg` functions to be used outside of wasm. This allows writing tests to be ran against the host target and to still use those wasm-specific functions.

Both implementations just print the requested object to stderr.

As a drive-by, this also makes sure to run wasm tests from `iroha_smart_contract_utils`, which was omitted in CI for some time.

### Linked issue

Fixes #4721

### Benefits

- [ ] make CI pass
