### PR TITLE
fix: Remove kura.lock

### DIFF
--- a/core/benches/kura.rs
+++ b/core/benches/kura.rs
@@ -7,7 +7,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use iroha_config::{base::WithOrigin, parameters::actual::Kura as Config};
 use iroha_core::{
     block::*,
-    kura::{BlockStore, LockStatus},
+    kura::BlockStore,
     prelude::*,
     query::store::LiveQueryStore,
     state::{State, World},
@@ -62,7 +62,7 @@ async fn measure_block_size_for_n_executors(n_executors: u32) {
     for _ in 1..n_executors {
         block.sign(&key_pair, &topology);
     }
-    let mut block_store = BlockStore::new(dir.path(), LockStatus::Unlocked);
+    let mut block_store = BlockStore::new(dir.path());
     block_store.create_files_if_they_do_not_exist().unwrap();
     block_store.append_block_to_chain(&block.into()).unwrap();
 

--- a/tools/kura_inspector/src/main.rs
+++ b/tools/kura_inspector/src/main.rs
@@ -2,7 +2,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
-use iroha_core::kura::{BlockIndex, BlockStore, LockStatus};
+use iroha_core::kura::{BlockIndex, BlockStore};
 use iroha_data_model::block::SignedBlock;
 use iroha_version::scale::DecodeVersioned;
 
@@ -59,7 +59,7 @@ fn print_blockchain(block_store_path: &Path, from_height: u64, block_count: u64)
         }
     }
 
-    let block_store = BlockStore::new(&block_store_path, LockStatus::Unlocked);
+    let block_store = BlockStore::new(&block_store_path);
 
     let index_count = block_store
         .read_index_count()


### PR DESCRIPTION
## Description

Originally `kura.lock` [was introduced](https://github.com/hyperledger/iroha/issues/3027) to prevent multiple iroha instances running with the same data directory. However if iroha doesn't remove `kura.lock`, e.g. in case of non-graceful shutdown, it causes problem that iroha couldn't start after restart. Also usually iroha is deployed using k8s cluster where each peer lives in different container so original problem is not relevant in this case. So it is proposed to remove `kura.lock`.

### Linked issue

Related: #4830
Related: #4848

### Benefits

Remove `kura.lock`, allowing Iroha to restart after non-graceful shutdown

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
