### PR TITLE
fix: Fix `kagami genesis generate synthetic`

### DIFF
--- a/data_model/benches/time_event_filter.rs
+++ b/data_model/benches/time_event_filter.rs
@@ -14,7 +14,7 @@ fn schedule_from_zero_with_little_period(criterion: &mut Criterion) {
 
     let since = Duration::from_secs(TIMESTAMP);
     let length = Duration::from_secs(1);
-    let interval = TimeInterval { since, length };
+    let interval = TimeInterval::new(since, length);
     let event = TimeEvent {
         prev_interval: None,
         interval,

--- a/tools/kagami/src/genesis/generate.rs
+++ b/tools/kagami/src/genesis/generate.rs
@@ -180,11 +180,6 @@ fn generate_synthetic(
         let domain_id: DomainId = format!("domain_{domain}").parse()?;
         genesis.append_instruction(Register::domain(Domain::new(domain_id.clone())));
 
-        for _ in 0..accounts_per_domain {
-            let (account_id, _account_keypair) = gen_account_in(&domain_id);
-            genesis.append_instruction(Register::account(Account::new(account_id.clone())));
-        }
-
         for asset in 0..assets_per_domain {
             let asset_definition_id: AssetDefinitionId =
                 format!("asset_{asset}#{domain_id}").parse()?;
@@ -193,18 +188,19 @@ fn generate_synthetic(
                 AssetType::Numeric(NumericSpec::default()),
             )));
         }
-    }
 
-    for domain in 0..domains {
-        for account in 0..accounts_per_domain {
-            // FIXME: it actually generates (assets_per_domain * accounts_per_domain) assets per domain
+        for _ in 0..accounts_per_domain {
+            let (account_id, _account_keypair) = gen_account_in(&domain_id);
+            genesis.append_instruction(Register::account(Account::new(account_id.clone())));
+
+            // FIXME: Should `assets_per_domain` be renamed to `asset_definitions_per_domain`?
             //        https://github.com/hyperledger/iroha/issues/3508
             for asset in 0..assets_per_domain {
                 let mint = Mint::asset_numeric(
                     13u32,
                     AssetId::new(
                         format!("asset_{asset}#domain_{domain}").parse()?,
-                        format!("account_{account}@domain_{domain}").parse()?,
+                        account_id.clone(),
                     ),
                 );
                 genesis.append_instruction(mint);


### PR DESCRIPTION
## Description

Fix account ids handling in `kagami genesis generate synthetic`

### Linked issue

Closes #4851

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
