### PR TITLE
fix: add missing mathematical operations to `Numeric`

### DIFF
--- a/primitives/numeric/src/lib.rs
+++ b/primitives/numeric/src/lib.rs
@@ -175,24 +175,39 @@ impl Numeric {
         self.inner.scale()
     }
 
-    /// Checked addition
-    ///
-    /// # Errors
-    /// In case of overflow
+    /// Checked addition. Computes `self + other`, returning `None` if overflow occurred
     pub fn checked_add(self, other: Self) -> Option<Self> {
         self.inner
             .checked_add(other.inner)
             .map(|inner| Self { inner })
     }
 
-    /// Checked subtraction
-    ///
-    /// # Errors
-    /// In case of overflow
+    /// Checked subtraction. Computes `self - other`, returning `None` if overflow occurred
     pub fn checked_sub(self, other: Self) -> Option<Self> {
         self.inner
             .checked_sub(other.inner)
             .and_then(|inner| inner.is_sign_positive().then_some(Self { inner }))
+    }
+
+    /// Checked multiplication. Computes `self * other`, returning `None` if overflow occurred
+    pub fn checked_mul(self, other: Self) -> Option<Self> {
+        self.inner
+            .checked_mul(other.inner)
+            .map(|inner| Self { inner })
+    }
+
+    /// Checked division. Computes `self / other`, returning `None` if overflow occurred.
+    pub fn checked_div(self, other: Self) -> Option<Self> {
+        self.inner
+            .checked_div(other.inner)
+            .map(|inner| Self { inner })
+    }
+
+    /// Checked remainder. Computes `self % other`, returning `None` if overflow occurred.
+    pub fn checked_rem(self, other: Self) -> Option<Self> {
+        self.inner
+            .checked_rem(other.inner)
+            .map(|inner| Self { inner })
     }
 
     /// Convert [`Numeric`] to [`f64`] with possible loss in precision
@@ -215,6 +230,14 @@ impl From<u32> for Numeric {
 impl From<u64> for Numeric {
     fn from(value: u64) -> Self {
         Self::new(value.into(), 0)
+    }
+}
+
+impl TryFrom<f64> for Numeric {
+    type Error = TryFromNumericError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        value.try_into().map_err(|_| TryFromNumericError)
     }
 }
 


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

`Numeric` is missing some mathematical operations and it's not possible to use it 

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] (optional) I've written unit tests for the code changes.
- [x] All review comments have been resolved.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->