### PR TITLE
fix(schema): rename `type_` to `type` in schema

### DIFF
--- a/client_cli/pytests/src/client_cli/iroha.py
+++ b/client_cli/pytests/src/client_cli/iroha.py
@@ -114,7 +114,7 @@ class Iroha(ClientCli):
 
             asset_definitions = {}
             for asset_def in asset_defs:
-                type_ = asset_def.get("type_")
+                type_ = asset_def.get("type")
                 if type_:
                     asset_definitions[asset_def["id"]] = type_
             return asset_definitions

--- a/configs/swarm/genesis.json
+++ b/configs/swarm/genesis.json
@@ -84,7 +84,7 @@
       "Register": {
         "AssetDefinition": {
           "id": "rose#wonderland",
-          "type_": "Numeric",
+          "type": "Numeric",
           "mintable": "Infinitely",
           "logo": null,
           "metadata": {}
@@ -112,7 +112,7 @@
       "Register": {
         "AssetDefinition": {
           "id": "cabbage#garden_of_live_flowers",
-          "type_": "Numeric",
+          "type": "Numeric",
           "mintable": "Infinitely",
           "logo": null,
           "metadata": {}

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -428,7 +428,7 @@ mod valid {
             if let Err(error) =
                 Self::validate_header(&block, topology, genesis_account, state_block)
             {
-                return WithEvents::new(Err((block, error.into())));
+                return WithEvents::new(Err((block, error)));
             }
 
             if let Err(error) =

--- a/data_model/derive/src/id.rs
+++ b/data_model/derive/src/id.rs
@@ -85,29 +85,29 @@ pub fn impl_id_eq_ord_hash(emitter: &mut Emitter, input: &syn::DeriveInput) -> T
     quote! {
         #identifiable_derive
 
-        impl #impl_generics ::core::cmp::PartialOrd for #name #ty_generics #where_clause where Self: crate::Identifiable {
+        impl #impl_generics ::core::cmp::PartialOrd for #name #ty_generics #where_clause where Self: Identifiable {
             #[inline]
             fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
                 Some(self.cmp(other))
             }
         }
 
-        impl #impl_generics ::core::cmp::Ord for #name #ty_generics #where_clause where Self: crate::Identifiable {
+        impl #impl_generics ::core::cmp::Ord for #name #ty_generics #where_clause where Self: Identifiable {
             fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
-                <Self as crate::Identifiable>::id(self).cmp(<Self as crate::Identifiable>::id(other))
+                <Self as Identifiable>::id(self).cmp(<Self as Identifiable>::id(other))
             }
         }
 
-        impl #impl_generics ::core::cmp::Eq for #name #ty_generics #where_clause where Self: crate::Identifiable  {}
-        impl #impl_generics ::core::cmp::PartialEq for #name #ty_generics #where_clause  where Self: crate::Identifiable {
+        impl #impl_generics ::core::cmp::Eq for #name #ty_generics #where_clause where Self: Identifiable  {}
+        impl #impl_generics ::core::cmp::PartialEq for #name #ty_generics #where_clause  where Self: Identifiable {
             fn eq(&self, other: &Self) -> bool {
-                <Self as crate::Identifiable>::id(self) == <Self as crate::Identifiable>::id(other)
+                <Self as Identifiable>::id(self) == <Self as Identifiable>::id(other)
             }
         }
 
-        impl #impl_generics ::core::hash::Hash for #name #ty_generics #where_clause  where Self: crate::Identifiable {
+        impl #impl_generics ::core::hash::Hash for #name #ty_generics #where_clause  where Self: Identifiable {
             fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
-                <Self as crate::Identifiable>::id(self).hash(state)
+                <Self as Identifiable>::id(self).hash(state)
             }
         }
     }
