### PR TITLE
fix(data-model,crypto,primitives)!: misc chores

### DIFF
--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -40,6 +40,7 @@ ffi::ffi_item! {
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, getset::Getters)]
     #[cfg_attr(not(feature="ffi_import"), derive(derive_more::DebugCustom, Hash, Decode, Encode, Deserialize, Serialize, IntoSchema))]
     #[cfg_attr(not(feature="ffi_import"), debug(fmt = "{{ {} }}", "hex::encode_upper(payload)"))]
+    #[serde(transparent)]
     pub struct Signature {
         #[serde_as(as = "serde_with::hex::Hex<serde_with::formats::Uppercase>")]
         payload: ConstVec<u8>
@@ -283,9 +284,7 @@ mod tests {
 
     #[test]
     fn signature_serialized_representation() {
-        let input = json!({
-            "payload": "3A7991AF1ABB77F3FD27CC148404A6AE4439D095A63591B77C788D53F708A02A1509A611AD6D97B01D871E58ED00C8FD7C3917B6CA61A8C2833A19E000AAC2E4"
-        });
+        let input = json!("3A7991AF1ABB77F3FD27CC148404A6AE4439D095A63591B77C788D53F708A02A1509A611AD6D97B01D871E58ED00C8FD7C3917B6CA61A8C2833A19E000AAC2E4");
 
         let signature: Signature = serde_json::from_value(input.clone()).unwrap();
 

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -9,7 +9,7 @@ use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 use core::{fmt::Display, time::Duration};
 
 use derive_more::Display;
-use iroha_crypto::{HashOf, MerkleTree, PrivateKey, SignatureOf};
+use iroha_crypto::{HashOf, MerkleTree, PrivateKey, Signature, SignatureOf};
 use iroha_data_model_derive::model;
 use iroha_macro::FromVariant;
 use iroha_schema::IntoSchema;
@@ -302,6 +302,18 @@ impl SignedBlock {
             payload,
         }
         .into()
+    }
+}
+
+impl BlockSignature {
+    /// Peer topology index
+    pub fn index(&self) -> u64 {
+        self.0
+    }
+
+    /// Signature itself
+    pub fn payload(&self) -> &Signature {
+        &self.1
     }
 }
 

--- a/data_model/src/transaction.rs
+++ b/data_model/src/transaction.rs
@@ -11,7 +11,7 @@ use core::{
 use derive_more::{DebugCustom, Display};
 #[cfg(feature = "http")]
 pub use http::*;
-use iroha_crypto::SignatureOf;
+use iroha_crypto::{Signature, SignatureOf};
 use iroha_data_model_derive::model;
 use iroha_macro::FromVariant;
 use iroha_schema::IntoSchema;
@@ -312,6 +312,13 @@ impl SignedTransactionV1 {
 impl AsRef<SignedTransaction> for CommittedTransaction {
     fn as_ref(&self) -> &SignedTransaction {
         &self.value
+    }
+}
+
+impl TransactionSignature {
+    /// Signature itself
+    pub fn payload(&self) -> &Signature {
+        &self.0
     }
 }
 

--- a/primitives/numeric/src/lib.rs
+++ b/primitives/numeric/src/lib.rs
@@ -264,6 +264,12 @@ impl NumericSpec {
     pub const fn fractional(scale: u32) -> Self {
         Self { scale: Some(scale) }
     }
+
+    /// Get the scale
+    #[inline]
+    pub const fn scale(&self) -> Option<u32> {
+        self.scale
+    }
 }
 
 impl core::str::FromStr for Numeric {


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

While working on Explorer and using Iroha crates as libraries, found a few minor yet hardly workaroundable issues. Some of them related to not using `iroha_data_model` with `transparent_api` feature, which revealed some inconsistencies with data access.

### Solution

- Expose getters for the following structs: `BlockSignature`, `TransactionSignature`, `NumericSpec`
- `iroha_crypto::Signature`: make serialization transparent instead of `{ "payload": "..." }`. This field is redundant and inconsistent with other `iroha_crypto` structures - they all serialize as plain strings.

### Migration Guide (optional)

If you passed `Signature` in JSON, do not nest it into an object with `payload` field anymore.

---

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->