### PR TITLE
fix(sumeragi): remove expired transaction from cache

### DIFF
--- a/core/src/gossiper.rs
+++ b/core/src/gossiper.rs
@@ -119,16 +119,16 @@ impl TransactionGossiper {
                         tx,
                         err: crate::queue::Error::InBlockchain,
                     }) => {
-                        iroha_logger::debug!(tx_payload_hash = %tx.as_ref().hash(), "Transaction already in blockchain, ignoring...")
+                        iroha_logger::debug!(tx = %tx.as_ref().hash(), "Transaction already in blockchain, ignoring...")
                     }
                     Err(crate::queue::Failure {
                         tx,
                         err: crate::queue::Error::IsInQueue,
                     }) => {
-                        iroha_logger::trace!(tx_payload_hash = %tx.as_ref().hash(), "Transaction already in the queue, ignoring...")
+                        iroha_logger::trace!(tx = %tx.as_ref().hash(), "Transaction already in the queue, ignoring...")
                     }
                     Err(crate::queue::Failure { tx, err }) => {
-                        iroha_logger::error!(?err, tx_payload_hash = %tx.as_ref().hash(), "Failed to enqueue transaction.")
+                        iroha_logger::error!(?err, tx = %tx.as_ref().hash(), "Failed to enqueue transaction.")
                     }
                 },
                 Err(err) => iroha_logger::error!(%err, "Transaction rejected"),

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -177,7 +177,7 @@ impl Queue {
     /// # Errors
     /// See [`enum@Error`]
     pub fn push(&self, tx: AcceptedTransaction, state_view: &StateView) -> Result<(), Failure> {
-        trace!(?tx, "Pushing to the queue");
+        trace!(tx=%tx.as_ref().hash(), "Pushing to the queue");
         if let Err(err) = self.check_tx(&tx, state_view) {
             return Err(Failure { tx, err });
         }

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -1024,7 +1024,7 @@ pub(crate) fn run(
             .retain(|tx| {
                 let expired = sumeragi.queue.is_expired(tx);
                 if expired {
-                    debug!(?tx, "Transaction expired")
+                    debug!(tx=%tx.as_ref().hash(), "Transaction expired")
                 }
                 !expired
             });

--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -1026,7 +1026,7 @@ pub(crate) fn run(
                 if expired {
                     debug!(?tx, "Transaction expired")
                 }
-                expired
+                !expired
             });
 
         sumeragi.queue.get_transactions_for_block(

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -229,7 +229,7 @@ impl TransactionExecutor {
             ));
         }
 
-        debug!("Validating transaction: {:?}", tx);
+        debug!(tx=%tx.as_ref().hash(), "Validating transaction");
         Self::validate_with_runtime_executor(tx.clone(), state_transaction)?;
 
         if let (authority, Executable::Wasm(bytes)) = tx.into() {


### PR DESCRIPTION
## Description

- fix a bug in retain that actually non expired transactions were removed
- qol improvment to print transactions by hash in the logs
    - i find it really hard to debug iroha on TRACE level in presence of heavy transactions because all logs are polluted by tx printing 

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

- fewer bugs
- more clear logs

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
