### PR TITLE
feat(test-env): Preserve test env logs on crash

### DIFF
--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -150,8 +150,8 @@ class _Peer:
         logging.info(f"Running peer {self.name}...")
 
         # FD never gets closed
-        stdout_file = open(self.peer_dir / ".stdout", "w")
-        stderr_file = open(self.peer_dir / ".stderr", "w")
+        stdout_file = open(self.peer_dir / "log.stdout", "w")
+        stderr_file = open(self.peer_dir / "log.stderr", "w")
         # These processes are created detached from the parent process already
         subprocess.Popen([self.name, "--config", self.config_path],
                     executable=self.out_dir / "peers/irohad", stdout=stdout_file, stderr=stderr_file)

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -150,11 +150,10 @@ class _Peer:
         logging.info(f"Running peer {self.name}...")
 
         # FD never gets closed
-        stdout_file = open(self.peer_dir / "log.stdout", "w")
-        stderr_file = open(self.peer_dir / "log.stderr", "w")
+        log_file = open(self.peer_dir / "log.txt", "w")
         # These processes are created detached from the parent process already
         subprocess.Popen([self.name, "--config", self.config_path],
-                    executable=self.out_dir / "peers/irohad", stdout=stdout_file, stderr=stderr_file)
+                    executable=self.out_dir / "peers/irohad", stdout=log_file, stderr=log_file)
 
 def pos_int(arg):
     if int(arg) > 0:

--- a/scripts/test_env.py
+++ b/scripts/test_env.py
@@ -77,7 +77,9 @@ class Network:
                 logging.info(f"Error connecting to genesis peer: {e}. Sleeping 1 second...")
                 time.sleep(1)
         logging.critical(f"Genesis block wasn't created within {n_tries} seconds. Aborting...")
-        cleanup(self.out_dir)
+        cleanup(self.out_dir, True)
+        logging.critical(f"Test environment directory `{self.out_dir}` was left intact. "
+                         f"Inspect it or use `cleanup` subcommand to remove it.")
         sys.exit(2)
 
     def run(self):
@@ -241,7 +243,7 @@ def main(args: argparse.Namespace):
     if args.command == "setup":
         setup(args)
     elif args.command == "cleanup":
-        cleanup(args.out_dir)
+        cleanup(args.out_dir, False)
 
 def setup(args: argparse.Namespace):
     logging.info(f"Starting Iroha network with {args.n_peers} peers...")
@@ -254,11 +256,14 @@ def setup(args: argparse.Namespace):
 
     Network(args).run()
 
-def cleanup(out_dir: pathlib.Path):
+def cleanup(out_dir: pathlib.Path, keep_out_dir: bool):
     logging.info("Killing peer processes...")
     subprocess.run(["pkill", "-9", "iroha"])
-    logging.info(f"Cleaning up test directory `{out_dir}`...")
-    shutil.rmtree(out_dir)
+    if keep_out_dir:
+        logging.info(f"Leaving test directory `{out_dir}` as-is...")
+    else:
+        logging.info(f"Cleaning up test directory `{out_dir}`...")
+        shutil.rmtree(out_dir)
 
 
 


### PR DESCRIPTION
## Description

1. Kill iroha but keep logs if waiting for genesis fails
2. Rename log files to make them not hidden by UNIX conventions

### Linked issue

Closes #4814 

<!-- Link if e.g. JIRA issue or  from another repository -->

### Benefits

1. Allows you to debug problems that lead to genesis not being committed
2. Log files not being hidden reduces surprises (I had to look into code two times already to find them)

### Checklist

- [ ] make CI pass