### PR TITLE
ci: Modify CodeQuality job branch checkout variable

### DIFF
--- a/.github/workflows/iroha2-dev-code-quality.yml
+++ b/.github/workflows/iroha2-dev-code-quality.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
-          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch }}
       - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --all -- --check
@@ -47,8 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
-          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_branch }}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests, with coverage
         run: |


### PR DESCRIPTION
## Description
Attempt to fix `CodeQuality` workflow `checkout` actions that always points to repository defaults branch even if PR is coming from not-default branch.

### Linked issue
https://github.com/orgs/community/discussions/66784
https://github.com/orgs/community/discussions/25220

### Benefits

Perhaps will fix `CodeQuality` workflow.

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

