### PR TITLE
fix: Fix bug in test harness for unstable network

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -126,7 +126,7 @@ jobs:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
       - name: Run tests
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha extra_functional
+        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha extra_functional -- --test-threads=1
 
   # Run the job to check that the docker containers are properly buildable
   pr-generator-build:

--- a/client/tests/integration/extra_functional/connected_peers.rs
+++ b/client/tests/integration/extra_functional/connected_peers.rs
@@ -57,7 +57,7 @@ fn register_new_peer() -> Result<()> {
         .1
         .submit_blocking(register_peer)?;
     peer_clients.push((&new_peer, Client::test(&new_peer.api_address)));
-    thread::sleep(pipeline_time * 2); // Wait for some time to allow peers to connect
+    thread::sleep(pipeline_time * 2 * 20); // Wait for some time to allow peers to connect
 
     check_status(&peer_clients, 2);
 

--- a/client/tests/integration/extra_functional/unstable_network.rs
+++ b/client/tests/integration/extra_functional/unstable_network.rs
@@ -82,11 +82,7 @@ fn unstable_network(
     let mut account_has_quantity = Numeric::ZERO;
 
     let mut rng = rand::thread_rng();
-    let freezers = {
-        let mut freezers = network.get_freeze_status_handles();
-        freezers.remove(0); // remove genesis peer
-        freezers
-    };
+    let freezers = network.get_freeze_status_handles();
 
     //When
     for _i in 0..n_transactions {


### PR DESCRIPTION
### Solution

The bug was that the node selection for the client was random. This meant that the node the client was using to observe the tests were being frozen. I fixed it so that the client always is connected to the genesis peer which never gets frozen.
