### PR TITLE
feat: include parameters into generated genesis

### DIFF
--- a/configs/swarm/genesis.json
+++ b/configs/swarm/genesis.json
@@ -137,6 +137,69 @@
           ]
         }
       }
+    },
+    {
+      "SetParameter": {
+        "Sumeragi": {
+          "BlockTimeMs": 2000
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "Sumeragi": {
+          "CommitTimeMs": 4000
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "Block": {
+          "MaxTransactions": 512
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "Transaction": {
+          "MaxInstructions": 4096
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "Transaction": {
+          "SmartContractSize": 4194304
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "SmartContract": {
+          "Fuel": 55000000
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "SmartContract": {
+          "Memory": 55000000
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "SmartContract": {
+          "Fuel": 55000000
+        }
+      }
+    },
+    {
+      "SetParameter": {
+        "SmartContract": {
+          "Memory": 55000000
+        }
+      }
     }
   ],
   "topology": []

--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -369,6 +369,24 @@ impl Default for SmartContractParameters {
     }
 }
 
+impl Parameters {
+    /// Convert [`Self`] into iterator of individual parameters
+    pub fn parameters(&self) -> impl Iterator<Item = Parameter> + '_ {
+        self.sumeragi
+            .parameters()
+            .map(Parameter::Sumeragi)
+            .chain(self.block.parameters().map(Parameter::Block))
+            .chain(self.transaction.parameters().map(Parameter::Transaction))
+            .chain(self.executor.parameters().map(Parameter::SmartContract))
+            .chain(
+                self.smart_contract
+                    .parameters()
+                    .map(Parameter::SmartContract),
+            )
+            .chain(self.custom.values().cloned().map(Parameter::Custom))
+    }
+}
+
 impl SumeragiParameters {
     /// Construct [`Self`]
     pub fn new(block_time: Duration, commit_time: Duration) -> Self {
@@ -383,12 +401,26 @@ impl SumeragiParameters {
                 .expect("INTERNAL BUG: Time should fit into u64"),
         }
     }
+
+    /// Convert [`Self`] into iterator of individual parameters
+    pub fn parameters(&self) -> impl Iterator<Item = SumeragiParameter> {
+        [
+            SumeragiParameter::BlockTimeMs(self.block_time_ms),
+            SumeragiParameter::CommitTimeMs(self.commit_time_ms),
+        ]
+        .into_iter()
+    }
 }
 
 impl BlockParameters {
     /// Construct [`Self`]
     pub const fn new(max_transactions: NonZeroU64) -> Self {
         Self { max_transactions }
+    }
+
+    /// Convert [`Self`] into iterator of individual parameters
+    pub fn parameters(&self) -> impl Iterator<Item = BlockParameter> {
+        [BlockParameter::MaxTransactions(self.max_transactions)].into_iter()
     }
 }
 
@@ -399,6 +431,26 @@ impl TransactionParameters {
             max_instructions,
             smart_contract_size,
         }
+    }
+
+    /// Convert [`Self`] into iterator of individual parameters
+    pub fn parameters(&self) -> impl Iterator<Item = TransactionParameter> {
+        [
+            TransactionParameter::MaxInstructions(self.max_instructions),
+            TransactionParameter::SmartContractSize(self.smart_contract_size),
+        ]
+        .into_iter()
+    }
+}
+
+impl SmartContractParameters {
+    /// Convert [`Self`] into iterator of individual parameters
+    pub fn parameters(&self) -> impl Iterator<Item = SmartContractParameter> {
+        [
+            SmartContractParameter::Fuel(self.fuel),
+            SmartContractParameter::Memory(self.memory),
+        ]
+        .into_iter()
     }
 }
 

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -285,6 +285,7 @@ types!(
     Option<HashOf<SignedBlock>>,
     Option<HashOf<SignedTransaction>>,
     Option<IpfsPath>,
+    Option<JsonString>,
     Option<Name>,
     Option<NonZeroU32>,
     Option<NonZeroU64>,

--- a/tools/kagami/src/genesis/generate.rs
+++ b/tools/kagami/src/genesis/generate.rs
@@ -5,7 +5,7 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::WrapErr as _;
-use iroha_data_model::prelude::*;
+use iroha_data_model::{isi::InstructionBox, parameter::Parameters, prelude::*};
 use iroha_executor_data_model::permission::{
     account::{CanRemoveKeyValueInAccount, CanSetKeyValueInAccount},
     parameter::CanSetParameters,
@@ -138,6 +138,12 @@ pub fn generate_default(
     )
     .into();
 
+    let parameters = Parameters::default();
+    let set_parameters = parameters
+        .parameters()
+        .map(SetParameter)
+        .map(InstructionBox::from);
+
     for isi in [
         mint.into(),
         mint_cabbage.into(),
@@ -147,6 +153,7 @@ pub fn generate_default(
     ]
     .into_iter()
     .chain(std::iter::once(register_user_metadata_access))
+    .chain(set_parameters)
     {
         builder = builder.append_instruction(isi);
     }


### PR DESCRIPTION
## Description

Include parameters into default genesis.json.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

While parameters may have default values i still think it's useful to include them into default genesis as an example.
I've got contacted by our QA and they didn't have a way to know how new parameters are expressed in the genesis.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->
<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
