### PR TITLE
fix(schema): make `Role` transparent

### DIFF
--- a/data_model/src/account.rs
+++ b/data_model/src/account.rs
@@ -81,8 +81,9 @@ mod model {
     #[derive(
         DebugCustom, Display, Clone, IdEqOrdHash, Decode, Encode, Serialize, Deserialize, IntoSchema,
     )]
-    #[display(fmt = "[{id}]")]
     #[debug(fmt = "[{id:?}] {{ metadata: {metadata} }}")]
+    #[display(fmt = "[{id}]")]
+    #[serde(rename = "Account")]
     #[ffi_type]
     pub struct NewAccount {
         /// Identification

--- a/data_model/src/asset.rs
+++ b/data_model/src/asset.rs
@@ -158,6 +158,7 @@ mod model {
         Debug, Display, Clone, IdEqOrdHash, Decode, Encode, Deserialize, Serialize, IntoSchema,
     )]
     #[display(fmt = "{id} {mintable}{type_}")]
+    #[serde(rename = "AssetDefinition")]
     #[ffi_type]
     pub struct NewAssetDefinition {
         /// The identification associated with the asset definition builder.

--- a/data_model/src/domain.rs
+++ b/data_model/src/domain.rs
@@ -82,6 +82,7 @@ mod model {
     #[derive(
         Debug, Display, Clone, IdEqOrdHash, Decode, Encode, Deserialize, Serialize, IntoSchema,
     )]
+    #[serde(rename = "Domain")]
     #[display(fmt = "[{id}]")]
     #[ffi_type]
     pub struct NewDomain {

--- a/data_model/src/metadata.rs
+++ b/data_model/src/metadata.rs
@@ -4,7 +4,7 @@
 use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
 use core::borrow::Borrow;
 #[cfg(feature = "std")]
-use std::{collections::BTreeMap, vec::Vec};
+use std::collections::BTreeMap;
 
 use iroha_data_model_derive::model;
 use iroha_primitives::json::JsonString;

--- a/data_model/src/role.rs
+++ b/data_model/src/role.rs
@@ -76,10 +76,11 @@ mod model {
         Serialize,
         IntoSchema,
     )]
-    #[getset(get = "pub")]
-    #[serde(transparent)]
-    #[repr(transparent)]
+    #[serde(transparent, rename = "Role")]
     #[ffi_type(unsafe {robust})]
+    #[getset(get = "pub")]
+    #[schema(transparent)]
+    #[repr(transparent)]
     pub struct NewRole {
         #[allow(missing_docs)]
         #[id(transparent)]

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -1962,7 +1962,7 @@
       {
         "tag": "NewRole",
         "discriminant": 3,
-        "type": "NewRole"
+        "type": "Role"
       },
       {
         "tag": "Peer",
@@ -2518,14 +2518,6 @@
       {
         "name": "metadata",
         "type": "Metadata"
-      }
-    ]
-  },
-  "NewRole": {
-    "Struct": [
-      {
-        "name": "inner",
-        "type": "Role"
       }
     ]
   },
@@ -3211,7 +3203,7 @@
     "Struct": [
       {
         "name": "object",
-        "type": "NewRole"
+        "type": "Role"
       }
     ]
   },


### PR DESCRIPTION
## Description

* make `Role` transparent in schema
* rename `NewXXX` to `XXX` when serializing as json

This is how schema looked like:
```json
"NewRole": {
  "Struct": [
    {
      "name": "inner",
      "type": "Role"
    }
  ]
},
```

but in genesis it was:
```json
{
  "Register": {
    "Role": {
      "id": "ALICE_METADATA_ACCESS",
      "permissions": [
        {
          "name": "CanRemoveKeyValueInAccount",
          "payload": {
            "account": "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
          }
        },
        {
          "name": "CanSetKeyValueInAccount",
          "payload": {
            "account": "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
          }
        }
      ]
    }
  }
},
```

which is the consequence of the fact that we have no way of representing transparency in schema

### Linked issue

Related to #1660 

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
