### PR TITLE
ci: use Nextest, remove broken rust-cache, more unit test coverage

### DIFF
--- a/.github/workflows/iroha2-custom-image.yml
+++ b/.github/workflows/iroha2-custom-image.yml
@@ -49,9 +49,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.CHECKOUT_REF }}
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/iroha2-dev-nightly.yml
+++ b/.github/workflows/iroha2-dev-nightly.yml
@@ -13,9 +13,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/iroha2-dev-pr-static.yml
+++ b/.github/workflows/iroha2-dev-pr-static.yml
@@ -8,55 +8,25 @@ on:
       - '**.json'
       - '**.toml'
       - '.github/workflows/iroha2-dev-pr-static.yml'
-      - 'pytests/**.py'
+      - '**.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  RUSTUP_TOOLCHAIN: nightly-2024-09-09
   DOCKER_COMPOSE_PATH: defaults
 
 jobs:
-  build_executor:
-    runs-on: ubuntu-latest
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
-      - name: Upload executor to reuse in other jobs
-        uses: actions/upload-artifact@v4
-        with:
-          name: executor.wasm
-          path: ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
-          retention-days: 1
-
   smart_contracts_analysis:
     runs-on: ubuntu-latest
-    needs: build_executor
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
-        uses: actions/download-artifact@v4
-        with:
-          name: executor.wasm
-          path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Default executor format
-        run: |
-          cd ./wasm_samples/default_executor
-          mold --run cargo fmt --all -- --check
-      - name: Integration tests smart contracts format
-        run: |
-          cd ./wasm_samples
-          mold --run cargo fmt --all -- --check
+      - name: cargo fmt (wasm_samples)
+        working-directory: wasm_samples
+        run: cargo fmt --all -- --check
 
   python_static_analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/iroha2-dev-pr-wasm.yaml'
+
       - 'crates/iroha_data_model/**.rs'
       - 'crates/iroha_data_model/**.yml'
       - 'crates/iroha_data_model/**.json'
@@ -34,7 +36,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTUP_TOOLCHAIN: nightly-2024-09-09
   DOCKER_COMPOSE_PATH: defaults
 
 jobs:
@@ -45,9 +46,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:
@@ -57,19 +57,18 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    needs: build_executor
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
+    needs: build_executor
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
+      - name: Download executor.wasm
         uses: actions/download-artifact@v4
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
       - name: Install iroha_wasm_test_runner
-        run: cargo install --path crates/iroha_wasm_test_runner
+        run: which iroha_wasm_test_runner || cargo install --path crates/iroha_wasm_test_runner
       - name: Run smart contract tests on WebAssembly VM
         working-directory: crates/iroha_smart_contract
         run: mold --run cargo test -p iroha_smart_contract -p iroha_smart_contract_utils --release --tests --target wasm32-unknown-unknown --no-fail-fast --quiet

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -19,11 +19,6 @@ env:
   CARGO_TERM_COLOR: always
   IROHA_CLI_DIR: "/__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/test"
   DOCKER_COMPOSE_PATH: defaults
-  TEST_DIR: "tmp/test"
-  IROHA_BIN: "iroha"
-  IROHA_CONTAINER: "defaults-irohad0-1"
-  PYTHON_VERSION: "3.11"
-  POETRY_PATH: "/root/.local/bin/poetry"
 
 jobs:
   consistency:
@@ -32,7 +27,6 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Check genesis.json
         if: always()
         run: ./scripts/tests/consistency.sh genesis
@@ -43,6 +37,29 @@ jobs:
         if: always()
         run: ./scripts/tests/consistency.sh docker-compose
 
+  fmt_and_clippy:
+    runs-on: [self-hosted, Linux, iroha2]
+    container:
+      image: hyperledger/iroha2-ci:nightly-2024-09-09
+    steps:
+      - uses: actions/checkout@v4
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Lints without features
+        if: always()
+        run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
+      - name: Lints with all features enabled
+        if: always()
+        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json | tee clippy.json
+      - name: Documentation
+        if: always()
+        run: cargo doc --no-deps --quiet
+      - name: Upload clippy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-clippy
+          path: clippy.json
+
   build_executor:
     runs-on: ubuntu-latest
     container:
