### PR TITLE
fix(tests): correctly list asset definitions in CLI tests

### DIFF
--- a/client_cli/pytests/src/client_cli/client_cli.py
+++ b/client_cli/pytests/src/client_cli/client_cli.py
@@ -166,7 +166,7 @@ class ClientCli:
         self.command.insert(2, "asset")
         if asset_definition and account and value_of_type:
             self.command.append(
-                "--asset-id="
+                "--id="
                 + asset_definition.name
                 + "#"
                 + asset_definition.domain
@@ -198,7 +198,7 @@ class ClientCli:
         self.command.append("transfer")
         self.command.append("--to=" + repr(target_account))
         self.command.append(
-            "--asset-id="
+            "--id="
             + asset.name
             + "#"
             + asset.domain
@@ -226,7 +226,7 @@ class ClientCli:
         self.command.append("asset")
         self.command.append("burn")
         self.command.append(
-            "--asset-id="
+            "--id="
             + asset.name
             + "#"
             + asset.domain
@@ -239,7 +239,7 @@ class ClientCli:
         self.execute()
         return self
 
-    def definition(self, asset: str, domain: str, type_: str):
+    def asset_definition(self, asset: str, domain: str, type_: str):
         """
         Executes the 'definition' command for the given asset, domain, and value type.
 
@@ -252,7 +252,9 @@ class ClientCli:
         :return: The current ClientCli object.
         :rtype: ClientCli
         """
-        self.command.append("--definition-id=" + asset + "#" + domain)
+        self.command.insert(2, "definition")
+        self.command.insert(2, "asset")
+        self.command.append("--id=" + asset + "#" + domain)
         self.command.append("--type=" + type_)
         self.execute()
         return self

--- a/client_cli/pytests/src/client_cli/have.py
+++ b/client_cli/pytests/src/client_cli/have.py
@@ -79,11 +79,10 @@ def asset_definition(expected):
     :param expected: The expected asset definition object.
     :return: True if the asset definition is present, False otherwise.
     """
-    expected_domain = expected.split("#")[1]
 
     def asset_definition_in_asset_definitions() -> bool:
         asset_definitions = iroha.list_filter(
-            f'{{"Identifiable": {{"Is": "{expected_domain}"}}}}'
+            f'{{"Identifiable": {{"Is": "{expected}"}}}}'
         ).asset_definitions()
         return expected_in_actual(expected, asset_definitions)
 

--- a/client_cli/pytests/src/client_cli/iroha.py
+++ b/client_cli/pytests/src/client_cli/iroha.py
@@ -106,16 +106,17 @@ class Iroha(ClientCli):
         :return: Dict of asset definitions ids with there value type.
         :rtype: Dict[str, str]
         """
-        self._execute_command("domain")
+        self.command.insert(2, "definition")
+        self._execute_command("asset")
+
         if self.stdout is not None:
-            domains = json.loads(self.stdout)
+            asset_defs = json.loads(self.stdout)
+
             asset_definitions = {}
-            for domain in domains:
-                asset_defs = domain.get("asset_definitions")
-                for asset_def in asset_defs.values():
-                    type_ = asset_def.get("type_")
-                    if type_:
-                        asset_definitions[asset_def["id"]] = type_
+            for asset_def in asset_defs:
+                type_ = asset_def.get("type_")
+                if type_:
+                    asset_definitions[asset_def["id"]] = type_
             return asset_definitions
         else:
             return {}

--- a/client_cli/pytests/test/assets/test_register_asset_definitions.py
+++ b/client_cli/pytests/test/assets/test_register_asset_definitions.py
@@ -20,7 +20,7 @@ def test_register_asset_definition_with_numeric_type(
         f'with "{GIVEN_numeric_type}" value type'
         f'in the "{GIVEN_registered_domain.name}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=GIVEN_fake_asset_name,
             domain=GIVEN_registered_domain.name,
             type_=GIVEN_numeric_type,
@@ -42,7 +42,7 @@ def test_register_asset_definition_with_store_type(
         f'with "{GIVEN_store_type}" value type'
         f'in the "{GIVEN_registered_domain.name}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=GIVEN_fake_asset_name,
             domain=GIVEN_registered_domain.name,
             type_=GIVEN_store_type,
@@ -64,7 +64,7 @@ def test_register_asset_with_existing_name(
         f'with the same name "{GIVEN_registered_asset_definition_with_numeric_type.name}"'
         f'in the "{GIVEN_registered_asset_definition_with_numeric_type.domain}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=GIVEN_registered_asset_definition_with_numeric_type.name,
             domain=GIVEN_registered_asset_definition_with_numeric_type.domain,
             type_=GIVEN_registered_asset_definition_with_numeric_type.type_,
@@ -82,7 +82,7 @@ def test_register_asset_with_empty_name(GIVEN_registered_domain):
         "WHEN client_cli tries to register an asset definition with an empty name"
         f'in the "{GIVEN_registered_domain.name}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset="", domain=GIVEN_registered_domain.name, type_="Numeric"
         )
     with allure.step(f'THEN сlient_cli should have the asset error: "{Stderr.EMPTY}"'):
@@ -96,7 +96,7 @@ def test_register_asset_with_not_existing_domain(
     with allure.step(
         "WHEN client_cli tries to register an asset definition with not existing domain"
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=GIVEN_fake_asset_name,
             domain=GIVEN_not_existing_name,
             type_=GIVEN_numeric_type,
@@ -112,7 +112,7 @@ def test_register_asset_with_too_long_type(
     with allure.step(
         "WHEN client_cli tries to register an asset definition with too long value type"
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=GIVEN_fake_asset_name,
             domain=GIVEN_registered_domain.name,
             type_="coin",

--- a/client_cli/pytests/test/conftest.py
+++ b/client_cli/pytests/test/conftest.py
@@ -109,7 +109,7 @@ def GIVEN_currently_account_quantity_with_two_quantity_of_asset(
         f'GIVEN the asset_definition "{name}" '
         f'in the "{GIVEN_currently_authorized_account.domain}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=asset.definition.name,
             domain=asset.definition.domain,
             type_=asset.definition.type_,
@@ -140,7 +140,7 @@ def GIVEN_numeric_asset_for_account(
     with allure.step(
         f'GIVEN the asset_definition "{asset_def.name}" ' f'in the "{domain}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=asset.definition.name,
             domain=asset.definition.domain,
             type_=asset.definition.type_,
@@ -168,7 +168,7 @@ def GIVEN_registered_asset_definition_with_numeric_type(
         f'GIVEN the asset_definition "{GIVEN_fake_asset_name}" '
         f'in the "{GIVEN_registered_domain.name}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=asset_def.name,
             domain=asset_def.domain,
             type_=asset_def.type_,
@@ -212,7 +212,7 @@ def GIVEN_registered_asset_definition_with_store_type(
         f'GIVEN the asset_definition "{GIVEN_fake_asset_name}" '
         f'in the "{GIVEN_registered_domain.name}" domain'
     ):
-        client_cli.register().asset().definition(
+        client_cli.register().asset_definition(
             asset=asset_def.name,
             domain=asset_def.domain,
             type=asset_def.type,

--- a/core/benches/validation.rs
+++ b/core/benches/validation.rs
@@ -50,7 +50,7 @@ fn build_test_and_transient_state() -> State {
             let (account_id, _account_keypair) = gen_account_in(&*STARTER_DOMAIN);
             let domain = Domain::new(STARTER_DOMAIN.clone()).build(&account_id);
             let account = Account::new(account_id.clone()).build(&account_id);
-            World::with([domain], [account], UniqueVec::new())
+            World::with([domain], [account], [], UniqueVec::new())
         },
         kura,
         query_handle,

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -503,7 +503,8 @@ pub mod query {
         ) -> Result<Box<dyn Iterator<Item = Asset> + 'state>, Error> {
             let id = self.account.clone();
             iroha_logger::trace!(%id);
-            let _ = state_ro.world().map_account(&id, |_| ())?;
+            state_ro.world().map_account(&id, |_| ())?;
+
             Ok(Box::new(
                 state_ro
                     .world()

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -295,7 +295,7 @@ impl AssetDefinition {
 }
 
 impl AssetId {
-    /// Create a new AssetId
+    /// Create a new [`AssetId`]
     pub fn new(definition: AssetDefinitionId, account: AccountId) -> Self {
         Self {
             account,


### PR DESCRIPTION
## Description

* fix client cli pytests
* rename `--asset-id` to `--id` in client CLI
* add `asset definition` subparameter in CLI

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #{issue_number} <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