@@ -119,7 +119,7 @@ fn derive_identifiable(emitter: &mut Emitter, input: &IdDeriveInput) -> TokenStr
     let (id_type, id_expr) = get_id_type(emitter, input);
 
     quote! {
-        impl #impl_generics crate::Identifiable for #name #ty_generics #where_clause {
+        impl #impl_generics Identifiable for #name #ty_generics #where_clause {
             type Id = #id_type;
 
             #[inline]
@@ -142,8 +142,8 @@ fn get_id_type(emitter: &mut Emitter, input: &IdDeriveInput) -> (syn::Type, syn:
             }
             IdAttr::Transparent => {
                 return (
-                    parse_quote! {<#ty as crate::Identifiable>::Id},
-                    parse_quote! {crate::Identifiable::id(&self.#field_name)},
+                    parse_quote! {<#ty as Identifiable>::Id},
+                    parse_quote! {Identifiable::id(&self.#field_name)},
                 );
             }
             IdAttr::Missing => {

--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -12,7 +12,8 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 pub use self::model::*;
 use crate::{
-    domain::prelude::*, metadata::Metadata, HasMetadata, ParseError, PublicKey, Registered,
+    domain::prelude::*, metadata::Metadata, HasMetadata, Identifiable, ParseError, PublicKey,
+    Registered,
 };
 
 #[model]

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -16,8 +16,8 @@ use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 pub use self::model::*;
 use crate::{
-    account::prelude::*, domain::prelude::*, ipfs::IpfsPath, metadata::Metadata, HasMetadata, Name,
-    ParseError, Registered,
+    account::prelude::*, domain::prelude::*, ipfs::IpfsPath, metadata::Metadata, HasMetadata,
+    Identifiable, Name, ParseError, Registered,
 };
 
 /// [`AssetTotalQuantityMap`] provides an API to work with collection of key([`AssetDefinitionId`])-value([`AssetValue`])
@@ -114,6 +114,7 @@ mod model {
         pub id: AssetDefinitionId,
         /// Type of [`AssetValue`]
         #[getset(get_copy = "pub")]
+        #[serde(rename = "type")]
         pub type_: AssetType,
         /// Is the asset mintable
         #[getset(get_copy = "pub")]
@@ -162,6 +163,7 @@ mod model {
         /// The identification associated with the asset definition builder.
         pub id: AssetDefinitionId,
         /// The type value associated with the asset definition builder.
+        #[serde(rename = "type")]
         pub type_: AssetType,
         /// The mintablility associated with the asset definition builder.
         pub mintable: Mintable,

--- a/data_model/src/domain.rs
+++ b/data_model/src/domain.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 pub use self::model::*;
-use crate::{ipfs::IpfsPath, metadata::Metadata, prelude::*, HasMetadata, Name, Registered};
+use crate::{
+    ipfs::IpfsPath, metadata::Metadata, prelude::*, HasMetadata, Identifiable, Name, Registered,
+};
 
 #[model]
 mod model {

--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -10,7 +10,7 @@ use iroha_primitives::json::JsonString;
 use nonzero_ext::nonzero;
 
 pub use self::model::*;
-use crate::name::Name;
+use crate::{name::Name, Identifiable};
 
 /// Collection of [`CustomParameter`]s
 pub(crate) type CustomParameters = btree_map::BTreeMap<CustomParameterId, CustomParameter>;

--- a/data_model/src/peer.rs
+++ b/data_model/src/peer.rs
@@ -13,7 +13,7 @@ use iroha_data_model_derive::model;
 use iroha_primitives::addr::SocketAddr;
 
 pub use self::model::*;
-use crate::{PublicKey, Registered};
+use crate::{Identifiable, PublicKey, Registered};
 
 #[model]
 mod model {

--- a/data_model/src/role.rs
+++ b/data_model/src/role.rs
@@ -8,7 +8,7 @@ use iroha_data_model_derive::model;
 pub use self::model::*;
 use crate::{
     permission::{Permission, Permissions},
-    Name, Registered,
+    Identifiable, Name, Registered,
 };
 
 #[model]

--- a/data_model/src/trigger.rs
+++ b/data_model/src/trigger.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 pub use self::model::*;
-use crate::{events::prelude::*, metadata::Metadata, transaction::Executable, Name, Registered};
+use crate::{
+    events::prelude::*, metadata::Metadata, transaction::Executable, Identifiable, Name, Registered,
+};
 
 #[model]
 mod model {

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -244,7 +244,7 @@
         "type": "AssetDefinitionId"
       },
       {
-        "name": "type_",
+        "name": "type",
         "type": "AssetType"
       },
       {
@@ -2492,7 +2492,7 @@
         "type": "AssetDefinitionId"
       },
       {
-        "name": "type_",
+        "name": "type",
         "type": "AssetType"
       },
       {


### PR DESCRIPTION
## Description

* add support for handling `serde(rename)` attributes with `IntoSchema`
* attach `serde(rename = "type")` to `type_` fields in data model

### Linked issue

Closes #4770

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits



### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