@@ -50,9 +67,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:
@@ -60,73 +76,93 @@ jobs:
           path: ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
           retention-days: 1
 
-  # exclude: iroha/tests/integration/
-  with_coverage:
+  unit_tests_with_coverage:
     runs-on: [self-hosted, Linux, iroha2]
-    needs: build_executor
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
+    needs: build_executor
+    env:
+      LLVM_PROFILE_FILE_NAME: "iroha-%p-%m.profraw"
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
+      - name: Download executor.wasm
         uses: actions/download-artifact@v4
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Run tests, with coverage
-        run: |
-          mold --run cargo test --all-features --no-fail-fast --workspace --exclude iroha
-          mold --run cargo test --all-features --no-fail-fast -p iroha -- --skip integration
-        env:
-          RUSTFLAGS: "-C instrument-coverage"
-          LLVM_PROFILE_FILE: "iroha-%p-%m.profraw"
+      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run unit tests (no default features)
+        run: >
+          mold --run cargo llvm-cov nextest
+          --no-fail-fast
+          --workspace --lib
+          --no-default-features
+          --branch
+          --no-report
+      - name: Run unit tests (all features)
+        run: >
+          mold --run cargo llvm-cov nextest
+          --no-fail-fast
+          --workspace --lib
+          --all-features
+          --branch
+          --no-report
       - name: Generate lcov report
-        if: always()
-        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "crates/iroha_cli" --ignore "**/main.rs" -o lcov.info
-      - name: Upload lcov report artifact
-        if: always()
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+      - name: Upload lcov report
         uses: actions/upload-artifact@v4
         with:
-          name: lcov.info
+          name: report-coverage
           path: lcov.info
 
   # include: iroha/tests/integration/
   # exclude: iroha/tests/integration/extra_functional
   integration:
     runs-on: [self-hosted, Linux, iroha2]
-    needs: build_executor
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
+    needs: build_executor
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
+      - name: Download executor.wasm
         uses: actions/download-artifact@v4
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Run tests, with no-default-features
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha integration -- --skip extra_functional
+      - uses: taiki-e/install-action@nextest
+      - name: Run integration tests, with all features
+        run: >
+          mold --run cargo nextest run 
+          --all-features
+          --no-fail-fast 
+          --failure-output immediate-final 
+          -E 'package(iroha) and test(integration) and not test(extra_functional)'
 
   # include: iroha/tests/integration/extra_functional
   extra_functional:
     runs-on: [self-hosted, Linux, iroha2]
-    needs: build_executor
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
+    needs: build_executor
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
+      - name: Download executor.wasm
         uses: actions/download-artifact@v4
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Run tests
-        run: mold --run cargo test --no-default-features --no-fail-fast -p iroha extra_functional -- --test-threads=1
+      - uses: taiki-e/install-action@nextest
+      - name: Run integration tests, with all features
+        run: >
+          mold --run cargo nextest run 
+          --all-features
+          --no-fail-fast 
+          --failure-output final 
+          --test-threads 1
+          -E 'test(extra_functional)'
 
   # Run the job to check that the docker containers are properly buildable
   pr-generator-build:
@@ -161,54 +197,36 @@ jobs:
           # This context specification is required
           context: .
 
-  workspace_analysis_clippy:
-    runs-on: ubuntu-latest
+  docker-compose-and-pytests:
     needs: build_executor
-    container:
-      image: hyperledger/iroha2-ci:nightly-2024-09-09
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Download executor.wasm file
-        uses: actions/download-artifact@v4
-        with:
-          name: executor.wasm
-          path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Format
-        run: cargo fmt --all -- --check
-      - name: Lints without features
-        if: always()
-        run: cargo clippy --workspace --benches --tests --examples --no-default-features --quiet
-      - name: Lints with all features enabled
-        if: always()
-        run: cargo clippy --workspace --benches --tests --examples --all-features --quiet --message-format=json | tee clippy.json
-      - name: Documentation
-        if: always()
-        run: cargo doc --no-deps --quiet
-      - name: Upload clippy report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: clippy.json
-          path: clippy.json
-
-  torii-api-client-cli-tests:
     runs-on: [self-hosted, Linux, iroha2]
