### PR TITLE
perf: Fix cloning of executor

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ eyre = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"] }
 crossbeam-queue = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ eyre = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time", "rt", "io-util", "rt-multi-thread", "macros", "fs"] }
 crossbeam-queue = { workspace = true }

--- a/core/src/executor.rs
+++ b/core/src/executor.rs
@@ -1,5 +1,7 @@
 //! Structures and impls related to *runtime* `Executor`s processing.
 
+use std::sync::Arc;
+
 use derive_more::DebugCustom;
 use iroha_data_model::{
     account::AccountId,
@@ -278,7 +280,9 @@ impl Executor {
 pub struct LoadedExecutor {
     #[serde(skip)]
     module: wasmtime::Module,
-    raw_executor: data_model_executor::Executor,
+    /// Arc is needed so cloning of executor will be fast.
+    /// See [`crate::tx::TransactionExecutor::validate_with_runtime_executor`].
+    raw_executor: Arc<data_model_executor::Executor>,
 }
 
 impl LoadedExecutor {
@@ -288,7 +292,7 @@ impl LoadedExecutor {
     ) -> Result<Self, wasm::error::Error> {
         Ok(Self {
             module: wasm::load_module(engine, &raw_executor.wasm)?,
-            raw_executor,
+            raw_executor: Arc::new(raw_executor),
         })
     }
 }

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -408,7 +408,7 @@ pub mod isi {
             // Also it's a cheap operation.
             let mut upgraded_executor = state_transaction.world.executor.clone();
             upgraded_executor
-                .migrate(raw_executor, state_transaction, authority)
+                .migrate(&raw_executor, state_transaction, authority)
                 .map_err(|migration_error| {
                     InvalidParameterError::Wasm(format!(
                         "{:?}",

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -14,12 +14,14 @@ use iroha_data_model::{
     prelude::*,
     query::{parameters::QueryId, AnyQueryBox, QueryOutput, QueryRequest, QueryResponse},
     smart_contract::payloads::{self, Validate},
+    transaction::base64_util::Base64Wrapper,
     Level as LogLevel, ValidationFail,
 };
 use iroha_logger::debug;
 // NOTE: Using error_span so that span info is logged on every event
 use iroha_logger::{error_span as wasm_log_span, prelude::tracing::Span};
 use iroha_wasm_codec::{self as codec, WasmUsize};
+use serde::Serialize;
 use wasmtime::{
     Caller, Config as WasmtimeConfig, Engine, Linker, Module, Store, StoreLimits,
     StoreLimitsBuilder, TypedFunc,
@@ -127,6 +129,8 @@ pub mod error {
         Finalization(#[source] crate::query::store::Error),
         /// Failed to load module
         ModuleLoading(#[source] WasmtimeError),
+        /// Failed to deserialize module
+        ModuleDeserialization(#[source] WasmtimeError),
         /// Module could not be instantiated
         Instantiation(#[from] InstantiationError),
         /// Export error
@@ -249,6 +253,21 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 // TODO: Probably we can do some checks here such as searching for entrypoint function
 pub fn load_module(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<wasmtime::Module> {
     Module::new(engine, bytes).map_err(Error::ModuleLoading)
+}
+
+pub(crate) fn serialize_module_base64<S>(module: &Module, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let bytes = module.serialize().map_err(serde::ser::Error::custom)?;
+    let wrapper = Base64Wrapper(bytes);
+    wrapper.serialize(serializer)
+}
+
+/// Deserialize [`Module`]. Accepts only output of [`Module::serialize`].
+#[allow(unsafe_code)]
+pub(crate) fn deserialize_module(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
+    unsafe { Module::deserialize(engine, bytes).map_err(Error::ModuleDeserialization) }
 }
 
 /// Create [`Engine`] with a predefined configuration.

--- a/core/src/smartcontracts/wasm.rs
+++ b/core/src/smartcontracts/wasm.rs
@@ -267,6 +267,8 @@ where
 /// Deserialize [`Module`]. Accepts only output of [`Module::serialize`].
 #[allow(unsafe_code)]
 pub(crate) fn deserialize_module(engine: &Engine, bytes: impl AsRef<[u8]>) -> Result<Module> {
+    // SAFETY: `Module::deserialize` is safe when calling for bytes received from `Module::serialize`.
+    // We store serialization result on disk and then load it back so should be ok.
     unsafe { Module::deserialize(engine, bytes).map_err(Error::ModuleDeserialization) }
 }
 

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -423,6 +423,17 @@ mod base64 {
     }
 }
 
+/// Internal module for use in `iroha_core`
+#[cfg(feature = "transparent_api")]
+pub mod base64_util {
+    use serde::{Deserialize, Serialize};
+
+    /// Wrapper for `Vec<u8>` which can be serialized and deserialized as base64
+    #[derive(Deserialize, Serialize)]
+    #[serde(transparent)]
+    pub struct Base64Wrapper(#[serde(with = "super::base64")] pub Vec<u8>);
+}
+
 pub mod error {
     //! Module containing errors that can occur in transaction lifecycle
     pub use self::model::*;


### PR DESCRIPTION
## Description

I am debugging tps of a single peer (#4727), measured performance of `Sumeragi::try_create_block`, and noticed that executor cloning takes about 25% of `try_create_block`. This is because of `LoadedExecutor::raw_executor` which was added for snapshot creation. Could be fixed by adding `Arc`.

It is also interesting that other wasm-related code takes a lot of time, e.g. `wasmtime::Linker::instantitate` and `wasmtime::Store::into_data`.

![image](https://github.com/user-attachments/assets/82792bd6-ffed-45d8-a298-3364ff36e7a3)

### Linked issue

Related: #4727

### Benefits

Slightly optimize block creation performance

### Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I've used the standard signed-off commit format (or will squash just before merging)
- [ ] All applicable CI checks pass (or I promised to make them pass later)
- [ ] (optional) I've written unit tests for the code changes
- [ ] I replied to all comments after code review, marking all implemented changes with thumbs up
