### PR TITLE
refactor: preserve voting block during block sync

### DIFF
--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -1143,6 +1143,17 @@ pub trait StateReadOnly {
         NonZeroUsize::new(self.height()).and_then(|height| self.kura().get_block_by_height(height))
     }
 
+    /// Get a reference to the previous to latest block. Returns none if at least 2 blocks are not committed.
+    ///
+    /// If you only need hash of the previous block prefer using [`Self::prev_block_hash`]
+    #[inline]
+    fn prev_block(&self) -> Option<Arc<SignedBlock>> {
+        self.height()
+            .checked_sub(1)
+            .and_then(NonZeroUsize::new)
+            .and_then(|height| self.kura().get_block_by_height(height))
+    }
+
     /// Return the hash of the latest block
     fn latest_block_hash(&self) -> Option<HashOf<SignedBlock>> {
         self.block_hashes().iter().nth_back(0).copied()


### PR DESCRIPTION
## Description

This change allow to preserve voting block during block sync until iroha have to drop it to process transactions.

It is done in two ways: 
1. check block signatures before verification
2. try verify block without discarding voting block

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4834 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Preserve voting block in more cases.

### Downsides

Resulting code is not pretty.
Because it has to handle soft-fork case explicitly and not just revert previous block and proceed.

### How To Test

```
cargo test --package iroha_core --lib -- sumeragi::main_loop::tests::block_sync_commit_err_keep_voting_block --exact --show-output
```

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
