### PR TITLE
feat(sumeragi): dynamic commit time based on view change index

### DIFF
--- a/crates/iroha/tests/integration/triggers/time_trigger.rs
+++ b/crates/iroha/tests/integration/triggers/time_trigger.rs
@@ -18,7 +18,7 @@ use iroha_test_samples::{gen_account_in, load_sample_wasm, ALICE_ID};
 pub fn pipeline_time() -> Duration {
     let default_parameters = SumeragiParameters::default();
 
-    default_parameters.pipeline_time()
+    default_parameters.pipeline_time(0, 0)
 }
 
 fn curr_time() -> core::time::Duration {

--- a/crates/iroha_core/src/sumeragi/mod.rs
+++ b/crates/iroha_core/src/sumeragi/mod.rs
@@ -44,6 +44,7 @@ pub struct SumeragiHandle {
 impl SumeragiHandle {
     /// Deposit a sumeragi control flow network message.
     pub fn incoming_control_flow_message(&self, msg: ControlFlowMessage) {
+        trace!(ty = "ViewChangeProofChain", "Incoming message");
         if let Err(error) = self.control_message_sender.try_send(msg) {
             self.dropped_messages_metric.inc();
 
@@ -58,7 +59,19 @@ impl SumeragiHandle {
 
     /// Deposit a sumeragi network message.
     pub fn incoming_block_message(&self, msg: impl Into<BlockMessage>) {
-        if let Err(error) = self.message_sender.try_send(msg.into()) {
+        let msg = msg.into();
+        let (ty, block) = match &msg {
+            BlockMessage::BlockCommitted(BlockCommitted { hash, .. }) => ("BlockCommitted", *hash),
+            BlockMessage::BlockCreated(BlockCreated { block }) => ("BlockCreated", block.hash()),
+            BlockMessage::BlockSigned(BlockSigned { hash, .. }) => ("BlockSigned", *hash),
+            BlockMessage::BlockSyncUpdate(BlockSyncUpdate { block }) => {
+                trace!(ty="BlockSyncUpdate", block=%block.hash(), "Incoming message");
+                ("BlockSyncUpdate", block.hash())
+            }
+        };
+        trace!(ty, %block, "Incoming message");
+
+        if let Err(error) = self.message_sender.try_send(msg) {
             self.dropped_messages_metric.inc();
 
             error!(

--- a/crates/iroha_data_model/src/parameter.rs
+++ b/crates/iroha_data_model/src/parameter.rs
@@ -347,8 +347,15 @@ impl SumeragiParameters {
 
     /// Maximal amount of time it takes to commit a block
     #[cfg(feature = "transparent_api")]
-    pub fn pipeline_time(&self) -> Duration {
-        self.block_time() + self.commit_time()
+    pub fn pipeline_time(&self, view_change_index: usize, shift: usize) -> Duration {
+        let shifted_view_change_index = view_change_index.saturating_sub(shift);
+        self.block_time().saturating_add(
+            self.commit_time().saturating_mul(
+                (shifted_view_change_index + 1)
+                    .try_into()
+                    .unwrap_or(u32::MAX),
+            ),
+        )
     }
 }
 


### PR DESCRIPTION
## Description

- Commit time is now linear function of view change index (capped at Duration::MAX)
- Add more logs to track messages arriving to sumeragi

Note: #4929 would also nice to have because it prevents degradation of view change updates.

<!-- Just describe what you did. -->

<!-- Skip if the title of the PR is self-explanatory -->

### Linked issue

<!-- Duplicate the main issue and add additional issues closed by this PR. -->

Closes #4265 <!-- Replace with an actual number,  -->

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

This allow to consensus to pass heavy transactions which cause infinite loop previously.

### How to test?

Currently it's not possible to modulary test consensus :(

So i've did my tests on bare metal iroha with 4 nodes.

Parameters:

config.toml:
```toml
[network]
transaction_gossip_period_ms = 10_000

[transaction]
time_to_live_ms = 3_600_000
```

genesis.json:
```json
    {
      "Sumeragi": {
        "BlockTimeMs": 100
      }
    },
    {
      "Sumeragi": {
        "CommitTimeMs": 100
      }
    }
```

Notice that `transaction_gossip_period_ms` was crucial here, because without it i faced #4952.  

Check this [comment](https://github.com/hyperledger/iroha/issues/4952#issuecomment-2275820415) for the transaction i've submitted to iroha.

<!-- EXAMPLE: users can't revoke their own right to revoke rights -->
<!-- HINT:  Add more points to checklist for large draft PRs-->

<!-- USEFUL LINKS 
 - https://www.secondstate.io/articles/dco
 - https://discord.gg/hyperledger (please ask us any questions)
 - https://t.me/hyperledgeriroha (if you prefer telegram)
-->
