### PR TITLE
refactor(client): allow turbofish with multiple `Instruction`s

### DIFF
--- a/client/benches/torii.rs
+++ b/client/benches/torii.rs
@@ -70,14 +70,13 @@ fn query_requests(criterion: &mut Criterion) {
     let iroha = Client::new(client_config);
     thread::sleep(std::time::Duration::from_millis(5000));
 
-    let instructions: [InstructionBox; 4] = [
-        create_domain.into(),
-        create_account.into(),
-        create_asset.into(),
-        mint_asset.into(),
-    ];
     let _ = iroha
-        .submit_all(instructions)
+        .submit_all::<InstructionBox>([
+            create_domain.into(),
+            create_account.into(),
+            create_asset.into(),
+            mint_asset.into(),
+        ])
         .expect("Failed to prepare state");
 
     let request = asset::by_account_id(account_id);
@@ -138,9 +137,9 @@ fn instruction_submits(criterion: &mut Criterion) {
     rt.block_on(builder.start_with_peer(&mut peer));
     let mut group = criterion.benchmark_group("instruction-requests");
     let domain_id: DomainId = "domain".parse().expect("Valid");
-    let create_domain: InstructionBox = Register::domain(Domain::new(domain_id)).into();
+    let create_domain = Register::domain(Domain::new(domain_id));
     let (account_id, _account_keypair) = gen_account_in("domain");
-    let create_account = Register::account(Account::new(account_id.clone())).into();
+    let create_account = Register::account(Account::new(account_id.clone()));
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse().expect("Valid");
     let client_config = iroha::samples::get_client_config(
         get_chain_id(),
@@ -150,7 +149,7 @@ fn instruction_submits(criterion: &mut Criterion) {
     let iroha = Client::new(client_config);
     thread::sleep(std::time::Duration::from_millis(5000));
     let _ = iroha
-        .submit_all([create_domain, create_account])
+        .submit_all::<InstructionBox>([create_domain.into(), create_account.into()])
         .expect("Failed to create role.");
     thread::sleep(std::time::Duration::from_millis(500));
     let mut success_count = 0;

--- a/client/examples/million_accounts_genesis.rs
+++ b/client/examples/million_accounts_genesis.rs
@@ -71,10 +71,10 @@ fn create_million_accounts_directly() {
     for i in 0_u32..1_000_000_u32 {
         let domain_id: DomainId = format!("wonderland-{i}").parse().expect("Valid");
         let normal_account_id = AccountId::new(domain_id.clone(), KeyPair::random().into_parts().0);
-        let create_domain: InstructionBox = Register::domain(Domain::new(domain_id)).into();
-        let create_account = Register::account(Account::new(normal_account_id.clone())).into();
+        let create_domain = Register::domain(Domain::new(domain_id));
+        let create_account = Register::account(Account::new(normal_account_id.clone()));
         if test_client
-            .submit_all([create_domain, create_account])
+            .submit_all::<InstructionBox>([create_domain.into(), create_account.into()])
             .is_err()
         {
             thread::sleep(Duration::from_millis(100));

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -451,9 +451,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if signing transaction fails
-    pub fn build_transaction(
+    pub fn build_transaction<Exec: Into<Executable>>(
         &self,
-        instructions: impl Into<Executable>,
+        instructions: Exec,
         metadata: Metadata,
     ) -> SignedTransaction {
         let tx_builder = TransactionBuilder::new(self.chain.clone(), self.account.clone());
@@ -497,7 +497,7 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit(&self, instruction: impl Instruction) -> Result<HashOf<SignedTransaction>> {
+    pub fn submit<I: Instruction>(&self, instruction: I) -> Result<HashOf<SignedTransaction>> {
         let isi = instruction.into();
         self.submit_all([isi])
     }
@@ -507,9 +507,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_all(
+    pub fn submit_all<I: Instruction>(
         &self,
-        instructions: impl IntoIterator<Item = impl Instruction>,
+        instructions: impl IntoIterator<Item = I>,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_all_with_metadata(instructions, Metadata::default())
     }
@@ -520,9 +520,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_with_metadata(
+    pub fn submit_with_metadata<I: Instruction>(
         &self,
-        instruction: impl Instruction,
+        instruction: I,
         metadata: Metadata,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_all_with_metadata([instruction], metadata)
@@ -534,9 +534,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_all_with_metadata(
+    pub fn submit_all_with_metadata<I: Instruction>(
         &self,
-        instructions: impl IntoIterator<Item = impl Instruction>,
+        instructions: impl IntoIterator<Item = I>,
         metadata: Metadata,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_transaction(&self.build_transaction(instructions, metadata))
@@ -704,9 +704,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_blocking(
+    pub fn submit_blocking<I: Instruction>(
         &self,
-        instruction: impl Instruction,
+        instruction: I,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_all_blocking(vec![instruction.into()])
     }
@@ -716,9 +716,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_all_blocking(
+    pub fn submit_all_blocking<I: Instruction>(
         &self,
-        instructions: impl IntoIterator<Item = impl Instruction>,
+        instructions: impl IntoIterator<Item = I>,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_all_blocking_with_metadata(instructions, Metadata::default())
     }
@@ -729,9 +729,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_blocking_with_metadata(
+    pub fn submit_blocking_with_metadata<I: Instruction>(
         &self,
-        instruction: impl Instruction,
+        instruction: I,
         metadata: Metadata,
     ) -> Result<HashOf<SignedTransaction>> {
         self.submit_all_blocking_with_metadata(vec![instruction.into()], metadata)
@@ -743,9 +743,9 @@ impl Client {
     ///
     /// # Errors
     /// Fails if sending transaction to peer fails or if it response with error
-    pub fn submit_all_blocking_with_metadata(
+    pub fn submit_all_blocking_with_metadata<I: Instruction>(
         &self,
-        instructions: impl IntoIterator<Item = impl Instruction>,
+        instructions: impl IntoIterator<Item = I>,
         metadata: Metadata,
     ) -> Result<HashOf<SignedTransaction>> {
         let transaction = self.build_transaction(instructions, metadata);

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -24,14 +24,17 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_a
         BlockParameter::MaxTransactions(nonzero!(1_u64)),
     )))?;
 
-    let create_domain: InstructionBox =
-        Register::domain(Domain::new(DomainId::from_str("domain")?)).into();
+    let create_domain = Register::domain(Domain::new(DomainId::from_str("domain")?));
     let (account_id, _account_keypair) = gen_account_in("domain");
-    let create_account = Register::account(Account::new(account_id.clone())).into();
+    let create_account = Register::account(Account::new(account_id.clone()));
     let asset_definition_id = AssetDefinitionId::from_str("xor#domain")?;
     let create_asset =
-        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone())).into();
-    client.submit_all([create_domain, create_account, create_asset])?;
+        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
+    client.submit_all::<InstructionBox>([
+        create_domain.into(),
+        create_account.into(),
+        create_asset.into(),
+    ])?;
     thread::sleep(pipeline_time * 3);
     //When
     let quantity = numeric!(200);

--- a/client/tests/integration/events/notification.rs
+++ b/client/tests/integration/events/notification.rs
@@ -19,7 +19,7 @@ fn trigger_completion_success_should_produce_event() -> Result<()> {
     let register_trigger = Register::trigger(Trigger::new(
         trigger_id.clone(),
         Action::new(
-            vec![InstructionBox::from(instruction)],
+            vec![instruction],
             Repeats::Indefinitely,
             asset_id.account().clone(),
             ExecuteTriggerEventFilter::new()
@@ -63,7 +63,7 @@ fn trigger_completion_failure_should_produce_event() -> Result<()> {
     let register_trigger = Register::trigger(Trigger::new(
         trigger_id.clone(),
         Action::new(
-            vec![InstructionBox::from(fail_isi)],
+            vec![fail_isi],
             Repeats::Indefinitely,
             account_id.clone(),
             ExecuteTriggerEventFilter::new()

--- a/client/tests/integration/extra_functional/multiple_blocks_created.rs
+++ b/client/tests/integration/extra_functional/multiple_blocks_created.rs
@@ -24,14 +24,18 @@ fn long_multiple_blocks_created() -> Result<()> {
         BlockParameter::MaxTransactions(nonzero!(1_u64)),
     )))?;
 
-    let create_domain: InstructionBox = Register::domain(Domain::new("domain".parse()?)).into();
+    let create_domain = Register::domain(Domain::new("domain".parse()?));
     let (account_id, _account_keypair) = gen_account_in("domain");
-    let create_account = Register::account(Account::new(account_id.clone())).into();
+    let create_account = Register::account(Account::new(account_id.clone()));
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse()?;
     let create_asset =
-        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone())).into();
+        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
 
-    client.submit_all([create_domain, create_account, create_asset])?;
+    client.submit_all::<InstructionBox>([
+        create_domain.into(),
+        create_account.into(),
+        create_asset.into(),
+    ])?;
 
     thread::sleep(pipeline_time);
 

--- a/client/tests/integration/extra_functional/unregister_peer.rs
+++ b/client/tests/integration/extra_functional/unregister_peer.rs
@@ -126,13 +126,12 @@ fn init() -> Result<(
     let asset_definition_id: AssetDefinitionId = "xor#domain".parse()?;
     let create_asset =
         Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
-    let instructions: [InstructionBox; 4] = [
+    client.submit_all_blocking::<InstructionBox>([
         set_max_txns_in_block.into(),
         create_domain.into(),
         create_account.into(),
         create_asset.into(),
-    ];
-    client.submit_all_blocking(instructions)?;
+    ])?;
     iroha_logger::info!("Init");
     Ok((
         rt,

--- a/client/tests/integration/multisig.rs
+++ b/client/tests/integration/multisig.rs
@@ -99,9 +99,7 @@ fn mutlisig() -> Result<()> {
     assert_eq!(trigger.id(), &multisig_trigger_id);
 
     let domain_id: DomainId = "domain_controlled_by_multisig".parse().unwrap();
-    let isi = vec![InstructionBox::from(Register::domain(Domain::new(
-        domain_id.clone(),
-    )))];
+    let isi = vec![Register::domain(Domain::new(domain_id.clone())).into()];
     let isi_hash = HashOf::new(&isi);
 
     let mut signatories_iter = signatories.into_iter();

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -64,17 +64,16 @@ fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Re
     // Given
     let account_id = ALICE_ID.clone();
     let asset_definition_id = AssetDefinitionId::from_str("xor#wonderland").expect("Valid");
-    let create_asset: InstructionBox = Register::asset_definition(
+    let create_asset = Register::asset_definition(
         AssetDefinition::numeric(asset_definition_id.clone()).mintable_once(),
-    )
-    .into();
+    );
 
     let asset_id = AssetId::new(asset_definition_id.clone(), account_id.clone());
-    let register_asset: InstructionBox =
-        Register::asset(Asset::new(asset_id.clone(), 1_u32)).into();
+    let register_asset = Register::asset(Asset::new(asset_id.clone(), 1_u32));
 
     // We can register the non-mintable token
-    test_client.submit_all([create_asset, register_asset.clone()])?;
+    test_client
+        .submit_all::<InstructionBox>([create_asset.into(), register_asset.clone().into()])?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
         let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
         assets.iter().any(|asset| {
@@ -110,9 +109,11 @@ fn non_mintable_asset_can_be_minted_if_registered_with_zero_value() -> Result<()
     let mint = Mint::asset_numeric(1u32, asset_id);
 
     // We can register the non-mintable token wih zero value and then mint it
-    let instructions: [InstructionBox; 3] =
-        [create_asset.into(), register_asset.into(), mint.into()];
-    test_client.submit_all(instructions)?;
+    test_client.submit_all::<InstructionBox>([
+        create_asset.into(),
+        register_asset.into(),
+        mint.into(),
+    ])?;
     test_client.poll_request(client::asset::by_account_id(account_id), |result| {
         let assets = result.collect::<QueryResult<Vec<_>>>().expect("Valid");
         assets.iter().any(|asset| {

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -46,11 +46,11 @@ fn fetch_size_should_work() -> Result<()> {
 
 fn register_assets(client: &Client) -> Result<()> {
     // FIXME transaction is rejected for more than a certain number of instructions
-    let register: Vec<InstructionBox> = ('a'..='j')
+    let register: Vec<_> = ('a'..='j')
         .map(|c| c.to_string())
         .map(|name| (name + "#wonderland").parse().expect("Valid"))
         .map(|asset_definition_id| {
-            Register::asset_definition(AssetDefinition::numeric(asset_definition_id)).into()
+            Register::asset_definition(AssetDefinition::numeric(asset_definition_id))
         })
         .collect();
     let _ = client.submit_all_blocking(register)?;

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -209,27 +209,28 @@ fn permissions_differ_not_only_by_names() {
     // Registering mouse
     let outfit_domain: DomainId = "outfit".parse().unwrap();
     let create_outfit_domain = Register::domain(Domain::new(outfit_domain.clone()));
-    let new_mouse_account = Account::new(mouse_id.clone());
+    let register_mouse_account = Register::account(Account::new(mouse_id.clone()));
     client
-        .submit_all_blocking([
-            InstructionBox::from(create_outfit_domain),
-            Register::account(new_mouse_account).into(),
+        .submit_all_blocking::<InstructionBox>([
+            create_outfit_domain.into(),
+            register_mouse_account.into(),
         ])
         .expect("Failed to register mouse");
 
     // Registering `Store` asset definitions
     let hat_definition_id: AssetDefinitionId = "hat#outfit".parse().expect("Valid");
-    let new_hat_definition = AssetDefinition::store(hat_definition_id.clone());
+    let register_hat_definition =
+        Register::asset_definition(AssetDefinition::store(hat_definition_id.clone()));
     let transfer_shoes_domain = Transfer::domain(alice_id.clone(), outfit_domain, mouse_id.clone());
     let shoes_definition_id: AssetDefinitionId = "shoes#outfit".parse().expect("Valid");
-    let new_shoes_definition = AssetDefinition::store(shoes_definition_id.clone());
-    let instructions: [InstructionBox; 3] = [
-        Register::asset_definition(new_hat_definition).into(),
-        Register::asset_definition(new_shoes_definition).into(),
-        transfer_shoes_domain.into(),
-    ];
+    let register_shoes_definition =
+        Register::asset_definition(AssetDefinition::store(shoes_definition_id.clone()));
     client
-        .submit_all_blocking(instructions)
+        .submit_all_blocking::<InstructionBox>([
+            register_hat_definition.into(),
+            register_shoes_definition.into(),
+            transfer_shoes_domain.into(),
+        ])
         .expect("Failed to register new asset definitions");
 
     // Granting permission to Alice to modify metadata in Mouse's hats
@@ -303,13 +304,9 @@ fn stored_vs_granted_permission_payload() -> Result<()> {
     let create_asset =
         Register::asset_definition(AssetDefinition::store(asset_definition_id.clone()));
     let (mouse_id, mouse_keypair) = gen_account_in("wonderland");
-    let new_mouse_account = Account::new(mouse_id.clone());
-    let instructions: [InstructionBox; 2] = [
-        Register::account(new_mouse_account).into(),
-        create_asset.into(),
-    ];
+    let register_mouse_account = Register::account(Account::new(mouse_id.clone()));
     iroha
-        .submit_all_blocking(instructions)
+        .submit_all_blocking::<InstructionBox>([register_mouse_account.into(), create_asset.into()])
         .expect("Failed to register mouse");
 
     // Allow alice to mint mouse asset and mint initial value
@@ -391,8 +388,8 @@ fn associated_permissions_removed_on_unregister() {
         Grant::account_permission(bob_to_set_kv_in_domain.clone(), bob_id.clone());
 
     iroha
-        .submit_all_blocking([
-            InstructionBox::from(register_domain),
+        .submit_all_blocking::<InstructionBox>([
+            register_domain.into(),
             allow_bob_to_set_kv_in_domain.into(),
         ])
         .expect("failed to register domain and grant permission");
@@ -443,7 +440,7 @@ fn associated_permissions_removed_from_role_on_unregister() {
     let register_role = Register::role(role);
 
     iroha
-        .submit_all_blocking([InstructionBox::from(register_domain), register_role.into()])
+        .submit_all_blocking::<InstructionBox>([register_domain.into(), register_role.into()])
         .expect("failed to register domain and grant permission");
 
     // check that role indeed have permission

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -40,8 +40,7 @@ fn json_and_scale_statuses_equality() -> Result<()> {
             1234u32,
             AssetId::new(asset_definition_id, account_id.clone()),
         );
-        let instructions: [InstructionBox; 2] = [create_asset.into(), mint_asset.into()];
-        client.submit_all(instructions)?;
+        client.submit_all::<InstructionBox>([create_asset.into(), mint_asset.into()])?;
     }
 
     let json_status_coins = get_status_json(&client).unwrap();

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -43,26 +43,23 @@ fn simulate_transfer_store_asset() {
         true,
     );
 
-    let instructions: [InstructionBox; 3] = [
-        // create_alice.into(), We don't need to register Alice, because she is created in genesis
-        create_mouse.into(),
-        create_asset.into(),
-        set_key_value.into(),
-    ];
-
     iroha
-        .submit_all_blocking(instructions)
+        .submit_all_blocking::<InstructionBox>([
+            // create_alice.into(), We don't need to register Alice, because she is created in genesis
+            create_mouse.into(),
+            create_asset.into(),
+            set_key_value.into(),
+        ])
         .expect("Failed to prepare state.");
 
     let transfer_asset = Transfer::asset_store(
         AssetId::new(asset_definition_id.clone(), alice_id.clone()),
         mouse_id.clone(),
     );
-    let transfer_box: InstructionBox = transfer_asset.into();
 
     iroha
         .submit_till(
-            transfer_box,
+            transfer_asset,
             client::asset::by_account_id(mouse_id.clone()),
             |result| {
                 let assets = result.collect::<QueryResult<Vec<_>>>().unwrap();

--- a/client/tests/integration/triggers/orphans.rs
+++ b/client/tests/integration/triggers/orphans.rs
@@ -21,15 +21,14 @@ fn set_up_trigger(
     wait_for_genesis_committed(&[iroha.clone()], 0);
 
     let failand: DomainId = "failand".parse()?;
-    let create_failand: InstructionBox = Register::domain(Domain::new(failand.clone())).into();
+    let create_failand = Register::domain(Domain::new(failand.clone()));
 
     let (the_one_who_fails, _account_keypair) = gen_account_in(failand.name());
-    let create_the_one_who_fails: InstructionBox =
-        Register::account(Account::new(the_one_who_fails.clone())).into();
+    let create_the_one_who_fails = Register::account(Account::new(the_one_who_fails.clone()));
 
     let fail_on_account_events = "fail".parse::<TriggerId>()?;
     let fail_isi = Unregister::domain("dummy".parse().unwrap());
-    let register_fail_on_account_events: InstructionBox = Register::trigger(Trigger::new(
+    let register_fail_on_account_events = Register::trigger(Trigger::new(
         fail_on_account_events.clone(),
         Action::new(
             [fail_isi],
@@ -37,12 +36,11 @@ fn set_up_trigger(
             the_one_who_fails.clone(),
             AccountEventFilter::new(),
         ),
-    ))
-    .into();
-    iroha.submit_all_blocking([
-        create_failand,
-        create_the_one_who_fails,
-        register_fail_on_account_events,
+    ));
+    iroha.submit_all_blocking::<InstructionBox>([
+        create_failand.into(),
+        create_the_one_who_fails.into(),
+        register_fail_on_account_events.into(),
     ])?;
     Ok((
         rt,

--- a/client/tests/integration/tx_chain_id.rs
+++ b/client/tests/integration/tx_chain_id.rs
@@ -15,23 +15,20 @@ fn send_tx_with_different_chain_id() {
         .unwrap();
     let to_transfer = numeric!(1);
 
-    let create_sender_account: InstructionBox =
-        Register::account(Account::new(sender_id.clone())).into();
-    let create_receiver_account: InstructionBox =
-        Register::account(Account::new(receiver_id.clone())).into();
-    let register_asset_definition: InstructionBox =
-        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone())).into();
-    let register_asset: InstructionBox = Register::asset(Asset::new(
+    let create_sender_account = Register::account(Account::new(sender_id.clone()));
+    let create_receiver_account = Register::account(Account::new(receiver_id.clone()));
+    let register_asset_definition =
+        Register::asset_definition(AssetDefinition::numeric(asset_definition_id.clone()));
+    let register_asset = Register::asset(Asset::new(
         AssetId::new(asset_definition_id.clone(), sender_id.clone()),
         numeric!(10),
-    ))
-    .into();
+    ));
     test_client
-        .submit_all_blocking([
-            create_sender_account,
-            create_receiver_account,
-            register_asset_definition,
-            register_asset,
+        .submit_all_blocking::<InstructionBox>([
+            create_sender_account.into(),
+            create_receiver_account.into(),
+            register_asset_definition.into(),
+            register_asset.into(),
         ])
         .unwrap();
     let chain_id_0 = ChainId::from("00000000-0000-0000-0000-000000000000"); // Value configured by default

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -22,8 +22,7 @@ fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes(
         200u32,
         AssetId::new(wrong_asset_definition_id.clone(), account_id.clone()),
     );
-    let instructions: [InstructionBox; 2] = [create_asset.into(), mint_asset.into()];
-    let _ = client.submit_all_blocking(instructions);
+    let _ = client.submit_all_blocking::<InstructionBox>([create_asset.into(), mint_asset.into()]);
 
     //Then
     let request = client::asset::by_account_id(account_id);

--- a/client/tests/integration/upgrade.rs
+++ b/client/tests/integration/upgrade.rs
@@ -407,8 +407,8 @@ fn define_custom_parameter() -> Result<()> {
         id_len: 2_u32.pow(6),
     }
     .into();
-    let set_param_isi: InstructionBox = SetParameter::new(parameter).into();
-    client.submit_all_blocking([set_param_isi, create_domain.into()])?;
+    let set_param_isi = SetParameter::new(parameter);
+    client.submit_all_blocking::<InstructionBox>([set_param_isi.into(), create_domain.into()])?;
 
     Ok(())
 }

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -29,14 +29,16 @@ const TRANSACTION_LIMITS: TransactionParameters =
 
 fn build_test_transaction(chain_id: ChainId) -> TransactionBuilder {
     let domain_id: DomainId = "domain".parse().unwrap();
-    let create_domain: InstructionBox = Register::domain(Domain::new(domain_id.clone())).into();
-    let create_account = Register::account(Account::new(gen_account_in(&domain_id).0)).into();
+    let create_domain = Register::domain(Domain::new(domain_id.clone()));
+    let create_account = Register::account(Account::new(gen_account_in(&domain_id).0));
     let asset_definition_id = "xor#domain".parse().unwrap();
-    let create_asset =
-        Register::asset_definition(AssetDefinition::numeric(asset_definition_id)).into();
-    let instructions = [create_domain, create_account, create_asset];
+    let create_asset = Register::asset_definition(AssetDefinition::numeric(asset_definition_id));
 
-    TransactionBuilder::new(chain_id, STARTER_ID.clone()).with_instructions(instructions)
+    TransactionBuilder::new(chain_id, STARTER_ID.clone()).with_instructions::<InstructionBox>([
+        create_domain.into(),
+        create_account.into(),
+        create_asset.into(),
+    ])
 }
 
 fn build_test_and_transient_state() -> State {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -1140,16 +1140,13 @@ mod tests {
         let create_asset =
             Register::asset_definition(AssetDefinition::numeric(asset_definition_id));
         let fail_isi = Unregister::domain("dummy".parse().unwrap());
-        let instructions_fail: [InstructionBox; 2] =
-            [create_domain.clone().into(), fail_isi.into()];
-        let instructions_accept: [InstructionBox; 2] = [create_domain.into(), create_asset.into()];
         let tx_fail = TransactionBuilder::new(chain_id.clone(), alice_id.clone())
-            .with_instructions(instructions_fail)
+            .with_instructions::<InstructionBox>([create_domain.clone().into(), fail_isi.into()])
             .sign(alice_keypair.private_key());
         let tx_fail =
             AcceptedTransaction::accept(tx_fail, &chain_id, transaction_limits).expect("Valid");
         let tx_accept = TransactionBuilder::new(chain_id.clone(), alice_id)
-            .with_instructions(instructions_accept)
+            .with_instructions::<InstructionBox>([create_domain.into(), create_asset.into()])
             .sign(alice_keypair.private_key());
         let tx_accept =
             AcceptedTransaction::accept(tx_accept, &chain_id, transaction_limits).expect("Valid");

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -437,9 +437,8 @@ mod tests {
         let state = state_with_test_domains(&kura)?;
         let state_block = state.block();
 
-        let instructions: [InstructionBox; 0] = [];
         let tx = TransactionBuilder::new(chain_id.clone(), SAMPLE_GENESIS_ACCOUNT_ID.clone())
-            .with_instructions(instructions)
+            .with_instructions::<InstructionBox>([])
             .sign(SAMPLE_GENESIS_ACCOUNT_KEYPAIR.private_key());
         let tx_limits = state_block.transaction_executor().limits;
         assert!(matches!(

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -383,9 +383,8 @@ mod tests {
             state_block.world.parameters.transaction = limits;
 
             let valid_tx = {
-                let instructions: [InstructionBox; 0] = [];
                 let tx = TransactionBuilder::new(chain_id.clone(), ALICE_ID.clone())
-                    .with_instructions(instructions)
+                    .with_instructions::<InstructionBox>([])
                     .sign(ALICE_KEYPAIR.private_key());
                 AcceptedTransaction::accept(tx, &chain_id, limits)?
             };
@@ -544,9 +543,8 @@ mod tests {
         let state = State::new(world_with_test_domains(), kura.clone(), query_handle);
 
         let mut state_block = state.block();
-        let instructions: [InstructionBox; 0] = [];
         let tx = TransactionBuilder::new(chain_id.clone(), ALICE_ID.clone())
-            .with_instructions(instructions)
+            .with_instructions::<InstructionBox>([])
             .sign(ALICE_KEYPAIR.private_key());
 
         let tx_limits = state_block.transaction_executor().limits;

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -75,20 +75,19 @@ pub enum Signatory {
 pub trait TestGenesis: Sized {
     /// Construct Iroha genesis
     fn test(topology: Vec<PeerId>) -> Self {
-        let instructions: [InstructionBox; 0] = [];
-        Self::test_with_instructions(instructions, topology)
+        Self::test_with_instructions::<InstructionBox>([], topology)
     }
 
     /// Construct genesis with additional instructions
-    fn test_with_instructions(
-        extra_isi: impl IntoIterator<Item = impl Instruction>,
+    fn test_with_instructions<T: Instruction>(
+        extra_isi: impl IntoIterator<Item = T>,
         topology: Vec<PeerId>,
     ) -> Self;
 }
 
 impl TestGenesis for GenesisBlock {
-    fn test_with_instructions(
-        extra_isi: impl IntoIterator<Item = impl Instruction>,
+    fn test_with_instructions<T: Instruction>(
+        extra_isi: impl IntoIterator<Item = T>,
         topology: Vec<PeerId>,
     ) -> Self {
         let cfg = Config::test();

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -18,12 +18,13 @@ use crate::{seal, Level, Registered};
 
 /// Marker trait designating instruction.
 ///
-/// Instructions allows to change the state of `Iroha`.
-/// All possible instructions are implementors of this trait, excluding
-/// [`InstructionBox`] which is just a wrapper.
+/// Instructions allow to change the state of `Iroha`.
+///
+/// If you need to use different instructions together,
+/// consider wrapping them into [`InstructionBox`]es.
 pub trait Instruction: Into<InstructionBox> {}
 
-/// Marker trait for built-in queries
+/// Marker trait for built-in instructions.
 pub trait BuiltInInstruction: Instruction + seal::Sealed {
     /// [`Encode`] [`Self`] as [`InstructionBox`].
     ///
@@ -38,11 +39,10 @@ mod model {
 
     use super::*;
 
-    /// Sized structure for all possible Instructions.
+    /// A sized wrapper for all possible [`Instruction`]s.
     ///
-    /// Note that [`InstructionBox`] is not a self-sufficient instruction,
-    /// but just a wrapper to pass instructions back and forth.
-    /// If you are a client SDK user then you likely don't need to use this type directly.
+    /// You can use this type to combine instructions of different types.
+    /// An [`InstructionBox`] is also an [`Instruction`].
     #[derive(
         DebugCustom,
         Display,

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -659,9 +659,9 @@ mod http {
 
     impl TransactionBuilder {
         /// Set instructions for this transaction
-        pub fn with_instructions(
+        pub fn with_instructions<T: Instruction>(
             mut self,
-            instructions: impl IntoIterator<Item = impl Instruction>,
+            instructions: impl IntoIterator<Item = T>,
         ) -> Self {
             self.payload.instructions = instructions
                 .into_iter()


### PR DESCRIPTION
## Description

Converts `impl Instruction` to an explicit type parameter in functions accepting multiple instructions.

### Benefits

Lets users avoid converting heterogeneous instructions to `InstructionBox`es in a separate variable before submitting to a client, which is more ergonomic.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
