### PR TITLE
feat: Allow multiple peers submit genesis block

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -103,11 +103,9 @@ You may deploy Iroha as a [native binary](#native-binary) or by using [Docker](#
 
 3. Start an Iroha peer.
 
-    You can do this either with `--genesis` parameter to specify `genesis.json` location or without. Pay attention that for multi-peer setup only one peer should be started with `--genesis` parameter.
-
     ```bash
     cd deploy
-    ./irohad --submit-genesis
+    ./irohad
     ```
 
 ### Docker

--- a/client/benches/tps/utils.rs
+++ b/client/benches/tps/utils.rs
@@ -110,7 +110,7 @@ impl Config {
 
         let blocks_out_of_measure = 2 + MeasurerUnit::PREPARATION_BLOCKS_NUMBER * self.peers;
         let state_view = network
-            .genesis
+            .first_peer
             .irohad
             .as_ref()
             .expect("Must be some")

--- a/client/tests/integration/extra_functional/genesis.rs
+++ b/client/tests/integration/extra_functional/genesis.rs
@@ -1,0 +1,33 @@
+use iroha_data_model::{
+    domain::{Domain, DomainId},
+    isi::Register,
+};
+use test_network::{wait_for_genesis_committed, NetworkBuilder};
+
+#[test]
+fn all_peers_submit_genesis() {
+    multiple_genesis_peers(4, 4, 13_800);
+}
+
+#[test]
+fn multiple_genesis_4_peers_3_genesis() {
+    multiple_genesis_peers(4, 3, 13_820);
+}
+
+#[test]
+fn multiple_genesis_4_peers_2_genesis() {
+    multiple_genesis_peers(4, 2, 13_840);
+}
+
+fn multiple_genesis_peers(n_peers: u32, n_genesis_peers: u32, port: u16) {
+    let (_rt, network, client) = NetworkBuilder::new(n_peers, Some(port))
+        .with_genesis_peers(n_genesis_peers)
+        .create_with_runtime();
+    wait_for_genesis_committed(&network.clients(), 0);
+
+    let domain_id: DomainId = "foo".parse().expect("Valid");
+    let create_domain = Register::domain(Domain::new(domain_id));
+    client
+        .submit_blocking(create_domain)
+        .expect("Failed to register domain");
+}

--- a/client/tests/integration/extra_functional/mod.rs
+++ b/client/tests/integration/extra_functional/mod.rs
@@ -1,4 +1,5 @@
 mod connected_peers;
+mod genesis;
 mod multiple_blocks_created;
 mod normal;
 mod offline_peers;

--- a/client/tests/integration/extra_functional/normal.rs
+++ b/client/tests/integration/extra_functional/normal.rs
@@ -1,24 +1,17 @@
 use std::num::NonZeroU32;
 
-use iroha::client::{self, Client};
+use iroha::client;
 use iroha_config::parameters::actual::Root as Config;
 use iroha_data_model::{asset::AssetDefinitionId, prelude::*};
 use test_network::*;
-use tokio::runtime::Runtime;
 
 #[test]
 fn tranasctions_should_be_applied() {
-    let rt = Runtime::test();
-    let (network, iroha) = rt.block_on(async {
-        let mut configuration = Config::test();
-        configuration.chain_wide.max_transactions_in_block = NonZeroU32::new(1).unwrap();
-        let network = Network::new_with_offline_peers(Some(configuration), 4, 0, Some(11_300))
-            .await
-            .unwrap();
-        let iroha = Client::test(&network.genesis.api_address);
-
-        (network, iroha)
-    });
+    let mut configuration = Config::test();
+    configuration.chain_wide.max_transactions_in_block = NonZeroU32::new(1).unwrap();
+    let (_rt, network, iroha) = NetworkBuilder::new(4, Some(11_300))
+        .with_config(configuration)
+        .create_with_runtime();
     wait_for_genesis_committed(&network.clients(), 0);
 
     let domain_id = "and".parse::<DomainId>().unwrap();

--- a/client/tests/integration/extra_functional/offline_peers.rs
+++ b/client/tests/integration/extra_functional/offline_peers.rs
@@ -11,18 +11,13 @@ use iroha_config::parameters::actual::Root as Config;
 use iroha_primitives::addr::socket_addr;
 use test_network::*;
 use test_samples::ALICE_ID;
-use tokio::runtime::Runtime;
 
 #[test]
 fn genesis_block_is_committed_with_some_offline_peers() -> Result<()> {
     // Given
-    let rt = Runtime::test();
-
-    let (network, client) = rt.block_on(Network::start_test_with_offline_and_set_n_shifts(
-        4,
-        1,
-        Some(10_560),
-    ));
+    let (_rt, network, client) = NetworkBuilder::new(4, Some(10_560))
+        .with_offline_peers(1)
+        .create_with_runtime();
     wait_for_genesis_committed(&network.clients(), 1);
 
     //When

--- a/client/tests/integration/extra_functional/restart_peer.rs
+++ b/client/tests/integration/extra_functional/restart_peer.rs
@@ -55,7 +55,7 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
             .expect("Asset not found");
         assert_eq!(AssetValue::Numeric(quantity), *asset.value());
 
-        let mut all_peers: Vec<_> = core::iter::once(network.genesis)
+        let mut all_peers: Vec<_> = core::iter::once(network.first_peer)
             .chain(network.peers.into_values())
             .collect();
         let removed_peer_idx = rand::thread_rng().gen_range(0..all_peers.len());

--- a/configs/swarm/docker-compose.local.yml
+++ b/configs/swarm/docker-compose.local.yml
@@ -50,7 +50,7 @@ services:
               --private-key $$GENESIS_PRIVATE_KEY \\
               --out-file $$GENESIS_SIGNED_FILE \\
           && \\
-          irohad --submit-genesis
+          irohad
       "
   irohad1:
     depends_on:

--- a/configs/swarm/docker-compose.single.yml
+++ b/configs/swarm/docker-compose.single.yml
@@ -49,5 +49,5 @@ services:
               --private-key $$GENESIS_PRIVATE_KEY \\
               --out-file $$GENESIS_SIGNED_FILE \\
           && \\
-          irohad --submit-genesis
+          irohad
       "

--- a/configs/swarm/docker-compose.yml
+++ b/configs/swarm/docker-compose.yml
@@ -42,7 +42,7 @@ services:
               --private-key $$GENESIS_PRIVATE_KEY \\
               --out-file $$GENESIS_SIGNED_FILE \\
           && \\
-          irohad --submit-genesis
+          irohad
       "
   irohad1:
     image: hyperledger/iroha:dev

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -410,6 +410,8 @@ impl Sumeragi {
             // Consider our peer has genesis,
             // and some other peer has genesis and broadcast it to our peer,
             // then we can ignore such genesis block because we already has genesis.
+            // Note: `ValidBlock::validate` also checks it,
+            // but we don't want warning to be printed since this is correct behaviour.
             return None;
         }
 

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -318,6 +318,8 @@ impl Sumeragi {
             "Genesis contains invalid transactions"
         );
 
+        self.topology = Topology::new(genesis.as_ref().commit_topology().cloned());
+
         let msg = BlockCreated::from(&genesis);
         let genesis = genesis
             .commit(&self.topology)
@@ -403,6 +405,13 @@ impl Sumeragi {
         BlockCreated { block }: BlockCreated,
     ) -> Option<VotingBlock<'state>> {
         let mut state_block = state.block();
+
+        if state_block.height() == 1 && block.header().height == 1 {
+            // Consider our peer has genesis,
+            // and some other peer has genesis and broadcast it to our peer,
+            // then we can ignore such genesis block because we already has genesis.
+            return None;
+        }
 
         ValidBlock::validate(
             block,

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -129,11 +129,9 @@ class _Peer:
             #     "tokio_console_addr": f"{self.host_ip}:{self.tokio_console_port}",
             # }
         }
-        self.submit_genesis = nth == 0 or args.all_peers_submit_genesis
-        if self.submit_genesis:
-            config["genesis"] = {
-                "signed_file": "../../genesis.signed.scale"
-            }
+        config["genesis"] = {
+            "signed_file": "../../genesis.signed.scale"
+        }
         with open(self.config_path, "wb") as f:
             tomli_w.dump(config, f)
         logging.info(f"Peer {self.name} initialized")
@@ -153,7 +151,7 @@ class _Peer:
         stdout_file = open(self.peer_dir / ".stdout", "w")
         stderr_file = open(self.peer_dir / ".stderr", "w")
         # These processes are created detached from the parent process already
-        subprocess.Popen([self.name, "--config", self.config_path] + (["--submit-genesis"] if self.submit_genesis else []),
+        subprocess.Popen([self.name, "--config", self.config_path],
                     executable=self.out_dir / "peers/irohad", stdout=stdout_file, stderr=stderr_file)
 
 def pos_int(arg):
@@ -295,8 +293,6 @@ if __name__ == "__main__":
     parser.add_argument("--peer-name-as-seed", action="store_true",
                         help="Use peer name as seed for key generation. \
                         This option could be useful to preserve the same peer keys between script invocations")
-    parser.add_argument("--all-peers-submit-genesis", action="store_true",
-                        help="Make all peers submit genesis (instead of only first one)")
 
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Enable verbose output")

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -37,8 +37,9 @@ class Network:
 
         logging.info("Generating shared configuration...")
         trusted_peers = [{"address": f"{peer.host_ip}:{peer.p2p_port}", "public_key": peer.public_key} for peer in self.peers]
-        genesis_public_key = self.peers[0].public_key
-        genesis_private_key = self.peers[0].private_key
+        genesis_key_pair = kagami_generate_key_pair(args.out_dir, seed="Irohagenesis")
+        genesis_public_key = genesis_key_pair["public_key"]
+        genesis_private_key = genesis_key_pair["private_key"]
         shared_config = {
             "chain": "00000000-0000-0000-0000-000000000000",
             "genesis": {
@@ -81,7 +82,7 @@ class Network:
 
     def run(self):
         for i, peer in enumerate(self.peers):
-            peer.run(submit_genesis=(i == 0))
+            peer.run()
         self.wait_for_genesis(20)
 
 class _Peer:
@@ -103,18 +104,8 @@ class _Peer:
 
         logging.info(f"Peer {self.name} generating key pair...")
 
-        command = [self.out_dir / "kagami", "crypto", "-j"]
-        if nth == 0:
-            command.extend(["-s", "Iroha" + "genesis"])
-        elif args.peer_name_as_seed:
-            command.extend(["-s", self.name])
-        kagami = subprocess.run(command, capture_output=True)
-        if kagami.returncode:
-            logging.error("Kagami failed to generate a key pair.")
-            sys.exit(3)
-        str_keypair = kagami.stdout
-        # dict with `{ public_key: string, private_key: { algorithm: string, payload: string } }`
-        self.key_pair = json.loads(str_keypair)
+        seed = self.name if args.peer_name_as_seed else None
+        self.key_pair = kagami_generate_key_pair(args.out_dir, seed)
         os.makedirs(self.peer_dir, exist_ok=True)
 
         config = {
@@ -138,7 +129,8 @@ class _Peer:
             #     "tokio_console_addr": f"{self.host_ip}:{self.tokio_console_port}",
             # }
         }
-        if nth == 0:
+        self.submit_genesis = nth == 0 or args.all_peers_submit_genesis
+        if self.submit_genesis:
             config["genesis"] = {
                 "signed_file": "../../genesis.signed.scale"
             }
@@ -154,14 +146,14 @@ class _Peer:
     def private_key(self):
         return self.key_pair["private_key"]
 
-    def run(self, submit_genesis: bool = False):
+    def run(self):
         logging.info(f"Running peer {self.name}...")
 
         # FD never gets closed
         stdout_file = open(self.peer_dir / ".stdout", "w")
         stderr_file = open(self.peer_dir / ".stderr", "w")
         # These processes are created detached from the parent process already
-        subprocess.Popen([self.name, "--config", self.config_path] + (["--submit-genesis"] if submit_genesis else []),
+        subprocess.Popen([self.name, "--config", self.config_path] + (["--submit-genesis"] if self.submit_genesis else []),
                     executable=self.out_dir / "peers/irohad", stdout=stdout_file, stderr=stderr_file)
 
 def pos_int(arg):
@@ -190,6 +182,17 @@ def copy_or_prompt_build_bin(bin_name: str, root_dir: pathlib.Path, target_dir: 
                 sys.exit(4)
             else:
                 logging.error("Please answer with either `y[es]` or `n[o]`")
+
+def kagami_generate_key_pair(out_dir: pathlib.Path, seed: str = None):
+    command = [out_dir / "kagami", "crypto", "-j"]
+    if seed is not None:
+        command.extend(["-s", seed])
+    kagami = subprocess.run(command, capture_output=True)
+    if kagami.returncode:
+        logging.error("Kagami failed to generate a key pair.")
+        sys.exit(3)
+    # dict with `{ public_key: string, private_key: string }`
+    return json.loads(kagami.stdout)
 
 def copy_genesis_json_and_change_topology(args: argparse.Namespace, topology):
     try:
@@ -292,6 +295,8 @@ if __name__ == "__main__":
     parser.add_argument("--peer-name-as-seed", action="store_true",
                         help="Use peer name as seed for key generation. \
                         This option could be useful to preserve the same peer keys between script invocations")
+    parser.add_argument("--all-peers-submit-genesis", action="store_true",
+                        help="Make all peers submit genesis (instead of only first one)")
 
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Enable verbose output")

--- a/tools/swarm/src/lib.rs
+++ b/tools/swarm/src/lib.rs
@@ -218,7 +218,7 @@ mod tests {
                           --private-key $$GENESIS_PRIVATE_KEY \\
                           --out-file $$GENESIS_SIGNED_FILE \\
                       && \\
-                      irohad --submit-genesis
+                      irohad
                   "
         "##]).assert_eq(&build_as_string(
             nonzero_ext::nonzero!(1u16),
@@ -276,7 +276,7 @@ mod tests {
                           --private-key $$GENESIS_PRIVATE_KEY \\
                           --out-file $$GENESIS_SIGNED_FILE \\
                       && \\
-                      irohad --submit-genesis
+                      irohad
                   "
         "##]).assert_eq(&build_as_string(
             nonzero_ext::nonzero!(1u16),
@@ -329,7 +329,7 @@ mod tests {
                           --private-key $$GENESIS_PRIVATE_KEY \\
                           --out-file $$GENESIS_SIGNED_FILE \\
                       && \\
-                      irohad --submit-genesis
+                      irohad
                   "
         "#]).assert_eq(&build_as_string(
             nonzero_ext::nonzero!(1u16),
@@ -384,7 +384,7 @@ mod tests {
                           --private-key $$GENESIS_PRIVATE_KEY \\
                           --out-file $$GENESIS_SIGNED_FILE \\
                       && \\
-                      irohad --submit-genesis
+                      irohad
                   "
               irohad1:
                 image: hyperledger/iroha:dev

--- a/tools/swarm/src/schema.rs
+++ b/tools/swarm/src/schema.rs
@@ -299,7 +299,7 @@ const SIGN_AND_SUBMIT_GENESIS: &str = r#"/bin/sh -c "
         --private-key $$GENESIS_PRIVATE_KEY \\
         --out-file $$GENESIS_SIGNED_FILE \\
     && \\
-    irohad --submit-genesis
+    irohad
 ""#;
 
 /// Configuration of the `irohad` service that submits genesis.


### PR DESCRIPTION
## Description

Continuation of #4739:
* Topology stored in genesis block will be used as initial topology, as a result multiple peers can submit genesis
* Removed `--submit-genesis` flag
* Changed `scripts/test_env.py`, it will submit genesis for all peers

### Linked issue

Closes #4696

### Benefits

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
