### PR TITLE
refactor(swarm): build with `irohad0` instead of dummy builder

### DIFF
--- a/configs/swarm/docker-compose.local.yml
+++ b/configs/swarm/docker-compose.local.yml
@@ -3,15 +3,9 @@
 # Seed: Iroha
 
 services:
-  builder:
+  irohad0:
     image: hyperledger/iroha:local
     build: ../..
-    pull_policy: never
-    command: echo ok
-  irohad0:
-    depends_on:
-    - builder
-    image: hyperledger/iroha:local
     pull_policy: never
     environment:
       CHAIN: 00000000-0000-0000-0000-000000000000
@@ -54,7 +48,7 @@ services:
       "
   irohad1:
     depends_on:
-    - builder
+    - irohad0
     image: hyperledger/iroha:local
     pull_policy: never
     environment:
@@ -79,7 +73,7 @@ services:
       start_period: 4s
   irohad2:
     depends_on:
-    - builder
+    - irohad0
     image: hyperledger/iroha:local
     pull_policy: never
     environment:
@@ -104,7 +98,7 @@ services:
       start_period: 4s
   irohad3:
     depends_on:
-    - builder
+    - irohad0
     image: hyperledger/iroha:local
     pull_policy: never
     environment:

--- a/configs/swarm/docker-compose.single.yml
+++ b/configs/swarm/docker-compose.single.yml
@@ -3,15 +3,9 @@
 # Seed: Iroha
 
 services:
-  builder:
+  irohad0:
     image: hyperledger/iroha:local
     build: ../..
-    pull_policy: never
-    command: echo ok
-  irohad0:
-    depends_on:
-    - builder
-    image: hyperledger/iroha:local
     pull_policy: never
     environment:
       CHAIN: 00000000-0000-0000-0000-000000000000

--- a/tools/swarm/README.md
+++ b/tools/swarm/README.md
@@ -74,4 +74,4 @@ iroha_swarm \
 
 ## Note on configuration structure
 
-When using the `--build` option, the generated configuration will consist of a number of peer services that depend on a dummy `builder` service that only builds the image and terminates. The builder service is needed to avoid redundant building of the same image by every peer.
+When using the `--build` option, the first peer in the generated configuration builds the image, while the rest of the peers depend on it. This is needed to avoid redundant building of the same image by every peer.

--- a/tools/swarm/src/schema/serde_impls.rs
+++ b/tools/swarm/src/schema/serde_impls.rs
@@ -1,14 +1,5 @@
 //! Custom `serde` impls. Keep them here to reduce clutter.
 
-impl serde::Serialize for super::EchoOk {
-    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        ser.serialize_str(super::ECHO_OK)
-    }
-}
-
 impl<const VALUE: bool> serde::Serialize for super::Bool<VALUE> {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
@@ -18,12 +9,12 @@ impl<const VALUE: bool> serde::Serialize for super::Bool<VALUE> {
     }
 }
 
-impl serde::Serialize for super::ImageBuilderRef {
+impl serde::Serialize for super::Irohad0Ref {
     fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        ser.serialize_str(super::IMAGE_BUILDER)
+        ser.serialize_str(super::IROHAD0)
     }
 }
 


### PR DESCRIPTION
## Description

Image for Compose is now built by the first peer service instead of the dummy builder. Solves [the CI failure](https://github.com/hyperledger/iroha/actions/runs/9739223415/job/26874072004) when testing generated Compose configs caused by https://github.com/docker/compose/issues/10596.

### Benefits

No need for a dummy service to build images.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