-    needs: build_executor
     timeout-minutes: 60
+    env:
+      PYTHON_VERSION: "3.11"
+      POETRY_PATH: "/root/.local/bin/poetry"
+      TEST_DIR: "tmp/test"
+      IROHA_BIN: "iroha"
+      IROHA_CONTAINER: "defaults-irohad0-1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Download executor.wasm file
+      - name: Download executor.wasm
         uses: actions/download-artifact@v4
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}
-      - name: Set up Docker Buildx
+      - name: Install Python and Poetry
+        run: |
+          yum install -y python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-devel
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo 'export PATH="${{ env.POETRY_PATH }}:$PATH"' >> /etc/profile
+          source /etc/profile
+      - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-      - name: Build and Tag Docker Images
+      - name: Build and tag Docker images
         uses: docker/build-push-action@v6
         if: always()
         with:
@@ -230,39 +248,37 @@ jobs:
           docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml down
       - name: Run docker-compose.yml containers
         run: docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml up --wait || exit 1
-
-      - name: Install Python and Poetry
-        run: |
-          yum install -y python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-devel
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo 'export PATH="${{ env.POETRY_PATH }}:$PATH"' >> /etc/profile
-          source /etc/profile
-
-      - name: Install Torii API Dependencies
+      - name: Install Torii pytest dependencies
         working-directory: pytests/iroha_torii_tests
         run: ${{ env.POETRY_PATH }} install
-      - name: Run Torii API Tests
+      - name: Run Torii pytests
         working-directory: pytests/iroha_torii_tests
         run: ${{ env.POETRY_PATH }} run pytest
-
-      - name: Copy Client CLI Binary from Iroha Container
+      - name: Copy client binary from Iroha container
         if: always()
         run: |
           mkdir -p ${{ env.TEST_DIR }}
-          docker cp ${{ env.IROHA_CONTAINER }}:/usr/local/bin/${{ env.IROHA_BIN }} ${{ env.TEST_DIR }}
           cp ./defaults/client.toml ${{ env.TEST_DIR }}
-      - name: Make Binaries Executable
-        run: chmod +x ${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
-      - name: Install Client CLI Dependencies
+          docker cp ${{ env.IROHA_CONTAINER }}:/usr/local/bin/${{ env.IROHA_BIN }} ${{ env.TEST_DIR }}
+          chmod +x ${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
+      - name: Install client pytest dependencies
         working-directory: pytests/iroha_cli_tests
         run: ${{ env.POETRY_PATH }} install
-      - name: Run Client CLI Tests
-        working-directory: pytests/iroha_cli_tests
+      - name: Run client pytests
+        uses: nick-fields/retry@v3
         env:
-          IROHA_CLI_BINARY: ../../${{ env.TEST_DIR }}/${{ env.IROHA_BIN }}
-          IROHA_CLI_CONFIG: ../../${{ env.TEST_DIR }}/client.toml
-        run: ${{ env.POETRY_PATH }} run pytest
-
+          TMP_DIR: ../../${{ env.TEST_DIR }}
+          IROHA_CLI_BINARY: ${{ env.IROHA_BIN }}
+          IROHA_CLI_CONFIG: client.toml
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: |
+            cd pytests/iroha_cli_tests
+            ${{ env.POETRY_PATH }} run pytest
+          on_retry_command: |
+            docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down
+            docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.local.yml up --wait || exit 1
       - name: Wipe docker-compose.yml containers
         if: always()
         run: docker compose -f ${{ env.DOCKER_COMPOSE_PATH }}/docker-compose.yml down

--- a/.github/workflows/iroha2-dev-sonar-dojo.yml
+++ b/.github/workflows/iroha2-dev-sonar-dojo.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: lints
+          pattern: report-*
           merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/iroha2-dev-sonar-dojo.yml
+++ b/.github/workflows/iroha2-dev-sonar-dojo.yml
@@ -16,6 +16,10 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.pull_requests[0].head.ref }}
+          fetch-depth: 0
       - name: Download clippy and lcov artifact reports
         uses: actions/download-artifact@v4
         with:
@@ -33,6 +37,9 @@ jobs:
           args: >
             -Dcommunity.rust.clippy.reportPaths=lints/clippy.json
             -Dcommunity.rust.lcov.reportPaths=lints/lcov.info
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
       - name: DefectDojo
         id: defectdojo
         uses: C4tWithShell/defectdojo-action@1.0.5

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -18,9 +18,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:
@@ -90,7 +89,6 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Run debug tests and save telemetry
         env:
           TELEMETRY_FILE: ../target/telemetry/debug.json.lz4

--- a/.github/workflows/iroha2-no-incorrect-image.yml
+++ b/.github/workflows/iroha2-no-incorrect-image.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: Set up Python 3.11
+      - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: '>=3.11'
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: pip install -r .github/scripts/ci_test/requirements.txt --no-input

--- a/.github/workflows/iroha2-pr-ui.yml
+++ b/.github/workflows/iroha2-pr-ui.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, iroha2]
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     timeout-minutes: 60
@@ -28,10 +28,6 @@ jobs:
       matrix:
         feature_flag: [all-features, no-default-features]
     steps:
-      - name: Maximize build space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@nextest
       - name: Run UI tests, with ${{ matrix.feature_flag }}

--- a/.github/workflows/iroha2-pr-ui.yml
+++ b/.github/workflows/iroha2-pr-ui.yml
@@ -9,6 +9,7 @@ on:
       - '**/tests/ui.rs'
       - '**/tests/ui_*/**'
       - 'rust-toolchain.toml'
+      - '.github/workflows/iroha2-pr-ui.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +19,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
     container:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
@@ -32,7 +33,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests, with ${{ matrix.feature_flag }}
-        run: |
-          mold --run cargo test --test ui --${{ matrix.feature_flag }}
+      - uses: taiki-e/install-action@nextest
+      - name: Run UI tests, with ${{ matrix.feature_flag }}
+        run: mold --run cargo nextest run --no-fail-fast  -E 'test(ui)' --${{ matrix.feature_flag }}

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -17,9 +17,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - name: Build iroha executor
-        run: cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
+        run: mold --run cargo run --bin iroha_wasm_builder -- build ./wasm_samples/default_executor --optimize --out-file ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
       - name: Upload executor to reuse in other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/crates/iroha/tests/integration/permissions.rs
+++ b/crates/iroha/tests/integration/permissions.rs
@@ -73,7 +73,7 @@ fn get_assets(iroha: &Client, id: &AccountId) -> Vec<Asset> {
 fn permissions_disallow_asset_transfer() {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_730).start_with_runtime();
+    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_725).start_with_runtime();
     wait_for_genesis_committed(&[iroha.clone()], 0);
 
     // Given

