### PR TITLE
ci: conterized testing

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -18,6 +18,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CLIENT_CLI_DIR: "/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/test"
+  DOCKER_COMPOSE_PATH: defaults
+  TEST_DIR: "tmp/test"
+  IROHA_BIN: "iroha"
+  IROHA_CONTAINER: "defaults-irohad0-1"
+  PYTHON_VERSION: "3.11"
+  POETRY_PATH: "/root/.local/bin/poetry"
 
 jobs:
   consistency:
@@ -144,44 +150,68 @@ jobs:
           name: clippy.json
           path: clippy.json
 
-  torii-api-and-client-cli-tests:
+  torii-api-client-cli-tests:
     runs-on: [self-hosted, Linux, iroha2]
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-04-18
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Build binaries
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      - name: Build and Tag Docker Images
+        uses: docker/build-push-action@v6
+        if: always()
+        with:
+          context: .
+          load: true
+          file: Dockerfile
+          tags: |
+            hyperledger/iroha:local
+            hyperledger/iroha:dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Test docker-compose.single.yml
         run: |
-          cargo build -p iroha_client_cli -p kagami -p irohad
-      - name: Setup test Iroha 2 environment on the bare metal
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml down
+      - name: Test docker-compose.local.yml
         run: |
-          pip3 install -r scripts/requirements.txt --no-input --break-system-packages
-          ./scripts/test_env.py setup
-      - name: Mark binaries as executable
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml up --wait || exit 1
+          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml down
+      - name: Run docker-compose.yml containers
+        run: docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml up --wait || exit 1
+      - name: Install Python and Poetry
         run: |
-          chmod +x ${{ env.CLIENT_CLI_DIR }}
-      - name: Install torii api dependencies using Poetry
+          yum install -y python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-devel
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo 'export PATH="${{ env.POETRY_PATH }}:$PATH"' >> /etc/profile
+          source /etc/profile
+      - name: Install Torii API Dependencies
         working-directory: torii/pytests
-        run: |
-          poetry install
-      - name: Run torii api tests
+        run: ${{ env.POETRY_PATH }} install
+      - name: Run Torii API Tests
         working-directory: torii/pytests
+        run: ${{ env.POETRY_PATH }} run pytest
+      - name: Copy Client CLI Binary from Iroha Container
+        if: always()
         run: |
-          poetry run pytest
-      - name: Install client cli dependencies using Poetry
+          mkdir -p ${{ env.TEST_DIR }}
+          docker cp ${{ env.IROHA_CONTAINER }}:/usr/local/bin/${{ env.IROHA_BIN }} ${{ env.TEST_DIR }}
+          cp ./defaults/client.toml ${{ env.TEST_DIR }}
+      - name: Make Binaries Executable
+        run: chmod +x ${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
+      - name: Install Client CLI Dependencies
         working-directory: client_cli/pytests
-        run: |
-          poetry install
-      - name: Run client cli tests
+        run: ${{ env.POETRY_PATH }} install
+      - name: Run Client CLI Tests
         working-directory: client_cli/pytests
         env:
-          # prepared by `test_env.py`
-          CLIENT_CLI_BINARY: ../../test/iroha
-          CLIENT_CLI_CONFIG: ../../test/client.toml
-        run: |
-          poetry run pytest
-      - name: Cleanup test environment
-        run: |
-          ./scripts/test_env.py cleanup
+          CLIENT_CLI_BINARY: ../../${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
+          CLIENT_CLI_CONFIG: ../../${{ env.TEST_DIR }}/client.toml
+        run: ${{ env.POETRY_PATH }} run pytest
+      - name: Wipe docker-compose.yml containers
+        if: always()
+        run: docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -19,31 +19,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-      - name: Build and export to Docker iroha:local and iroha:dev images
-        uses: docker/build-push-action@v6
-        if: always()
-        with:
-          context: .
-          load: true
-          file: Dockerfile
-          tags: |
-            hyperledger/iroha:local
-            hyperledger/iroha:dev
-            docker.soramitsu.co.jp/iroha2/iroha:dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Test docker-compose.single.yml before pushing
-        run: |
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml up --wait || exit 1
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.single.yml down
-      - name: Test docker-compose.local.yml before pushing
-        run: |
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml up --wait || exit 1
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml down
-      - name: Test docker-compose.yml before pushing
-        run: |
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml up --wait || exit 1
-          docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -55,15 +30,18 @@ jobs:
           registry: docker.soramitsu.co.jp
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
-      - name: Push iroha2:dev image
+      - name: Build and push iroha2:dev image
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile
           push: true
           tags: |
             hyperledger/iroha:dev
             docker.soramitsu.co.jp/iroha2/iroha:dev
           labels: commit=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   archive_binaries_and_schema:
     runs-on: ubuntu-latest

--- a/client_cli/pytests/common/json_isi_examples/unregister_asset.json
+++ b/client_cli/pytests/common/json_isi_examples/unregister_asset.json
@@ -1,7 +1,7 @@
 [{
 "Unregister": {
     "Asset": {
-        "object": "rose#ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
+        "object": "rose##ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
     }
 }
 }]

--- a/client_cli/pytests/src/client_cli/client_cli.py
+++ b/client_cli/pytests/src/client_cli/client_cli.py
@@ -302,7 +302,8 @@ class ClientCli:
         :type temp_file_path: str
         """
         self._execute_pipe(
-            ["cat", temp_file_path], [self.BASE_PATH] + self.BASE_FLAGS + ["json"]
+            ["cat", temp_file_path],
+            [self.BASE_PATH] + self.BASE_FLAGS + ["json"] + ["transaction"],
         )
 
     def register_trigger(self, account):


### PR DESCRIPTION
## Description

This PR implements the ability to run Docker Compose tests within the context of pull requests (PR) instead of after merging. 

We have also developed a CI process that executes Torii API and Client CLI tests on real containers rather than on bare metal. This has reduced the job execution time by 30% thanks to the optimization of the testing process using Torii API and Client CLI tests.

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4925 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

Docker Compose tests are now run within the context of PRs, allowing us to identify and fix errors before merging.
Optimization of the testing process using real containers has reduced job execution time by 30%, speeding up the CI process.

### Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I've used the standard signed-off commit format (or will squash just before merging)
- [x] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
