### PR TITLE
refactor(view_change): only send current and previous view change proof

### DIFF
--- a/core/src/sumeragi/message.rs
+++ b/core/src/sumeragi/message.rs
@@ -26,13 +26,13 @@ pub enum BlockMessage {
 pub struct ControlFlowMessage {
     /// Proof of view change. As part of this message handling, all
     /// peers which agree with view change should sign it.
-    pub view_change_proofs: view_change::ProofChain,
+    pub view_change_proof: view_change::SignedViewChangeProof,
 }
 
 impl ControlFlowMessage {
     /// Helper function to construct a `ControlFlowMessage`
-    pub fn new(view_change_proofs: view_change::ProofChain) -> ControlFlowMessage {
-        ControlFlowMessage { view_change_proofs }
+    pub fn new(view_change_proof: view_change::SignedViewChangeProof) -> ControlFlowMessage {
+        ControlFlowMessage { view_change_proof }
     }
 }
 


### PR DESCRIPTION
## Description

Instead of sending every view change proof only view change proof for current round and previous verified proof are sent.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4926 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

This help peer which is lagging behind to directly jump to most recent view change and participate in consensus.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->

<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