--- a/crates/iroha/tests/integration/upgrade.rs
+++ b/crates/iroha/tests/integration/upgrade.rs
@@ -312,7 +312,7 @@ fn executor_custom_instructions_complex() -> Result<()> {
 
 #[test]
 fn migration_fail_should_not_cause_any_effects() {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_998).start_with_runtime();
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_980).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     let assert_domain_does_not_exist = |client: &Client, domain_id: &DomainId| {
@@ -345,7 +345,7 @@ fn migration_fail_should_not_cause_any_effects() {
 
 #[test]
 fn migration_should_cause_upgrade_event() {
-    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_996).start_with_runtime();
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_995).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     let events_client = client.clone();

--- a/crates/iroha_cli/.gitignore
+++ b/crates/iroha_cli/.gitignore
@@ -1,2 +1,0 @@
-peers_configs/
-isi_unregister_asset.json

--- a/pytests/iroha_cli_tests/README.md
+++ b/pytests/iroha_cli_tests/README.md
@@ -66,8 +66,9 @@ The test model has the following structure:
 3. Configure the tests by creating the following `.env` file in _this_ (`<repo root>/pytests/iroha_cli_tests/`) directory:
 
 	 ```shell
-     IROHA_CLI_BINARY=/path/to/iroha_cli
-     IROHA_CLI_CONFIG=/path/to/client.toml
+     TMP_DIR=/path/to/tmp_dir
+     IROHA_CLI_BINARY=iroha # relative to TMP_DIR
+     IROHA_CLI_CONFIG=client.toml # relative to TMP_DIR
 	 TORII_API_PORT_MIN=8080
 	 TORII_API_PORT_MAX=8083
 	 ```

--- a/pytests/iroha_cli_tests/common/settings.py
+++ b/pytests/iroha_cli_tests/common/settings.py
@@ -14,9 +14,11 @@ BASE_DIR = os.path.dirname(
 )
 ROOT_DIR = os.environ.get("IROHA_CLI_DIR", BASE_DIR)
 
-PATH_CONFIG_IROHA_CLI = os.environ["IROHA_CLI_CONFIG"]
-IROHA_CLI_PATH = os.environ["IROHA_CLI_BINARY"]
-PEERS_CONFIGS_PATH = os.path.join(ROOT_DIR, "peers_configs")
+TMP_DIR = os.environ["TMP_DIR"]
+IROHA_CLI_CONFIG = os.path.join(TMP_DIR, os.environ["IROHA_CLI_CONFIG"])
+IROHA_CLI_BINARY = os.path.join(TMP_DIR, os.environ["IROHA_CLI_BINARY"])
+PEER_CONFIGS_PATH = os.path.join(TMP_DIR, "peer_configs")
+ISI_PATH = os.path.join(TMP_DIR, "isi")
 
 PORT_MIN = int(os.getenv("TORII_API_PORT_MIN", "8080"))
 PORT_MAX = int(os.getenv("TORII_API_PORT_MAX", "8083"))

--- a/pytests/iroha_cli_tests/src/iroha_cli/__init__.py
+++ b/pytests/iroha_cli_tests/src/iroha_cli/__init__.py
@@ -2,12 +2,12 @@
 This module initializes the Iroha client and configuration using environment variables.
 """
 
-from ...common.settings import PATH_CONFIG_IROHA_CLI, PORT_MAX, PORT_MIN
+from ...common.settings import IROHA_CLI_CONFIG, PORT_MAX, PORT_MIN
 from .iroha_cli import IrohaCli
 from .configuration import Config
 from .iroha import Iroha
 
 config = Config(PORT_MIN, PORT_MAX)
-config.load(PATH_CONFIG_IROHA_CLI)
+config.load(IROHA_CLI_CONFIG)
 iroha_cli = IrohaCli(config)
 iroha = Iroha(config)

--- a/pytests/iroha_cli_tests/src/iroha_cli/configuration.py
+++ b/pytests/iroha_cli_tests/src/iroha_cli/configuration.py
@@ -47,7 +47,7 @@ class Config:
             self._config = tomlkit.load(config_file)
         self.file = path_config_iroha_cli
 
-    def generate_by_peers(self, peers_configs_dir):
+    def generate_by_peers(self, peer_configs_dir):
         """
         Generate configuration files for each port in the range from port_min to port_max.
         """
@@ -59,13 +59,13 @@ class Config:
         if self.port_min >= self.port_max:
             raise ValueError("port_min must be less than port_max.")
 
-        os.makedirs(peers_configs_dir, exist_ok=True)
+        os.makedirs(peer_configs_dir, exist_ok=True)
 
         for port in range(self.port_min, self.port_max + 1):
             config_copy = self._config.copy()
             config_copy["TORII_API_URL"] = f"http://localhost:{port}"
             file_name = f"config_to_peer_{port}.json"
-            file_path = os.path.join(peers_configs_dir, file_name)
+            file_path = os.path.join(peer_configs_dir, file_name)
             with open(file_path, "w", encoding="utf-8") as config_file:
                 json.dump(config_copy, config_file, indent=4)
 
@@ -76,13 +76,13 @@ class Config:
 
         :return: None
         """
-        peers_configs = glob.glob("path/to/peers/configs/*.json")
-        if not peers_configs:
+        peer_configs = glob.glob("path/to/peer/configs/*.json")
+        if not peer_configs:
             raise ValueError(
                 "Peer configuration files not found. First generate them using generate_by_peers."
             )
 
-        chosen_config_file = random.choice(peers_configs)
+        chosen_config_file = random.choice(peer_configs)
 
         self.load(chosen_config_file)
 

--- a/pytests/iroha_cli_tests/src/iroha_cli/iroha_cli.py
+++ b/pytests/iroha_cli_tests/src/iroha_cli/iroha_cli.py
@@ -12,7 +12,7 @@ from typing import Callable
 import allure  # type: ignore
 
 from ...common.helpers import extract_hash, read_isi_from_json, write_isi_to_json
-from ...common.settings import BASE_DIR, IROHA_CLI_PATH, PATH_CONFIG_IROHA_CLI, ROOT_DIR
+from ...common.settings import IROHA_CLI_BINARY, ISI_PATH, IROHA_CLI_CONFIG, ROOT_DIR
 from .configuration import Config
 
 
@@ -21,8 +21,8 @@ class IrohaCli:
     A class to represent the Iroha client command line interface.
     """
 
-    BASE_PATH = IROHA_CLI_PATH
-    BASE_FLAGS = ["--config=" + PATH_CONFIG_IROHA_CLI]
+    BASE_PATH = IROHA_CLI_BINARY
+    BASE_FLAGS = ["--config=" + IROHA_CLI_CONFIG]
 
     def __init__(self, config: Config):
         """
@@ -274,7 +274,7 @@ class IrohaCli:
         :rtype: str
         """
         json_template_path = (
-            Path(BASE_DIR)
+            Path(ROOT_DIR)
             / "pytests"
             / "common"
             / "json_isi_examples"
@@ -289,7 +289,7 @@ class IrohaCli:
                 element = element[key]
             element[key_path[-1]] = value
 
-        json_temp_file_path = Path(ROOT_DIR) / f"isi_{template_filename}"
+        json_temp_file_path = Path(ISI_PATH) / f"isi_{template_filename}"
         write_isi_to_json(data, str(json_temp_file_path))
 
         return str(json_temp_file_path)

--- a/pytests/iroha_cli_tests/test/conftest.py
+++ b/pytests/iroha_cli_tests/test/conftest.py
@@ -20,7 +20,7 @@ from ..common.helpers import (
     random,
     string,
 )
-from ..common.settings import PEERS_CONFIGS_PATH
+from ..common.settings import PEER_CONFIGS_PATH
 from ..models import Account, Asset, AssetDefinition, Domain
 from ..src.iroha_cli import iroha_cli, config
 
@@ -31,7 +31,7 @@ def before_all():
     """Initial setup for all test sessions.
     This fixture generates configurations based on peers and is automatically
     used for every test session."""
-    config.generate_by_peers(PEERS_CONFIGS_PATH)
+    config.generate_by_peers(PEER_CONFIGS_PATH)
     yield
 
 


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

This PR sets up `cargo nextest` for running Rust tests, and makes other CI-related improvements:

- Run unit tests with `no-default-features` (closes #4854)
- Retry client pytests (follow-up ticket: https://github.com/hyperledger/iroha/issues/5014)
- Do not build/download the default executor where it's not needed (post #4931)
- ~Caching dependencies should actually work now (switch from [`rust-cache`](https://github.com/Swatinem/rust-cache) to [`cargo-cache`](https://github.com/Leafwing-Studios/cargo-cache)), cache is shared between similar jobs~
  - Self-hosted runners don't work with `cargo-cache`, and `rust-cache` never seems to hit the cache even though it writes to it.
- Fixes #4499 (specifies the exact Ubuntu version)

---

### Checklist

- [x] Finish fixing client pytests
- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->