### PR TITLE
refactor: sign only block's header, not the whole payload

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -295,7 +295,7 @@ mod valid {
             };
 
             leader_signature
-                .verify(topology.leader().public_key(), block.payload())
+                .verify(topology.leader().public_key(), &block.payload().header)
                 .map_err(|_err| SignatureVerificationError::LeaderMissing)?;
             Ok(())
         }
@@ -332,7 +332,7 @@ mod valid {
                         .ok_or(SignatureVerificationError::UnknownSignatory)?;
 
                     signature
-                        .verify(signatory.public_key(), block.payload())
+                        .verify(signatory.public_key(), &block.payload().header)
                         .map_err(|_err| SignatureVerificationError::UnknownSignature)?;
 
                     Ok(())
@@ -386,7 +386,7 @@ mod valid {
             };
 
             proxy_tail_signature
-                .verify(topology.proxy_tail().public_key(), block.payload())
+                .verify(topology.proxy_tail().public_key(), &block.payload().header)
                 .map_err(|_err| SignatureVerificationError::ProxyTailMissing)?;
 
             Ok(())
@@ -772,7 +772,7 @@ mod valid {
         };
         signature
             .1
-            .verify(&genesis_account.signatory, block.payload())
+            .verify(&genesis_account.signatory, &block.payload().header)
             .map_err(|_| InvalidGenesisError::InvalidSignature)?;
 
         let transactions = block.payload().transactions.as_slice();
@@ -811,7 +811,10 @@ mod valid {
                 .skip(1)
                 .filter(|(i, _)| *i != 4) // Skip proxy tail
                 .map(|(i, key_pair)| {
-                    BlockSignature(i as u64, SignatureOf::new(key_pair.private_key(), &payload))
+                    BlockSignature(
+                        i as u64,
+                        SignatureOf::new(key_pair.private_key(), &payload.header),
+                    )
                 })
                 .try_for_each(|signature| block.add_signature(signature, &topology))
                 .expect("Failed to add signatures");
@@ -879,7 +882,10 @@ mod valid {
                 .skip(1)
                 .filter(|(i, _)| *i != 4) // Skip proxy tail
                 .map(|(i, key_pair)| {
-                    BlockSignature(i as u64, SignatureOf::new(key_pair.private_key(), &payload))
+                    BlockSignature(
+                        i as u64,
+                        SignatureOf::new(key_pair.private_key(), &payload.header),
+                    )
                 })
                 .try_for_each(|signature| block.add_signature(signature, &topology))
                 .expect("Failed to add signatures");

--- a/data_model/src/block.rs
+++ b/data_model/src/block.rs
@@ -113,7 +113,7 @@ mod model {
         /// Index of the peer in the topology
         pub u64,
         /// Payload
-        pub SignatureOf<BlockPayload>,
+        pub SignatureOf<BlockHeader>,
     );
 
     /// Signed block
@@ -165,7 +165,10 @@ impl BlockPayload {
     /// Create new signed block, using `key_pair` to sign `payload`
     #[cfg(feature = "transparent_api")]
     pub fn sign(self, private_key: &iroha_crypto::PrivateKey) -> SignedBlock {
-        let signatures = vec![BlockSignature(0, SignatureOf::new(private_key, &self))];
+        let signatures = vec![BlockSignature(
+            0,
+            SignatureOf::new(private_key, &self.header),
+        )];
 
         SignedBlockV1 {
             signatures,
@@ -236,7 +239,7 @@ impl SignedBlock {
             ));
         }
 
-        signature.1.verify(public_key, self.payload())?;
+        signature.1.verify(public_key, &self.payload().header)?;
 
         let SignedBlock::V1(block) = self;
         block.signatures.push(signature);
@@ -261,7 +264,7 @@ impl SignedBlock {
 
         block.signatures.push(BlockSignature(
             signatory as u64,
-            SignatureOf::new(private_key, &block.payload),
+            SignatureOf::new(private_key, &block.payload.header),
         ));
     }
 
@@ -300,7 +303,7 @@ impl SignedBlock {
             transactions,
         };
 
-        let signature = BlockSignature(0, SignatureOf::new(genesis_private_key, &payload));
+        let signature = BlockSignature(0, SignatureOf::new(genesis_private_key, &payload.header));
         SignedBlockV1 {
             signatures: vec![signature],
             payload,

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -720,7 +720,7 @@
   "BlockSignature": {
     "Tuple": [
       "u64",
-      "SignatureOf<BlockPayload>"
+      "SignatureOf<BlockHeader>"
     ]
   },
   "BlockStatus": {
@@ -3943,7 +3943,7 @@
       }
     ]
   },
-  "SignatureOf<BlockPayload>": "Signature",
+  "SignatureOf<BlockHeader>": "Signature",
   "SignatureOf<QueryRequestWithAuthority>": "Signature",
   "SignatureOf<TransactionPayload>": "Signature",
   "SignedBlock": {

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -384,7 +384,7 @@ types!(
     SetKeyValue<Trigger>,
     SetParameter,
     Signature,
-    SignatureOf<BlockPayload>,
+    SignatureOf<BlockHeader>,
     SignatureOf<QueryRequestWithAuthority>,
     SignatureOf<TransactionPayload>,
     SignedBlock,


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

it's not necessary to sign the whole block payload since block header holds the merkle tree root hash

### Reason

this will enable us to work on #4914
