### PR TITLE
ci: Unify CI to build profiling and glibc iroha image

### DIFF
--- a/.github/workflows/iroha2-profiling-image.yml
+++ b/.github/workflows/iroha2-profiling-image.yml
@@ -4,6 +4,24 @@ on:
   push:
     tags:
       - 'v2*'
+  workflow_dispatch:
+    inputs:
+      BUILD_GLIBC_IMAGE:
+        description: "Select \"true\" to build and push the standard \"glibc\" image"
+        type: choice
+        required: true
+        default: 'false'
+        options:
+          - true
+          - false
+      CHECKOUT_REF:
+        description: "The branch, tag or SHA to checkout"
+        required: true
+        default: main
+      PROFILER_NAME:
+        description: "Profiler value as the image tag part"
+        required: true
+        default: glibc
 
 env:
   IROHA2_DOCKERFILE: Dockerfile.glibc
@@ -13,7 +31,8 @@ env:
   IROHA2_CARGOFLAGS: -Z build-std
 
 jobs:
-  registry:
+  registry-profiling-image:
+    if: ${{ inputs.BUILD_GLIBC_IMAGE == 'false' }}
     runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-04-18
@@ -56,5 +75,35 @@ jobs:
             "FEATURES=${{ env.IROHA2_FEATURES }}"
             "CARGOFLAGS=${{ env.IROHA2_CARGOFLAGS }}"
           file: ${{env.IROHA2_DOCKERFILE }}
-          # This context specification is required
+          context: .
+
+  registry-glibc-image:
+    if: ${{ inputs.BUILD_GLIBC_IMAGE == 'true' }}
+    runs-on: [self-hosted, Linux, iroha2]
+    container:
+      image: hyperledger/iroha2-ci:nightly-2024-04-18
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.CHECKOUT_REF }}
+      - name: Login to Soramitsu Harbor
+        uses: docker/login-action@v3
+        with:
+          registry: docker.soramitsu.co.jp
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+      - name: Set up Docker Buildx
+        id: buildx
+        if: always()
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+      - name: Build and push iroha2-profiling image
+        uses: docker/build-push-action@v6
+        if: always()
+        with:
+          push: true
+          tags: docker.soramitsu.co.jp/iroha2/iroha:${{ inputs.PROFILER_NAME }}-${{ github.sha }}
+          labels: commit=${{ github.sha }}
+          file: ${{env.IROHA2_DOCKERFILE }}
           context: .


### PR DESCRIPTION

## Context
Sometimes we need to build iroha2 `glibc` image without `profiling` features for longevity testing. Currently we do it manually and locally only.

### Solution

- Modify `I2::Profiling::Publish` workflow to build either `profiling` image (by new git tag publishing) or vanilla `glibc` image by `workflow_dispatch` event.
- Consider to chose the needed git SHA to build `glibc` image when is required.


### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
