### PR TITLE
refactor: remove `TriggeringEventFilterBox`

### DIFF
--- a/core/src/smartcontracts/isi/triggers/set.rs
+++ b/core/src/smartcontracts/isi/triggers/set.rs
@@ -612,6 +612,12 @@ impl<'set> SetBlock<'set> {
     }
 }
 
+trait TriggeringEventFilter: EventFilter {}
+impl TriggeringEventFilter for DataEventFilter {}
+impl TriggeringEventFilter for PipelineEventFilterBox {}
+impl TriggeringEventFilter for TimeEventFilter {}
+impl TriggeringEventFilter for ExecuteTriggerEventFilter {}
+
 impl<'block, 'set> SetTransaction<'block, 'set> {
     /// Apply transaction's changes
     pub fn apply(self) {
@@ -704,7 +710,7 @@ impl<'block, 'set> SetTransaction<'block, 'set> {
     /// # Errors
     ///
     /// Return [`Err`] if failed to preload wasm trigger
-    fn add_to<F: storage::Value + EventFilter>(
+    fn add_to<F: TriggeringEventFilter + storage::Value>(
         &mut self,
         engine: &wasmtime::Engine,
         trigger: SpecializedTrigger<F>,

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -1467,10 +1467,6 @@ pub mod error {
         pub enum InvalidParameterError {
             /// Invalid WASM binary: {0}
             Wasm(String),
-            /// Name length violation
-            ///
-            /// i.e. too long [`AccountId`]
-            NameLength,
             /// Attempt to register a time-trigger with `start` point in the past
             TimeTriggerInThePast,
         }

--- a/data_model/src/query/mod.rs
+++ b/data_model/src/query/mod.rs
@@ -32,7 +32,7 @@ use self::{
 use crate::{
     account::{Account, AccountId},
     block::{BlockHeader, SignedBlock},
-    events::TriggeringEventFilterBox,
+    events::EventFilterBox,
     seal,
     transaction::{CommittedTransaction, SignedTransaction, TransactionPayload},
     IdBox, Identifiable, IdentifiableBox,
@@ -1031,7 +1031,7 @@ pub mod trigger {
     use crate::{
         account::AccountId,
         domain::prelude::*,
-        events::TriggeringEventFilterBox,
+        events::EventFilterBox,
         prelude::InstructionBox,
         trigger::{Trigger, TriggerId},
         Executable, Identifiable, Name,

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -167,7 +167,7 @@
       },
       {
         "name": "filter",
-        "type": "TriggeringEventFilterBox"
+        "type": "EventFilterBox"
       },
       {
         "name": "metadata",
@@ -2228,12 +2228,8 @@
         "type": "String"
       },
       {
-        "tag": "NameLength",
-        "discriminant": 1
-      },
-      {
         "tag": "TimeTriggerInThePast",
-        "discriminant": 2
+        "discriminant": 1
       }
     ]
   },
@@ -4337,30 +4333,6 @@
       {
         "name": "by",
         "type": "u32"
-      }
-    ]
-  },
-  "TriggeringEventFilterBox": {
-    "Enum": [
-      {
-        "tag": "Pipeline",
-        "discriminant": 0,
-        "type": "PipelineEventFilterBox"
-      },
-      {
-        "tag": "Data",
-        "discriminant": 1,
-        "type": "DataEventFilter"
-      },
-      {
-        "tag": "Time",
-        "discriminant": 2,
-        "type": "TimeEventFilter"
-      },
-      {
-        "tag": "ExecuteTrigger",
-        "discriminant": 3,
-        "type": "ExecuteTriggerEventFilter"
       }
     ]
   },

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -400,7 +400,6 @@ types!(
     TriggerEventSet,
     TriggerId,
     TriggerNumberOfExecutionsChanged,
-    TriggeringEventFilterBox,
     TypeError,
     Unregister<Account>,
     Unregister<Asset>,


### PR DESCRIPTION
## Description

I love static typing. It prevents many errors.
But there is a tradeoff between static typing and an API that is easy to use.
Sometimes too much static typing is difficult for end users

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4376

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
