### PR TITLE
fix(torii): use `GET` for blocks stream

### DIFF
--- a/torii/src/lib.rs
+++ b/torii/src/lib.rs
@@ -220,7 +220,7 @@ impl Torii {
             )
             .route(
                 uri::BLOCKS_STREAM,
-                post({
+                get({
                     let kura = self.kura.clone();
                     move |ws: WebSocketUpgrade| {
                         core::future::ready(ws.on_upgrade(|ws| async move {


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

Blocks stream endpoint doesn't work with standard WebSocket clients because it uses `POST`. The standard says it should be `GET`: https://stackoverflow.com/questions/50386211/should-websocket-server-only-handle-get-requests

### Solution

Use `GET` for blocks stream route.

Events stream already uses `GET` (discrepancy btw).

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->