### PR TITLE
fix(torii): display more error details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,6 +3530,7 @@ dependencies = [
  "error-stack",
  "eyre",
  "futures",
+ "http-body-util",
  "iroha_config",
  "iroha_core",
  "iroha_data_model",
@@ -3545,6 +3546,7 @@ dependencies = [
  "nonzero_ext",
  "parity-scale-codec",
  "pprof",
+ "pretty-error-debug",
  "serde",
  "serde_json",
  "thiserror",
@@ -4588,6 +4590,25 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty-error-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8f3888f1de6a9d977610972eab0014b663a3907ec153d77200252ad22e4bb0"
+dependencies = [
+ "pretty-error-debug-derive",
+]
+
+[[package]]
+name = "pretty-error-debug-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788992637e9c73f809f7bdc647572785efb06cb7c860105a4e55e9c7d6935d39"
+dependencies = [
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -56,7 +56,7 @@ pub enum AcceptTransactionFail {
     SignatureVerification(#[source] SignatureVerificationFail),
     /// The genesis account can only sign transactions in the genesis block
     UnexpectedGenesisAccountSignature,
-    /// Chain id doesn't correspond to the id of current blockchain
+    /// Chain id doesn't correspond to the id of current blockchain: {0}
     ChainIdMismatch(Mismatch<ChainId>),
 }
 

--- a/torii/Cargo.toml
+++ b/torii/Cargo.toml
@@ -54,3 +54,7 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 # TODO: switch to original crate once fix is merged (https://github.com/tikv/pprof-rs/pull/241)
 pprof = { git = " https://github.com/Erigara/pprof-rs", branch = "fix_pointer_align", optional = true, default-features = false, features = ["protobuf-codec", "frame-pointer", "cpp"] }
 nonzero_ext = { workspace = true }
+pretty-error-debug = "0.3.0"
+
+[dev-dependencies]
+http-body-util = "0.1.2"


### PR DESCRIPTION
## Description

While submitting an invalid transaction to Iroha, I got a response `400 Bad Request` with message 

```
Failed to accept transaction
``` 

That was not very helpful. This PR extends this message:

```
Failed to accept transaction

Caused by:
    Chain id doesn't correspond to the id of current blockchain: Expected ChainId("00000000-0000-0000-0000-000000000000"), actual ChainId("0")
```

Iroha has detailed errors internally, but their formatting doesn't work properly.

**This PR does not aim to fix the issue entirely**, but only highlights & fixes a special case of it. Will create a separate general issue for it.

### Linked issue

None

### Benefits

Better error messages at least on the highest level of Torii.
