### PR TITLE
refactor!: shift from `JsonString` to `JsonValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,7 @@ dependencies = [
  "iroha_smart_contract_derive",
  "iroha_smart_contract_utils",
  "parity-scale-codec",
+ "serde_json",
  "test_samples",
  "trybuild",
  "webassembly-test",

--- a/client/tests/integration/multisig.rs
+++ b/client/tests/integration/multisig.rs
@@ -80,7 +80,8 @@ fn mutlisig() -> Result<()> {
             .map(Register::account),
     )?;
 
-    let call_trigger = ExecuteTrigger::new(multisig_register_trigger_id).with_args(&args);
+    let call_trigger = ExecuteTrigger::new(multisig_register_trigger_id)
+        .with_args(serde_json::to_value(&args).unwrap());
     test_client.submit_blocking(call_trigger)?;
 
     // Check that multisig account exist
@@ -107,7 +108,8 @@ fn mutlisig() -> Result<()> {
 
     if let Some((signatory, key_pair)) = signatories_iter.next() {
         let args = MultisigArgs::Instructions(isi);
-        let call_trigger = ExecuteTrigger::new(multisig_trigger_id.clone()).with_args(&args);
+        let call_trigger = ExecuteTrigger::new(multisig_trigger_id.clone())
+            .with_args(serde_json::to_value(&args).unwrap());
         test_client.submit_transaction_blocking(
             &TransactionBuilder::new(test_client.chain.clone(), signatory)
                 .with_instructions([call_trigger])
@@ -125,7 +127,8 @@ fn mutlisig() -> Result<()> {
 
     for (signatory, key_pair) in signatories_iter {
         let args = MultisigArgs::Vote(isi_hash);
-        let call_trigger = ExecuteTrigger::new(multisig_trigger_id.clone()).with_args(&args);
+        let call_trigger = ExecuteTrigger::new(multisig_trigger_id.clone())
+            .with_args(serde_json::to_value(&args).unwrap());
         test_client.submit_transaction_blocking(
             &TransactionBuilder::new(test_client.chain.clone(), signatory)
                 .with_instructions([call_trigger])

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -259,7 +259,7 @@ fn permissions_differ_not_only_by_names() {
         .submit_blocking(SetKeyValue::asset(
             mouse_hat_id,
             Name::from_str("color").expect("Valid"),
-            "red".parse::<JsonString>().expect("Valid"),
+            "red",
         ))
         .expect("Failed to modify Mouse's hats");
 
@@ -268,7 +268,7 @@ fn permissions_differ_not_only_by_names() {
     let set_shoes_color = SetKeyValue::asset(
         mouse_shoes_id.clone(),
         Name::from_str("color").expect("Valid"),
-        "yellow".parse::<JsonString>().expect("Valid"),
+        "yellow",
     );
     let _err = client
         .submit_blocking(set_shoes_color.clone())
@@ -316,11 +316,12 @@ fn stored_vs_granted_permission_payload() -> Result<()> {
         .expect("Failed to register mouse");
 
     // Allow alice to mint mouse asset and mint initial value
-    let value_json = JsonString::from_string_unchecked(format!(
+    let value_json = JsonValue::from_string(format!(
         // NOTE: Permissions is created explicitly as a json string to introduce additional whitespace
         // This way, if the executor compares permissions just as JSON strings, the test will fail
         r##"{{ "asset"   :   "xor#wonderland#{mouse_id}" }}"##
-    ));
+    ))
+    .expect("input is a valid JSON");
 
     let mouse_asset = AssetId::new(asset_definition_id, mouse_id.clone());
     let allow_alice_to_set_key_value_in_mouse_asset = Grant::account_permission(
@@ -336,11 +337,7 @@ fn stored_vs_granted_permission_payload() -> Result<()> {
         .expect("Failed to grant permission to alice.");
 
     // Check that alice can indeed mint mouse asset
-    let set_key_value = SetKeyValue::asset(
-        mouse_asset,
-        Name::from_str("color")?,
-        "red".parse::<JsonString>().expect("Valid"),
-    );
+    let set_key_value = SetKeyValue::asset(mouse_asset, Name::from_str("color")?, "red");
     iroha
         .submit_blocking(set_key_value)
         .expect("Failed to mint asset for mouse.");

--- a/client/tests/integration/queries/smart_contract.rs
+++ b/client/tests/integration/queries/smart_contract.rs
@@ -22,11 +22,12 @@ fn live_query_is_dropped_after_smart_contract_end() -> Result<()> {
         client.build_transaction(WasmSmartContract::from_compiled(wasm), Metadata::default());
     client.submit_transaction_blocking(&transaction)?;
 
-    let metadata_value: JsonString = client.query_single(FindAccountMetadata::new(
-        client.account.clone(),
-        Name::from_str("cursor").unwrap(),
-    ))?;
-    let asset_cursor = metadata_value.try_into_any()?;
+    let asset_cursor = client
+        .query_single(FindAccountMetadata::new(
+            client.account.clone(),
+            Name::from_str("cursor").unwrap(),
+        ))?
+        .try_into_any()?;
 
     // here we are breaking the abstraction preventing us from using a cursor we pulled from the metadata
     let err = client

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -67,11 +67,7 @@ fn register_and_grant_role_for_metadata_access() -> Result<()> {
     test_client.submit_transaction_blocking(&grant_role_tx)?;
 
     // Alice modifies Mouse's metadata
-    let set_key_value = SetKeyValue::account(
-        mouse_id,
-        "key".parse::<Name>()?,
-        "value".parse::<JsonString>()?,
-    );
+    let set_key_value = SetKeyValue::account(mouse_id, "key".parse::<Name>()?, "value");
     test_client.submit_blocking(set_key_value)?;
 
     // Making request to find Alice's roles
@@ -224,11 +220,7 @@ fn grant_revoke_role_permissions() -> Result<()> {
         .sign(mouse_keypair.private_key());
     test_client.submit_transaction_blocking(&grant_role_tx)?;
 
-    let set_key_value = SetKeyValue::account(
-        mouse_id.clone(),
-        "key".parse()?,
-        "value".parse::<JsonString>()?,
-    );
+    let set_key_value = SetKeyValue::account(mouse_id.clone(), "key".parse()?, "value");
     let can_set_key_value_in_mouse = CanSetKeyValueInAccount {
         account: mouse_id.clone(),
     };

--- a/client/tests/integration/sorting.rs
+++ b/client/tests/integration/sorting.rs
@@ -47,7 +47,7 @@ fn correct_pagination_assets_after_creating_new_one() {
             AssetDefinitionId::from_str(&format!("xor{i}#wonderland")).expect("Valid");
         let asset_definition = AssetDefinition::store(asset_definition_id.clone());
         let mut asset_metadata = Metadata::default();
-        asset_metadata.insert(sort_by_metadata_key.clone(), i as u32);
+        asset_metadata.insert(sort_by_metadata_key.clone(), i);
         let asset = Asset::new(
             AssetId::new(asset_definition_id, account_id.clone()),
             AssetValue::Store(asset_metadata),

--- a/client/tests/integration/transfer_domain.rs
+++ b/client/tests/integration/transfer_domain.rs
@@ -13,7 +13,6 @@ use iroha_executor_data_model::permission::{
     trigger::CanUnregisterUserTrigger,
 };
 use iroha_genesis::GenesisBlock;
-use iroha_primitives::json::JsonString;
 use test_network::{Peer as TestPeer, *};
 use test_samples::{gen_account_in, ALICE_ID, BOB_ID, SAMPLE_GENESIS_ACCOUNT_ID};
 use tokio::runtime::Runtime;
@@ -74,8 +73,11 @@ fn domain_owner_domain_permissions() -> Result<()> {
 
     // check that "alice@wonderland" as owner of domain can edit metadata in her domain
     let key: Name = "key".parse()?;
-    let value = JsonString::new("value");
-    test_client.submit_blocking(SetKeyValue::domain(kingdom_id.clone(), key.clone(), value))?;
+    test_client.submit_blocking(SetKeyValue::domain(
+        kingdom_id.clone(),
+        key.clone(),
+        "value",
+    ))?;
     test_client.submit_blocking(RemoveKeyValue::domain(kingdom_id.clone(), key))?;
 
     // check that "alice@wonderland" as owner of domain can grant and revoke domain related permissions
@@ -111,11 +113,10 @@ fn domain_owner_account_permissions() -> Result<()> {
 
     // check that "alice@wonderland" as owner of domain can edit metadata of account in her domain
     let key: Name = "key".parse()?;
-    let value = JsonString::new("value");
     test_client.submit_blocking(SetKeyValue::account(
         mad_hatter_id.clone(),
         key.clone(),
-        value,
+        "value",
     ))?;
     test_client.submit_blocking(RemoveKeyValue::account(mad_hatter_id.clone(), key))?;
 
@@ -177,11 +178,10 @@ fn domain_owner_asset_definition_permissions() -> Result<()> {
 
     // check that "alice@wonderland" as owner of domain can edit metadata of asset definition in her domain
     let key: Name = "key".parse()?;
-    let value = JsonString::new("value");
     test_client.submit_blocking(SetKeyValue::asset_definition(
         coin_id.clone(),
         key.clone(),
-        value,
+        "value",
     ))?;
     test_client.submit_blocking(RemoveKeyValue::asset_definition(coin_id.clone(), key))?;
 
@@ -249,9 +249,12 @@ fn domain_owner_asset_permissions() -> Result<()> {
 
     // check that "alice@wonderland" as owner of domain can edit metadata of store asset in her domain
     let key: Name = "key".parse()?;
-    let value = JsonString::new("value");
     let bob_store_id = AssetId::new(store_id, bob_id.clone());
-    test_client.submit_blocking(SetKeyValue::asset(bob_store_id.clone(), key.clone(), value))?;
+    test_client.submit_blocking(SetKeyValue::asset(
+        bob_store_id.clone(),
+        key.clone(),
+        "value",
+    ))?;
     test_client.submit_blocking(RemoveKeyValue::asset(bob_store_id.clone(), key))?;
 
     // check that "alice@wonderland" as owner of domain can grant and revoke asset related permissions in her domain

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -14,6 +14,7 @@ use iroha::{
 use iroha_executor_data_model::permission::trigger::CanRegisterUserTrigger;
 use iroha_genesis::GenesisBlock;
 use iroha_logger::info;
+use serde_json::json;
 use test_network::{Peer as TestPeer, *};
 use test_samples::ALICE_ID;
 use tokio::runtime::Runtime;
@@ -458,11 +459,7 @@ fn trigger_in_genesis_using_base64() -> Result<()> {
 
     // Executing trigger
     test_client
-        .submit_blocking(SetKeyValue::trigger(
-            trigger_id.clone(),
-            "VAL".parse()?,
-            1_u32,
-        ))
+        .submit_blocking(SetKeyValue::trigger(trigger_id.clone(), "VAL".parse()?, 1))
         .unwrap();
     let call_trigger = ExecuteTrigger::new(trigger_id);
     test_client.submit_blocking(call_trigger)?;
@@ -685,7 +682,7 @@ fn call_execute_trigger_with_args() -> Result<()> {
     test_client.submit_blocking(Register::trigger(trigger))?;
 
     let args: MintRoseArgs = MintRoseArgs { val: 42 };
-    let call_trigger = ExecuteTrigger::new(trigger_id).with_args(&args);
+    let call_trigger = ExecuteTrigger::new(trigger_id).with_args(json!(args));
     test_client.submit_blocking(call_trigger)?;
 
     let new_value = get_asset_value(&mut test_client, asset_id);

--- a/client/tests/integration/triggers/time_trigger.rs
+++ b/client/tests/integration/triggers/time_trigger.rs
@@ -203,11 +203,7 @@ fn pre_commit_trigger_should_be_executed() -> Result<()> {
         prev_value = new_value;
 
         // ISI just to create a new block
-        let sample_isi = SetKeyValue::account(
-            account_id.clone(),
-            "key".parse::<Name>()?,
-            "value".parse::<JsonString>()?,
-        );
+        let sample_isi = SetKeyValue::account(account_id.clone(), "key".parse::<Name>()?, "value");
         test_client.submit(sample_isi)?;
     }
 
@@ -343,11 +339,7 @@ fn submit_sample_isi_on_every_block_commit(
     for _ in block_committed_event_listener.take(times) {
         std::thread::sleep(timeout);
         // ISI just to create a new block
-        let sample_isi = SetKeyValue::account(
-            account_id.clone(),
-            "key".parse::<Name>()?,
-            JsonString::new("value"),
-        );
+        let sample_isi = SetKeyValue::account(account_id.clone(), "key".parse::<Name>()?, "value");
         test_client.submit(sample_isi)?;
     }
 

--- a/core/src/query/store.rs
+++ b/core/src/query/store.rs
@@ -297,7 +297,6 @@ mod tests {
         query::parameters::{FetchSize, Pagination, QueryParams, Sorting},
     };
     use nonzero_ext::nonzero;
-    
     use test_samples::ALICE_ID;
 
     use super::*;

--- a/core/src/query/store.rs
+++ b/core/src/query/store.rs
@@ -296,8 +296,8 @@ mod tests {
         permission::Permission,
         query::parameters::{FetchSize, Pagination, QueryParams, Sorting},
     };
-    use iroha_primitives::json::JsonString;
     use nonzero_ext::nonzero;
+    
     use test_samples::ALICE_ID;
 
     use super::*;
@@ -322,8 +322,7 @@ mod tests {
             };
 
             // it's not important which type we use here, just to test the flow
-            let query_output =
-                (0..100).map(|_| Permission::new(String::default(), JsonString::from(false)));
+            let query_output = (0..100).map(|_| Permission::new(String::default(), false));
             let query_output = crate::smartcontracts::query::apply_query_postprocessing(
                 query_output,
                 &query_params,

--- a/core/src/smartcontracts/isi/account.rs
+++ b/core/src/smartcontracts/isi/account.rs
@@ -491,7 +491,7 @@ pub mod query {
             },
         },
     };
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
 
     use super::*;
     use crate::{smartcontracts::ValidQuery, state::StateReadOnly};
@@ -546,7 +546,7 @@ pub mod query {
 
     impl ValidSingularQuery for FindAccountMetadata {
         #[metrics(+"find_account_key_value_by_id_and_key")]
-        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonString, Error> {
+        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonValue, Error> {
             let id = &self.id;
             let key = &self.key;
             iroha_logger::trace!(%id, %key);

--- a/core/src/smartcontracts/isi/asset.rs
+++ b/core/src/smartcontracts/isi/asset.rs
@@ -432,7 +432,7 @@ pub mod query {
             },
         },
     };
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
 
     use super::*;
     use crate::{smartcontracts::ValidQuery, state::StateReadOnly};
@@ -504,7 +504,7 @@ pub mod query {
 
     impl ValidSingularQuery for FindAssetMetadata {
         #[metrics(+"find_asset_key_value_by_id_and_key")]
-        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonString, Error> {
+        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonValue, Error> {
             let id = &self.id;
             let key = &self.key;
             let asset = state_ro.world().asset(id).map_err(|asset_err| {

--- a/core/src/smartcontracts/isi/domain.rs
+++ b/core/src/smartcontracts/isi/domain.rs
@@ -398,7 +398,7 @@ pub mod query {
             predicate::{predicate_atoms::domain::DomainPredicateBox, CompoundPredicate},
         },
     };
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
 
     use super::*;
     use crate::{smartcontracts::ValidQuery, state::StateReadOnly};
@@ -420,7 +420,7 @@ pub mod query {
 
     impl ValidSingularQuery for FindDomainMetadata {
         #[metrics(+"find_domain_key_value_by_id_and_key")]
-        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonString, Error> {
+        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonValue, Error> {
             let id = &self.id;
             let key = &self.key;
             iroha_logger::trace!(%id, %key);
@@ -434,7 +434,7 @@ pub mod query {
 
     impl ValidSingularQuery for FindAssetDefinitionMetadata {
         #[metrics(+"find_asset_definition_key_value_by_id_and_key")]
-        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonString, Error> {
+        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonValue, Error> {
             let id = &self.id;
             let key = &self.key;
             iroha_logger::trace!(%id, %key);

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -229,6 +229,7 @@ mod tests {
     use core::str::FromStr as _;
     use std::sync::Arc;
 
+    use serde_json::json;
     use test_samples::{
         gen_account_in, ALICE_ID, SAMPLE_GENESIS_ACCOUNT_ID, SAMPLE_GENESIS_ACCOUNT_KEYPAIR,
     };
@@ -270,14 +271,14 @@ mod tests {
         let asset_definition_id = AssetDefinitionId::from_str("rose#wonderland")?;
         let asset_id = AssetId::new(asset_definition_id, account_id.clone());
         let key = Name::from_str("Bytes")?;
-        SetKeyValue::asset(asset_id.clone(), key.clone(), vec![1_u32, 2_u32, 3_u32])
+        SetKeyValue::asset(asset_id.clone(), key.clone(), vec![1, 2, 3])
             .execute(&account_id, &mut state_transaction)?;
         let asset = state_transaction.world.asset(&asset_id)?;
         let AssetValue::Store(store) = &asset.value else {
             panic!("expected store asset");
         };
         let value = store.get(&key).cloned();
-        assert_eq!(value, Some(vec![1_u32, 2_u32, 3_u32,].into()));
+        assert_eq!(value, Some(json!([1, 2, 3]).into()));
         Ok(())
     }
 
@@ -289,12 +290,12 @@ mod tests {
         let mut state_transaction = state_block.transaction();
         let account_id = ALICE_ID.clone();
         let key = Name::from_str("Bytes")?;
-        SetKeyValue::account(account_id.clone(), key.clone(), vec![1_u32, 2_u32, 3_u32])
+        SetKeyValue::account(account_id.clone(), key.clone(), vec![1, 2, 3])
             .execute(&account_id, &mut state_transaction)?;
         let bytes = state_transaction
             .world
             .map_account(&account_id, |account| account.metadata().get(&key).cloned())?;
-        assert_eq!(bytes, Some(vec![1_u32, 2_u32, 3_u32,].into()));
+        assert_eq!(bytes, Some(json!([1, 2, 3]).into()));
         Ok(())
     }
 
@@ -307,19 +308,15 @@ mod tests {
         let definition_id = AssetDefinitionId::from_str("rose#wonderland")?;
         let account_id = ALICE_ID.clone();
         let key = Name::from_str("Bytes")?;
-        SetKeyValue::asset_definition(
-            definition_id.clone(),
-            key.clone(),
-            vec![1_u32, 2_u32, 3_u32],
-        )
-        .execute(&account_id, &mut state_transaction)?;
+        SetKeyValue::asset_definition(definition_id.clone(), key.clone(), vec![1, 2, 3])
+            .execute(&account_id, &mut state_transaction)?;
         let value = state_transaction
             .world
             .asset_definition(&definition_id)?
             .metadata()
             .get(&key)
             .cloned();
-        assert_eq!(value, Some(vec![1_u32, 2_u32, 3_u32,].into()));
+        assert_eq!(value, Some(json!([1, 2, 3]).into()));
         Ok(())
     }
 
@@ -332,7 +329,7 @@ mod tests {
         let domain_id = DomainId::from_str("wonderland")?;
         let account_id = ALICE_ID.clone();
         let key = Name::from_str("Bytes")?;
-        SetKeyValue::domain(domain_id.clone(), key.clone(), vec![1_u32, 2_u32, 3_u32])
+        SetKeyValue::domain(domain_id.clone(), key.clone(), vec![1, 2, 3])
             .execute(&account_id, &mut state_transaction)?;
         let bytes = state_transaction
             .world
@@ -340,7 +337,7 @@ mod tests {
             .metadata()
             .get(&key)
             .cloned();
-        assert_eq!(bytes, Some(vec![1_u32, 2_u32, 3_u32,].into()));
+        assert_eq!(bytes, Some(json!([1, 2, 3]).into()));
         Ok(())
     }
 

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -364,7 +364,6 @@ mod tests {
     };
     use iroha_primitives::json::JsonValue;
     use nonzero_ext::nonzero;
-    
     use test_samples::{gen_account_in, ALICE_ID, ALICE_KEYPAIR};
     use tokio::test;
 

--- a/core/src/smartcontracts/isi/query.rs
+++ b/core/src/smartcontracts/isi/query.rs
@@ -26,29 +26,29 @@ pub trait SortableQueryOutput {
     /// Get the sorting key for the output, from metadata
     ///
     /// If the type doesn't have metadata or metadata key doesn't exist - return None
-    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonString>;
+    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonValue>;
 }
 
 impl SortableQueryOutput for Account {
-    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonValue> {
         self.metadata.get(key).cloned()
     }
 }
 
 impl SortableQueryOutput for Domain {
-    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonValue> {
         self.metadata.get(key).cloned()
     }
 }
 
 impl SortableQueryOutput for AssetDefinition {
-    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonValue> {
         self.metadata.get(key).cloned()
     }
 }
 
 impl SortableQueryOutput for Asset {
-    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, key: &Name) -> Option<JsonValue> {
         match &self.value {
             AssetValue::Numeric(_) => None,
             AssetValue::Store(metadata) => metadata.get(key).cloned(),
@@ -57,55 +57,55 @@ impl SortableQueryOutput for Asset {
 }
 
 impl SortableQueryOutput for Role {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for RoleId {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for TransactionQueryOutput {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for Peer {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for Permission {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for Trigger {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for TriggerId {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for iroha_data_model::block::SignedBlock {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
 
 impl SortableQueryOutput for iroha_data_model::block::BlockHeader {
-    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonString> {
+    fn get_metadata_sorting_key(&self, _key: &Name) -> Option<JsonValue> {
         None
     }
 }
@@ -140,7 +140,7 @@ where
     let output = match &sorting.sort_by_metadata_key {
         Some(key) => {
             // if sorting was requested, we need to retrieve all the results first
-            let mut pairs: Vec<(Option<JsonString>, I::Item)> = iter
+            let mut pairs: Vec<(Option<JsonValue>, I::Item)> = iter
                 .map(|value| {
                     let key = value.get_metadata_sorting_key(key);
                     (key, value)
@@ -362,8 +362,9 @@ mod tests {
         parameter::TransactionParameters,
         query::{error::FindError, predicate::CompoundPredicate},
     };
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
     use nonzero_ext::nonzero;
+    
     use test_samples::{gen_account_in, ALICE_ID, ALICE_KEYPAIR};
     use tokio::test;
 
@@ -395,10 +396,7 @@ mod tests {
             AssetDefinition::numeric(asset_definition_id.clone()).build(&ALICE_ID);
 
         let mut store = Metadata::default();
-        store.insert(
-            Name::from_str("Bytes").expect("Valid"),
-            vec![1_u32, 2_u32, 3_u32],
-        );
+        store.insert(Name::from_str("Bytes").expect("Valid"), vec![1, 2, 3]);
         let asset_id = AssetId::new(asset_definition_id, account.id().clone());
         let asset = Asset::new(asset_id, AssetValue::Store(store));
 
@@ -407,7 +405,7 @@ mod tests {
 
     fn world_with_test_account_with_metadata() -> Result<World> {
         let mut metadata = Metadata::default();
-        metadata.insert(Name::from_str("Bytes")?, vec![1_u32, 2_u32, 3_u32]);
+        metadata.insert(Name::from_str("Bytes")?, vec![1, 2, 3]);
 
         let domain = Domain::new(DomainId::from_str("wonderland")?).build(&ALICE_ID);
         let account = Account::new(ALICE_ID.clone())
@@ -500,7 +498,7 @@ mod tests {
         let asset_id = AssetId::new(asset_definition_id, ALICE_ID.clone());
         let bytes =
             FindAssetMetadata::new(asset_id, Name::from_str("Bytes")?).execute(&state.view())?;
-        assert_eq!(JsonString::from(vec![1_u32, 2_u32, 3_u32,]), bytes,);
+        assert_eq!(JsonValue::from(vec![1, 2, 3]), bytes);
         Ok(())
     }
 
@@ -512,7 +510,7 @@ mod tests {
 
         let bytes = FindAccountMetadata::new(ALICE_ID.clone(), Name::from_str("Bytes")?)
             .execute(&state.view())?;
-        assert_eq!(JsonString::from(vec![1_u32, 2_u32, 3_u32,]), bytes,);
+        assert_eq!(JsonValue::from(vec![1, 2, 3]), bytes,);
         Ok(())
     }
 
@@ -654,7 +652,7 @@ mod tests {
         let kura = Kura::blank_kura_for_testing();
         let state = {
             let mut metadata = Metadata::default();
-            metadata.insert(Name::from_str("Bytes")?, vec![1_u32, 2_u32, 3_u32]);
+            metadata.insert(Name::from_str("Bytes")?, vec![1, 2, 3]);
             let domain = Domain::new(DomainId::from_str("wonderland")?)
                 .with_metadata(metadata)
                 .build(&ALICE_ID);
@@ -672,7 +670,7 @@ mod tests {
         let domain_id = DomainId::from_str("wonderland")?;
         let key = Name::from_str("Bytes")?;
         let bytes = FindDomainMetadata::new(domain_id, key).execute(&state.view())?;
-        assert_eq!(JsonString::from(vec![1_u32, 2_u32, 3_u32,]), bytes,);
+        assert_eq!(JsonValue::from(vec![1, 2, 3]), bytes,);
         Ok(())
     }
 }

--- a/core/src/smartcontracts/isi/triggers/mod.rs
+++ b/core/src/smartcontracts/isi/triggers/mod.rs
@@ -328,7 +328,7 @@ pub mod query {
         },
         trigger::{Trigger, TriggerId},
     };
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
 
     use super::*;
     use crate::{
@@ -379,7 +379,7 @@ pub mod query {
 
     impl ValidSingularQuery for FindTriggerMetadata {
         #[metrics(+"find_trigger_key_value_by_id_and_key")]
-        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonString, Error> {
+        fn execute(&self, state_ro: &impl StateReadOnly) -> Result<JsonValue, Error> {
             let id = &self.id;
             let key = &self.key;
             iroha_logger::trace!(%id, %key);

--- a/core/src/smartcontracts/isi/world.rs
+++ b/core/src/smartcontracts/isi/world.rs
@@ -25,7 +25,7 @@ pub mod isi {
         query::error::FindError,
         Level,
     };
-    use iroha_primitives::{json::JsonString, unique_vec::PushResult};
+    use iroha_primitives::{json::JsonValue, unique_vec::PushResult};
 
     use super::*;
 
@@ -360,7 +360,7 @@ pub mod isi {
 
                                     CustomParameter {
                                         id: next.id.clone(),
-                                        payload: JsonString::default(),
+                                        payload: JsonValue::default(),
                                     }
                                 });
 

--- a/data_model/src/events/data/events.rs
+++ b/data_model/src/events/data/events.rs
@@ -3,7 +3,7 @@
 
 use getset::Getters;
 use iroha_data_model_derive::{model, EventSet, HasOrigin};
-use iroha_primitives::{json::JsonString, numeric::Numeric};
+use iroha_primitives::{json::JsonValue, numeric::Numeric};
 
 pub use self::model::*;
 use super::*;
@@ -60,7 +60,7 @@ mod model {
     pub struct MetadataChanged<Id> {
         pub target: Id,
         pub key: Name,
-        pub value: JsonString,
+        pub value: JsonValue,
     }
 
     /// Event
@@ -653,7 +653,7 @@ impl<Id> MetadataChanged<Id> {
     }
 
     /// Getter for `value`
-    pub fn value(&self) -> &JsonString {
+    pub fn value(&self) -> &JsonValue {
         &self.value
     }
 }

--- a/data_model/src/events/execute_trigger.rs
+++ b/data_model/src/events/execute_trigger.rs
@@ -35,7 +35,7 @@ mod model {
         pub authority: AccountId,
         /// Args to pass for trigger execution
         #[getset(skip)]
-        pub args: Option<JsonString>,
+        pub args: Option<JsonValueWrap>,
     }
 
     /// Filter for trigger execution [`Event`]
@@ -64,8 +64,8 @@ mod model {
 
 impl ExecuteTriggerEvent {
     /// Args to pass for trigger execution
-    pub fn args(&self) -> Option<&JsonString> {
-        self.args.as_ref()
+    pub fn args(&self) -> Option<&JsonValue> {
+        self.args.as_ref().map(|wrapped| &wrapped.value)
     }
 }
 

--- a/data_model/src/executor.rs
+++ b/data_model/src/executor.rs
@@ -6,7 +6,7 @@ use alloc::{collections::BTreeSet, format, string::String, vec::Vec};
 use std::collections::BTreeSet;
 
 use iroha_data_model_derive::model;
-use iroha_primitives::json::JsonString;
+use iroha_primitives::json::JsonValue;
 use iroha_schema::{Ident, IntoSchema};
 
 pub use self::model::*;
@@ -89,7 +89,7 @@ mod model {
         /// Ids of permission tokens supported by the executor.
         pub permissions: BTreeSet<Ident>,
         /// Schema of executor defined data types (instructions, parameters, permissions)
-        pub schema: JsonString,
+        pub schema: JsonValue,
     }
 
     // TODO: Client doesn't need structures defined inside this macro. When dynamic linking is
@@ -105,7 +105,7 @@ impl ExecutorDataModel {
     }
 
     /// Getter
-    pub fn schema(&self) -> &JsonString {
+    pub fn schema(&self) -> &JsonValue {
         &self.schema
     }
 }

--- a/data_model/src/isi.rs
+++ b/data_model/src/isi.rs
@@ -189,7 +189,7 @@ impl BuiltInInstruction for InstructionBox {
 }
 
 mod transparent {
-    use iroha_primitives::json::JsonString;
+    use iroha_primitives::json::JsonValue;
 
     use super::*;
     use crate::{account::NewAccount, domain::NewDomain, metadata::Metadata};
@@ -271,13 +271,13 @@ mod transparent {
             /// Key.
             pub key: Name,
             /// Value.
-            pub value: JsonString,
+            pub value: JsonValue,
         }
     }
 
     impl SetKeyValue<Domain> {
         /// Constructs a new [`SetKeyValue`] for a [`Domain`] with the given `key` and `value`.
-        pub fn domain(domain_id: DomainId, key: Name, value: impl Into<JsonString>) -> Self {
+        pub fn domain(domain_id: DomainId, key: Name, value: impl Into<JsonValue>) -> Self {
             Self {
                 object: domain_id,
                 key,
@@ -288,7 +288,7 @@ mod transparent {
 
     impl SetKeyValue<Account> {
         /// Constructs a new [`SetKeyValue`] for an [`Account`] with the given `key` and `value`.
-        pub fn account(account_id: AccountId, key: Name, value: impl Into<JsonString>) -> Self {
+        pub fn account(account_id: AccountId, key: Name, value: impl Into<JsonValue>) -> Self {
             Self {
                 object: account_id,
                 key,
@@ -302,7 +302,7 @@ mod transparent {
         pub fn asset_definition(
             asset_definition_id: AssetDefinitionId,
             key: Name,
-            value: impl Into<JsonString>,
+            value: impl Into<JsonValue>,
         ) -> Self {
             Self {
                 object: asset_definition_id,
@@ -314,7 +314,7 @@ mod transparent {
 
     impl SetKeyValue<Asset> {
         /// Constructs a new [`SetKeyValue`] for an [`Asset`] with the given `key` and `value`.
-        pub fn asset(asset_id: AssetId, key: Name, value: impl Into<JsonString>) -> Self {
+        pub fn asset(asset_id: AssetId, key: Name, value: impl Into<JsonValue>) -> Self {
             Self {
                 object: asset_id,
                 key,
@@ -325,7 +325,7 @@ mod transparent {
 
     impl SetKeyValue<Trigger> {
         /// Constructs a new [`SetKeyValue`] for a [`Trigger`] with the given `key` and `value`.
-        pub fn trigger(trigger_id: TriggerId, key: Name, value: impl Into<JsonString>) -> Self {
+        pub fn trigger(trigger_id: TriggerId, key: Name, value: impl Into<JsonValue>) -> Self {
             Self {
                 object: trigger_id,
                 key,
@@ -930,7 +930,7 @@ mod transparent {
             /// Id of a trigger to execute
             pub trigger: TriggerId,
             /// Arguments to trigger execution
-            pub args: Option<JsonString>,
+            pub args: Option<JsonValueWrap>,
         }
     }
 
@@ -945,8 +945,8 @@ mod transparent {
 
         /// Add trigger execution args
         #[must_use]
-        pub fn with_args<T: serde::Serialize>(mut self, args: &T) -> Self {
-            self.args = Some(JsonString::new(args));
+        pub fn with_args(mut self, args: impl Into<JsonValue>) -> Self {
+            self.args = Some(JsonValueWrap { value: args.into() });
             self
         }
     }
@@ -992,13 +992,13 @@ mod transparent {
         #[display(fmt = "CUSTOM({payload})")]
         pub struct CustomInstruction {
             /// Custom payload
-            pub payload: JsonString,
+            pub payload: JsonValue,
         }
     }
 
     impl CustomInstruction {
         /// Constructor
-        pub fn new(payload: impl Into<JsonString>) -> Self {
+        pub fn new(payload: impl Into<JsonValue>) -> Self {
             Self {
                 payload: payload.into(),
             }

--- a/data_model/src/metadata.rs
+++ b/data_model/src/metadata.rs
@@ -7,7 +7,7 @@ use core::borrow::Borrow;
 use std::collections::BTreeMap;
 
 use iroha_data_model_derive::model;
-use iroha_primitives::json::JsonString;
+use iroha_primitives::json::JsonValue;
 
 pub use self::model::*;
 use crate::prelude::Name;
@@ -46,7 +46,7 @@ mod model {
     #[serde(transparent)]
     #[display(fmt = "Metadata")]
     #[allow(clippy::multiple_inherent_impl)]
-    pub struct Metadata(pub(super) BTreeMap<Name, JsonString>);
+    pub struct Metadata(pub(super) BTreeMap<Name, JsonValue>);
 }
 
 impl Metadata {
@@ -56,13 +56,13 @@ impl Metadata {
     }
 
     /// Iterate over key/value pairs stored in the internal map.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&Name, &JsonString)> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&Name, &JsonValue)> {
         self.0.iter()
     }
 
     /// Get the `Some(&Value)` associated to `key`. Return `None` if not found.
     #[inline]
-    pub fn get<K: Ord + ?Sized>(&self, key: &K) -> Option<&JsonString>
+    pub fn get<K: Ord + ?Sized>(&self, key: &K) -> Option<&JsonValue>
     where
         Name: Borrow<K>,
     {
@@ -71,7 +71,7 @@ impl Metadata {
 
     /// Insert [`Value`] under the given key.  Returns `Some(value)`
     /// if the value was already present, `None` otherwise.
-    pub fn insert(&mut self, key: Name, value: impl Into<JsonString>) -> Option<JsonString> {
+    pub fn insert(&mut self, key: Name, value: impl Into<JsonValue>) -> Option<JsonValue> {
         self.0.insert(key, value.into())
     }
 }
@@ -82,7 +82,7 @@ impl Metadata {
     /// `Some(value)` at the key if the key was previously in the
     /// map, else `None`.
     #[inline]
-    pub fn remove<K: Ord + ?Sized>(&mut self, key: &K) -> Option<JsonString>
+    pub fn remove<K: Ord + ?Sized>(&mut self, key: &K) -> Option<JsonValue>
     where
         Name: Borrow<K>,
     {

--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -6,7 +6,7 @@ use core::{num::NonZeroU64, time::Duration};
 use std::collections::btree_map;
 
 use iroha_data_model_derive::model;
-use iroha_primitives::json::JsonString;
+use iroha_primitives::json::JsonValue;
 use nonzero_ext::nonzero;
 
 pub use self::model::*;
@@ -218,7 +218,7 @@ mod model {
         ///
         /// It is JSON-encoded, and its structure must correspond to the structure of
         /// the type defined in [`crate::executor::ExecutorDataModel`].
-        pub payload: JsonString,
+        pub payload: JsonValue,
     }
 
     /// Set of all current blockchain parameter values
@@ -463,7 +463,7 @@ impl CustomParameterId {
 
 impl CustomParameter {
     /// Constructor
-    pub fn new(id: CustomParameterId, payload: impl Into<JsonString>) -> Self {
+    pub fn new(id: CustomParameterId, payload: impl Into<JsonValue>) -> Self {
         Self {
             id,
             payload: payload.into(),
@@ -472,7 +472,7 @@ impl CustomParameter {
 
     /// Getter
     // TODO: derive with getset once FFI impl is fixed
-    pub fn payload(&self) -> &JsonString {
+    pub fn payload(&self) -> &JsonValue {
         &self.payload
     }
 }

--- a/data_model/src/permission.rs
+++ b/data_model/src/permission.rs
@@ -5,7 +5,7 @@ use alloc::{collections::BTreeSet, format, string::String, vec::Vec};
 use std::collections::BTreeSet;
 
 use iroha_data_model_derive::model;
-use iroha_primitives::json::JsonString;
+use iroha_primitives::json::JsonValue;
 use iroha_schema::{Ident, IntoSchema};
 
 pub use self::model::*;
@@ -45,13 +45,13 @@ mod model {
         ///
         /// It is JSON-encoded, and its structure must correspond to the structure of
         /// the type defined in [`crate::executor::ExecutorDataModel`].
-        pub payload: JsonString,
+        pub payload: JsonValue,
     }
 }
 
 impl Permission {
     /// Constructor
-    pub fn new(name: Ident, payload: impl Into<JsonString>) -> Self {
+    pub fn new(name: Ident, payload: impl Into<JsonValue>) -> Self {
         Self {
             name,
             payload: payload.into(),
@@ -65,7 +65,7 @@ impl Permission {
 
     /// Getter
     // TODO: derive with getset once FFI impl is fixed
-    pub fn payload(&self) -> &JsonString {
+    pub fn payload(&self) -> &JsonValue {
         &self.payload
     }
 }

--- a/data_model/src/query/mod.rs
+++ b/data_model/src/query/mod.rs
@@ -9,7 +9,7 @@ use derive_more::Constructor;
 use iroha_crypto::{PublicKey, SignatureOf};
 use iroha_data_model_derive::model;
 use iroha_macro::FromVariant;
-use iroha_primitives::{json::JsonString, numeric::Numeric};
+use iroha_primitives::{json::JsonValue, numeric::Numeric};
 use iroha_schema::IntoSchema;
 use iroha_version::prelude::*;
 use parameters::{ForwardCursor, QueryParams, MAX_FETCH_SIZE};
@@ -155,7 +155,7 @@ mod model {
     pub enum SingularQueryOutputBox {
         Numeric(Numeric),
         ExecutorDataModel(crate::executor::ExecutorDataModel),
-        JsonString(JsonString),
+        JsonValue(JsonValue),
         Trigger(crate::trigger::Trigger),
         Parameters(Parameters),
         Transaction(TransactionQueryOutput),
@@ -565,15 +565,15 @@ impl_iter_queries! {
 }
 
 impl_singular_queries! {
-    FindAccountMetadata => JsonString,
+    FindAccountMetadata => JsonValue,
     FindAssetQuantityById => Numeric,
     FindTotalAssetQuantityByAssetDefinitionId => Numeric,
-    FindAssetMetadata => JsonString,
-    FindAssetDefinitionMetadata => JsonString,
-    FindDomainMetadata => JsonString,
+    FindAssetMetadata => JsonValue,
+    FindAssetDefinitionMetadata => JsonValue,
+    FindDomainMetadata => JsonValue,
     FindParameters => crate::parameter::Parameters,
     FindTriggerById => crate::trigger::Trigger,
-    FindTriggerMetadata => JsonString,
+    FindTriggerMetadata => JsonValue,
     FindTransactionByHash => TransactionQueryOutput,
     FindBlockHeaderByHash => crate::block::BlockHeader,
     FindExecutorDataModel => crate::executor::ExecutorDataModel,

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -1358,7 +1358,7 @@
     "Struct": [
       {
         "name": "payload",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -1370,7 +1370,7 @@
       },
       {
         "name": "payload",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -1698,7 +1698,7 @@
       },
       {
         "name": "args",
-        "type": "Option<JsonString>"
+        "type": "Option<JsonValueWrap>"
       }
     ]
   },
@@ -1714,7 +1714,7 @@
       },
       {
         "name": "args",
-        "type": "Option<JsonString>"
+        "type": "Option<JsonValueWrap>"
       }
     ]
   },
@@ -1767,7 +1767,7 @@
       },
       {
         "name": "schema",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2374,7 +2374,15 @@
   "IpfsPath": "String",
   "Ipv4Addr": "Array<u8, 4>",
   "Ipv6Addr": "Array<u16, 8>",
-  "JsonString": "String",
+  "JsonValue": "JsonValue",
+  "JsonValueWrap": {
+    "Struct": [
+      {
+        "name": "value",
+        "type": "JsonValue"
+      }
+    ]
+  },
   "Level": {
     "Enum": [
       {
@@ -2447,7 +2455,7 @@
   "MerkleTree<SignedTransaction>": {
     "Vec": "HashOf<SignedTransaction>"
   },
-  "Metadata": "SortedMap<Name, JsonString>",
+  "Metadata": "SortedMap<Name, JsonValue>",
   "MetadataChanged<AccountId>": {
     "Struct": [
       {
@@ -2460,7 +2468,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2476,7 +2484,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2492,7 +2500,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2508,7 +2516,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2524,7 +2532,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -2711,8 +2719,8 @@
   "Option<IpfsPath>": {
     "Option": "IpfsPath"
   },
-  "Option<JsonString>": {
-    "Option": "JsonString"
+  "Option<JsonValueWrap>": {
+    "Option": "JsonValueWrap"
   },
   "Option<Name>": {
     "Option": "Name"
@@ -2911,7 +2919,7 @@
       },
       {
         "name": "payload",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -3837,7 +3845,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -3853,7 +3861,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -3869,7 +3877,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -3885,7 +3893,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -3901,7 +3909,7 @@
       },
       {
         "name": "value",
-        "type": "JsonString"
+        "type": "JsonValue"
       }
     ]
   },
@@ -4089,9 +4097,9 @@
         "type": "ExecutorDataModel"
       },
       {
-        "tag": "JsonString",
+        "tag": "JsonValue",
         "discriminant": 2,
-        "type": "JsonString"
+        "type": "JsonValue"
       },
       {
         "tag": "Trigger",
@@ -4202,10 +4210,10 @@
       "value": "CustomParameter"
     }
   },
-  "SortedMap<Name, JsonString>": {
+  "SortedMap<Name, JsonValue>": {
     "Map": {
       "key": "Name",
-      "value": "JsonString"
+      "value": "JsonValue"
     }
   },
   "SortedVec<Permission>": {

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -155,7 +155,7 @@ types!(
     Box<CompoundPredicate<TriggerIdPredicateBox>>,
     Box<TransactionRejectionReason>,
     BTreeMap<CustomParameterId, CustomParameter>,
-    BTreeMap<Name, JsonString>,
+    BTreeMap<Name, JsonValue>,
     BTreeSet<Permission>,
     BTreeSet<String>,
     BurnBox,
@@ -277,7 +277,8 @@ types!(
     QueryWithFilter<FindRolesByAccountId, RoleIdPredicateBox>,
     QueryWithFilter<FindTransactionsByAccountId, TransactionQueryOutputPredicateBox>,
     QueryWithParams,
-    JsonString,
+    JsonValue,
+    JsonValueWrap,
     Level,
     Log,
     MathError,
@@ -313,7 +314,7 @@ types!(
     Option<HashOf<BlockHeader>>,
     Option<HashOf<SignedTransaction>>,
     Option<IpfsPath>,
-    Option<JsonString>,
+    Option<JsonValueWrap>,
     Option<Name>,
     Option<NonZeroU32>,
     Option<NonZeroU64>,
@@ -545,7 +546,7 @@ pub mod complete_data_model {
         addr::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrHost, SocketAddrV4, SocketAddrV6},
         const_vec::ConstVec,
         conststr::ConstString,
-        json::JsonString,
+        json::{JsonValue, JsonValueWrap},
     };
     pub use iroha_schema::Compact;
 }
@@ -734,5 +735,17 @@ mod tests {
         let mut schemas = super::build_schemas();
         <Vec<PublicKey>>::update_schema_map(&mut schemas);
         <BTreeSet<SignedTransactionV1>>::update_schema_map(&mut schemas);
+    }
+
+    #[test]
+    fn no_option_json_value() {
+        let map = super::build_schemas();
+
+        if map
+            .into_iter()
+            .any(|(_, (id, _))| id == "Option<JsonValue>")
+        {
+            panic!("Using `Option<JsonValue>` is not allowed. Use `Option<JsonValueWrap>` instead");
+        }
     }
 }

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -132,6 +132,8 @@ pub enum Metadata {
     String,
     /// Bool
     Bool,
+    /// JsonValue
+    JsonValue,
     /// Number with fixed decimal precision
     FixedPoint(FixedMeta),
     /// Array

--- a/schema/src/serialize.rs
+++ b/schema/src/serialize.rs
@@ -239,6 +239,7 @@ impl Serialize for WithContext<'_, '_, Metadata> {
                 match self.data {
                     Metadata::String => serializer.serialize_str(self.type_name(TypeId::of::<String>())),
                     Metadata::Bool => serializer.serialize_str(self.type_name(TypeId::of::<bool>())),
+                    Metadata::JsonValue => serializer.serialize_str("JsonValue"),
                     Metadata::Option(type_id) => {
                         let mut map = serializer.serialize_map(Some(1))?;
                         map.serialize_entry("Option", self.type_name(*type_id))?;
@@ -281,6 +282,7 @@ impl PartialEq for WithContext<'_, '_, Metadata> {
                 match self.data {
                     Metadata::String => matches!(other.data, Metadata::String),
                     Metadata::Bool => matches!(other.data, Metadata::Bool),
+                    Metadata::JsonValue => matches!(other.data, Metadata::JsonValue),
                     Metadata::Int(self_meta) => {
                         if let Metadata::Int(other_meta) = other.data {
                             return self_meta == other_meta

--- a/smart_contract/Cargo.toml
+++ b/smart_contract/Cargo.toml
@@ -22,6 +22,7 @@ iroha_data_model.workspace = true
 iroha_smart_contract_utils.workspace = true
 
 parity-scale-codec.workspace = true
+serde_json.workspace = true
 derive_more.workspace = true
 
 displaydoc.workspace = true

--- a/smart_contract/executor/data_model/derive/src/parameter.rs
+++ b/smart_contract/executor/data_model/derive/src/parameter.rs
@@ -22,7 +22,7 @@ pub fn impl_derive_parameter(input: &syn::DeriveInput) -> TokenStream {
                     return Err(Self::Error::UnknownIdent(alloc::string::ToString::to_string(value_id.name().as_ref())));
                 }
 
-                serde_json::from_str::<Self>(value.payload().as_ref()).map_err(Self::Error::Deserialize)
+                serde_json::from_value::<Self>(value.payload().get().clone()).map_err(Self::Error::Deserialize)
             }
         }
 

--- a/smart_contract/executor/data_model/derive/src/permission.rs
+++ b/smart_contract/executor/data_model/derive/src/permission.rs
@@ -22,7 +22,7 @@ pub fn impl_derive_permission(input: &syn::DeriveInput) -> TokenStream {
                     return Err(Self::Error::UnknownIdent(value.name().to_owned()));
                 }
 
-                serde_json::from_str::<Self>(value.payload().as_ref()).map_err(Self::Error::Deserialize)
+                serde_json::from_value::<Self>(value.payload().get().clone()).map_err(Self::Error::Deserialize)
             }
         }
 

--- a/smart_contract/src/lib.rs
+++ b/smart_contract/src/lib.rs
@@ -252,6 +252,7 @@ mod host {
 pub mod prelude {
     pub use iroha_smart_contract_derive::main;
     pub use iroha_smart_contract_utils::debug::DebugUnwrapExt;
+    pub use serde_json;
 
     pub use crate::{data_model::prelude::*, ExecuteOnHost};
 }

--- a/tools/kagami/src/genesis/generate.rs
+++ b/tools/kagami/src/genesis/generate.rs
@@ -91,7 +91,7 @@ pub fn generate_default(
 ) -> color_eyre::Result<RawGenesisTransaction> {
     let genesis_account_id = AccountId::new(GENESIS_DOMAIN_ID.clone(), genesis_public_key);
     let mut meta = Metadata::default();
-    meta.insert("key".parse()?, JsonString::new("value"));
+    meta.insert("key".parse()?, "value");
 
     let mut builder = builder
         .domain_with_metadata("wonderland".parse()?, meta.clone())

--- a/tools/parity_scale_cli/Cargo.toml
+++ b/tools/parity_scale_cli/Cargo.toml
@@ -24,7 +24,7 @@ clap = { workspace = true, features = ["derive", "cargo", "env", "string"] }
 eyre = { workspace = true }
 parity-scale-codec = { workspace = true }
 colored = "2.1.0"
-serde_json = { workspace = true, features = ["std"]}
+serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 supports-color = { workspace = true }
 
@@ -32,7 +32,7 @@ supports-color = { workspace = true }
 iroha_data_model = { workspace = true }
 
 parity-scale-codec = { workspace = true }
-serde_json = { workspace = true, features = ["std"]}
+serde_json = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 eyre = { workspace = true }
 

--- a/tools/parity_scale_cli/src/main.rs
+++ b/tools/parity_scale_cli/src/main.rs
@@ -306,7 +306,6 @@ mod tests {
     use std::str::FromStr as _;
 
     use iroha_data_model::{ipfs::IpfsPath, prelude::*};
-    
     use test_samples::ALICE_ID;
 
     use super::*;

--- a/tools/parity_scale_cli/src/main.rs
+++ b/tools/parity_scale_cli/src/main.rs
@@ -306,6 +306,7 @@ mod tests {
     use std::str::FromStr as _;
 
     use iroha_data_model::{ipfs::IpfsPath, prelude::*};
+    
     use test_samples::ALICE_ID;
 
     use super::*;
@@ -313,10 +314,7 @@ mod tests {
     #[test]
     fn decode_account_sample() {
         let mut metadata = Metadata::default();
-        metadata.insert(
-            "hat".parse().expect("Valid"),
-            "white".parse::<JsonString>().expect("Valid"),
-        );
+        metadata.insert("hat".parse().expect("Valid"), "white");
         let account = Account::new(ALICE_ID.clone()).with_metadata(metadata);
 
         decode_sample("account.bin", String::from("NewAccount"), &account);

--- a/wasm_samples/executor_custom_data_model/src/complex_isi.rs
+++ b/wasm_samples/executor_custom_data_model/src/complex_isi.rs
@@ -12,7 +12,7 @@ mod isi {
 
     use iroha_data_model::{
         isi::{CustomInstruction, Instruction, InstructionBox},
-        prelude::JsonString,
+        prelude::JsonValue,
     };
     use iroha_schema::IntoSchema;
     use serde::{Deserialize, Serialize};
@@ -69,11 +69,11 @@ mod isi {
         }
     }
 
-    impl TryFrom<&JsonString> for CustomInstructionExpr {
+    impl TryFrom<&JsonValue> for CustomInstructionExpr {
         type Error = serde_json::Error;
 
-        fn try_from(payload: &JsonString) -> serde_json::Result<Self> {
-            serde_json::from_str::<Self>(payload.as_ref())
+        fn try_from(payload: &JsonValue) -> serde_json::Result<Self> {
+            serde_json::from_value(payload.get().clone())
         }
     }
 

--- a/wasm_samples/executor_custom_data_model/src/simple_isi.rs
+++ b/wasm_samples/executor_custom_data_model/src/simple_isi.rs
@@ -6,7 +6,7 @@ use alloc::{format, string::String, vec::Vec};
 use iroha_data_model::{
     asset::AssetDefinitionId,
     isi::{CustomInstruction, Instruction, InstructionBox},
-    prelude::{JsonString, Numeric},
+    prelude::{JsonValue, Numeric},
 };
 use iroha_schema::IntoSchema;
 use serde::{Deserialize, Serialize};
@@ -53,10 +53,10 @@ impl From<CustomInstructionBox> for InstructionBox {
     }
 }
 
-impl TryFrom<&JsonString> for CustomInstructionBox {
+impl TryFrom<&JsonValue> for CustomInstructionBox {
     type Error = serde_json::Error;
 
-    fn try_from(payload: &JsonString) -> serde_json::Result<Self> {
-        serde_json::from_str::<Self>(payload.as_ref())
+    fn try_from(payload: &JsonValue) -> serde_json::Result<Self> {
+        serde_json::from_value(payload.get().clone())
     }
 }

--- a/wasm_samples/mint_rose_trigger_args/src/lib.rs
+++ b/wasm_samples/mint_rose_trigger_args/src/lib.rs
@@ -27,6 +27,7 @@ fn main(_id: TriggerId, owner: AccountId, event: EventBox) {
         EventBox::ExecuteTrigger(event) => event
             .args()
             .dbg_expect("Trigger expect parameters")
+            .clone()
             .try_into_any()
             .dbg_expect("Failed to parse args"),
         _ => dbg_panic("Only work as by call trigger"),

--- a/wasm_samples/multisig/src/lib.rs
+++ b/wasm_samples/multisig/src/lib.rs
@@ -11,6 +11,7 @@ use alloc::{collections::btree_set::BTreeSet, format, vec::Vec};
 use dlmalloc::GlobalDlmalloc;
 use executor_custom_data_model::multisig::MultisigArgs;
 use iroha_trigger::{debug::dbg_panic, prelude::*, smart_contract::query_single};
+use serde_json::json;
 
 #[global_allocator]
 static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
@@ -24,6 +25,7 @@ fn main(id: TriggerId, _owner: AccountId, event: EventBox) {
             event
                 .args()
                 .dbg_expect("trigger expect args")
+                .clone()
                 .try_into_any()
                 .dbg_expect("failed to parse arguments"),
             event.authority().clone(),
@@ -52,18 +54,14 @@ fn main(id: TriggerId, _owner: AccountId, event: EventBox) {
             SetKeyValue::trigger(
                 id.clone(),
                 instructions_metadata_key.clone(),
-                JsonString::new(&instructions),
+                json!(&instructions),
             )
             .execute()
             .dbg_unwrap();
 
-            SetKeyValue::trigger(
-                id.clone(),
-                votes_metadata_key.clone(),
-                JsonString::new(&votes),
-            )
-            .execute()
-            .dbg_unwrap();
+            SetKeyValue::trigger(id.clone(), votes_metadata_key.clone(), json!(&votes))
+                .execute()
+                .dbg_unwrap();
 
             (votes, instructions)
         }
@@ -78,13 +76,9 @@ fn main(id: TriggerId, _owner: AccountId, event: EventBox) {
 
             votes.insert(signatory.clone());
 
-            SetKeyValue::trigger(
-                id.clone(),
-                votes_metadata_key.clone(),
-                JsonString::new(&votes),
-            )
-            .execute()
-            .dbg_unwrap();
+            SetKeyValue::trigger(id.clone(), votes_metadata_key.clone(), json!(&votes))
+                .execute()
+                .dbg_unwrap();
 
             let instructions: Vec<InstructionBox> = query_single(FindTriggerMetadata::new(
                 id.clone(),

--- a/wasm_samples/multisig_register/src/lib.rs
+++ b/wasm_samples/multisig_register/src/lib.rs
@@ -12,6 +12,7 @@ use dlmalloc::GlobalDlmalloc;
 use executor_custom_data_model::multisig::MultisigRegisterArgs;
 use iroha_executor_data_model::permission::trigger::CanExecuteUserTrigger;
 use iroha_trigger::{debug::dbg_panic, prelude::*};
+use serde_json::json;
 
 #[global_allocator]
 static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
@@ -27,6 +28,7 @@ fn main(_id: TriggerId, _owner: AccountId, event: EventBox) {
         EventBox::ExecuteTrigger(event) => event
             .args()
             .dbg_expect("trigger expect args")
+            .clone()
             .try_into_any()
             .dbg_expect("failed to parse args"),
         _ => dbg_panic("Only work as by call trigger"),
@@ -81,7 +83,7 @@ fn main(_id: TriggerId, _owner: AccountId, event: EventBox) {
     SetKeyValue::trigger(
         trigger_id,
         "signatories".parse().unwrap(),
-        JsonString::new(&args.signatories),
+        json!(&args.signatories),
     )
     .execute()
     .dbg_unwrap();

--- a/wasm_samples/query_assets_and_save_cursor/src/lib.rs
+++ b/wasm_samples/query_assets_and_save_cursor/src/lib.rs
@@ -20,6 +20,7 @@ use iroha_smart_contract::{
 };
 use nonzero_ext::nonzero;
 use parity_scale_codec::{Decode, DecodeAll, Encode};
+use serde_json::json;
 
 #[global_allocator]
 static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
@@ -50,11 +51,7 @@ fn main(owner: AccountId) {
     let asset_cursor =
         SmartContractQueryCursor::decode_all(&mut &cursor.dbg_unwrap().encode()[..]).dbg_unwrap();
 
-    SetKeyValue::account(
-        owner,
-        "cursor".parse().unwrap(),
-        JsonString::new(asset_cursor.cursor),
-    )
-    .execute()
-    .dbg_expect("Failed to save cursor to the owner's metadata");
+    SetKeyValue::account(owner, "cursor".parse().unwrap(), json!(asset_cursor.cursor))
+        .execute()
+        .dbg_expect("Failed to save cursor to the owner's metadata");
 }


### PR DESCRIPTION
## Context

`JsonString` is a type in the schema for arbitrary JSON values. In SCALE it is encoded as a string (hence the name), while in JSON it is inlined as any JSON value.

There are a few issues:

- Ambiguity of `Option<JsonString>` in JSON: it is impossible to distinguish between `None` and `Some("null")`, since both serialize as `null` in actual JSON.
- Schema's purpose is solely to describe SCALE encoding and it doesn't tell anything about `JsonString` representation in JSON. In JSON it is not a string, which caused confusion for SDK developers.

This PR fixes #4900 by disallowing `Option<JsonString>` and essentially forcing SDKs to handle JSON values as a special case and account for its differences in SCALE vs JSON.

### Solution

 by these changes:

- Rename `JsonString` to `JsonValue` and make stronger emphasis on using the native Rust JSON type, i.e. `serde_json::Value`. Remove ambiguous conversions and delegate it to the `serde_json::Value` itself.
- Add `struct JsonValueWrap { value: JsonValue }` for use with `Option` 
- In schema, treat `JsonValue` as a special type, i.e. not as an alias to `String`, and forbid use of `Option<JsonValue>`.

### Migration Guide

There is a breaking change **for SDK developers.** Apart from `JsonString` being renamed to `JsonValue`, it is also no longer an alias to `String` type, but instead is a special type `JsonValue`. SDK should treat it as a special case in a way that is suitable for their platform.

Binary and JSON serialisation compatibility is not broken. However, JSON form of `ExecuteTrigger` instruction and `ExecuteTriggerEvent` changed: its `args` field was an `Option<JsonString>` with ambiguous `null` value. Now it is `Option<JsonValueWrap>`, meaning that you need to use it this way:

```json5
// Before
{ "args": null }
{ "args": 42 }

// After
{ "args": null }
{ "args": { "value": null } }
{ "args": { "value": 42 } }
```

---

### Review notes

- Start from `primitives/json.rs`, then schema, then the rest
- I am not sure about `JsonValue` method names, especially `get(&self) -> &Value`.

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->