### PR TITLE
fix(p2p): prevent deadlock on simultaneous sending large message

### DIFF
--- a/p2p/src/network.rs
+++ b/p2p/src/network.rs
@@ -299,10 +299,11 @@ impl<T: Pload, K: Kex, E: Enc> NetworkBase<T, K, E> {
         let self_public_key_hash = blake2b_hash(self.key_pair.public_key().encode());
         let topology = topology
             .into_iter()
+            .filter(|peer_id| peer_id.public_key() != self.key_pair.public_key())
             .map(|peer_id| {
                 // Determine who is responsible for connecting
                 let peer_public_key_hash = blake2b_hash(peer_id.public_key().encode());
-                let is_active = self_public_key_hash > peer_public_key_hash;
+                let is_active = self_public_key_hash >= peer_public_key_hash;
                 (peer_id, is_active)
             })
             .collect();


### PR DESCRIPTION
## Description

When 2 peers try to send each other huge messages they end up deadlocked.
I suspect that this happen when message is large enough that it's not possible to fully put it in the OS buffer.

Here is minimal [example](https://github.com/Erigara/tcp_deadlock) i was able to came up with which suffers from the same issue.

Solution was to lift sending data up to the `select!` statement so peer can either read or write data simultaneously. 

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

No deadlock.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
