### PR TITLE
fix: fix flaky unstable network tests

### DIFF
--- a/client/tests/integration/asset.rs
+++ b/client/tests/integration/asset.rs
@@ -20,8 +20,8 @@ use test_samples::{gen_account_in, ALICE_ID, BOB_ID};
 // This test is also covered at the UI level in the iroha_cli tests
 // in test_register_asset_definitions.py
 fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_620).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_620).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -59,8 +59,8 @@ fn client_register_asset_should_add_asset_once_but_not_twice() -> Result<()> {
 
 #[test]
 fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_555).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_555).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -107,8 +107,8 @@ fn unregister_asset_should_remove_asset_from_account() -> Result<()> {
 // This test is also covered at the UI level in the iroha_cli tests
 // in test_mint_assets.py
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_000).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_000).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -141,8 +141,8 @@ fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount() ->
 
 #[test]
 fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_510).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_510).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -175,8 +175,8 @@ fn client_add_big_asset_quantity_to_existing_asset_should_increase_asset_amount(
 
 #[test]
 fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_515).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_515).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -235,8 +235,8 @@ fn client_add_asset_with_decimal_should_increase_asset_amount() -> Result<()> {
 // This test is also covered at the UI level in the iroha_cli tests
 // in test_register_asset_definitions.py
 fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transaction() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_520).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_520).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
     let pipeline_time = Config::pipeline_time();
 
     // Given
@@ -281,8 +281,8 @@ fn client_add_asset_with_name_length_more_than_limit_should_not_commit_transacti
 #[allow(clippy::expect_fun_call)]
 #[test]
 fn find_rate_and_make_exchange_isi_should_succeed() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_675).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_675).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let (dex_id, _dex_keypair) = gen_account_in("exchange");
     let (seller_id, seller_keypair) = gen_account_in("company");
@@ -375,8 +375,8 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
 
 #[test]
 fn transfer_asset_definition() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_060).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_060).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let bob_id = BOB_ID.clone();
@@ -413,8 +413,8 @@ fn transfer_asset_definition() {
 
 #[test]
 fn fail_if_dont_satisfy_spec() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_125).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_125).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let bob_id = BOB_ID.clone();

--- a/client/tests/integration/asset_propagation.rs
+++ b/client/tests/integration/asset_propagation.rs
@@ -16,8 +16,8 @@ use test_samples::gen_account_in;
 fn client_add_asset_quantity_to_existing_asset_should_increase_asset_amount_on_another_peer(
 ) -> Result<()> {
     // Given
-    let (_rt, network, client) = Network::start_test_with_runtime(4, Some(10_450));
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, client) = Network::start_test_with_runtime(4, Some(10_450));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     let pipeline_time = Config::pipeline_time();
 
     client.submit_blocking(SetParameter::new(Parameter::Block(

--- a/client/tests/integration/events/data.rs
+++ b/client/tests/integration/events/data.rs
@@ -134,8 +134,8 @@ fn transaction_execution_should_produce_events(
     executable: impl Into<Executable>,
     port: u16,
 ) -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(port).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(port).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     // spawn event reporter
     let listener = client.clone();
@@ -178,8 +178,8 @@ fn transaction_execution_should_produce_events(
 #[test]
 #[allow(clippy::too_many_lines)]
 fn produce_multiple_events() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_645).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_645).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     // Spawn event reporter
     let listener = client.clone();

--- a/client/tests/integration/events/notification.rs
+++ b/client/tests/integration/events/notification.rs
@@ -7,8 +7,8 @@ use test_samples::ALICE_ID;
 
 #[test]
 fn trigger_completion_success_should_produce_event() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_050).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_050).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -53,8 +53,8 @@ fn trigger_completion_success_should_produce_event() -> Result<()> {
 
 #[test]
 fn trigger_completion_failure_should_produce_event() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_055).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_055).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let account_id = ALICE_ID.clone();
     let trigger_id = TriggerId::from_str("fail_box")?;

--- a/client/tests/integration/events/pipeline.rs
+++ b/client/tests/integration/events/pipeline.rs
@@ -51,10 +51,10 @@ fn test_with_instruction_and_status_and_port(
     should_be: &TransactionStatus,
     port: u16,
 ) -> Result<()> {
-    let (_rt, network, client) =
+    let (rt, network, client) =
         Network::start_test_with_runtime(PEER_COUNT.try_into().unwrap(), Some(port));
     let clients = network.clients();
-    wait_for_genesis_committed(&clients, 0);
+    rt.block_on(wait_for_genesis_committed_async(&clients));
     let pipeline_time = Config::pipeline_time();
 
     client.submit_blocking(SetParameter::new(Parameter::Block(
@@ -106,8 +106,8 @@ impl Checker {
 
 #[test]
 fn applied_block_must_be_available_in_kura() {
-    let (_rt, peer, client) = <PeerBuilder>::new().with_port(11_040).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, peer, client) = <PeerBuilder>::new().with_port(11_040).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     let event_filter = BlockEventFilter::default().for_status(BlockStatus::Applied);
     let mut event_iter = client

--- a/client/tests/integration/extra_functional/connected_peers.rs
+++ b/client/tests/integration/extra_functional/connected_peers.rs
@@ -30,7 +30,7 @@ fn register_new_peer() -> Result<()> {
     let (rt, network, mut iroha) = Network::start_test_with_runtime(4, Some(11_180));
     iroha.transaction_ttl = Some(Duration::from_millis(u64::MAX));
     iroha.transaction_status_timeout = Duration::from_millis(u64::MAX);
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
 
     let mut peer_clients: Vec<_> = Network::peers(&network)
         .zip(Network::clients(&network))
@@ -81,7 +81,7 @@ fn connected_peers_with_f(faults: u64, start_port: Option<u16>) -> Result<()> {
     );
     iroha.transaction_ttl = Some(Duration::from_millis(u64::MAX));
     iroha.transaction_status_timeout = Duration::from_millis(u64::MAX);
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     let pipeline_time = Config::pipeline_time();
 
     let mut peer_clients: Vec<_> = Network::peers(&network)

--- a/client/tests/integration/extra_functional/connected_peers.rs
+++ b/client/tests/integration/extra_functional/connected_peers.rs
@@ -1,4 +1,4 @@
-use std::{thread, time::Duration};
+use std::time::Duration;
 
 use eyre::{Context, Result};
 use iroha::{
@@ -9,7 +9,7 @@ use iroha::{
     },
 };
 use iroha_config::parameters::actual::Root as Config;
-use iroha_data_model::domain::Domain;
+use iroha_data_model::{domain::Domain, prelude::FindPeers, query::builder::QueryBuilderExt};
 use iroha_primitives::unique_vec;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use test_network::*;
@@ -36,7 +36,7 @@ fn register_new_peer() -> Result<()> {
         .zip(Network::clients(&network))
         .collect();
 
-    check_status(&peer_clients, 1);
+    check_status(&rt, &peer_clients, 1);
 
     // Start new peer
     let mut configuration = Config::test();
@@ -64,7 +64,7 @@ fn register_new_peer() -> Result<()> {
 
     peer_clients.push((&new_peer, new_peer_client));
 
-    check_status(&peer_clients, 3);
+    check_status(&rt, &peer_clients, 3);
 
     Ok(())
 }
@@ -82,33 +82,52 @@ fn connected_peers_with_f(faults: u64, start_port: Option<u16>) -> Result<()> {
     iroha.transaction_ttl = Some(Duration::from_millis(u64::MAX));
     iroha.transaction_status_timeout = Duration::from_millis(u64::MAX);
     rt.block_on(wait_for_genesis_committed_async(&network.clients()));
-    let pipeline_time = Config::pipeline_time();
 
     let mut peer_clients: Vec<_> = Network::peers(&network)
         .zip(Network::clients(&network))
         .collect();
 
-    check_status(&peer_clients, 1);
+    check_status(&rt, &peer_clients, 1);
 
     // Unregister a peer: committed with f = `faults` then `status.peers` decrements
     let removed_peer_idx = rand::thread_rng().gen_range(1..peer_clients.len());
     let (removed_peer, mut removed_peer_client) = peer_clients.remove(removed_peer_idx);
     removed_peer_client.transaction_ttl = Some(Duration::from_millis(u64::MAX));
     removed_peer_client.transaction_status_timeout = Duration::from_millis(u64::MAX);
+
+    // Check that peer is present in topology
+    assert!(iroha
+        .query(FindPeers)
+        .execute_all()?
+        .into_iter()
+        .any(|peer| peer.id == removed_peer.id));
+
     let unregister_peer = Unregister::peer(removed_peer.id.clone());
     iroha.submit_blocking(unregister_peer)?;
 
-    thread::sleep(pipeline_time * 2); // Wait for some time to allow peers to disconnect
+    // Check that peer is removed from topology
+    assert!(iroha
+        .query(FindPeers)
+        .execute_all()?
+        .into_iter()
+        .all(|peer| peer.id != removed_peer.id));
 
-    check_status(&peer_clients, 2);
+    check_status(&rt, &peer_clients, 2);
+
     let status = removed_peer_client.get_status()?;
     // Peer might have been disconnected before getting the block
     assert!(status.blocks == 1 || status.blocks == 2);
-    assert_eq!(status.peers, 0);
 
     // Re-register the peer: committed with f = `faults` - 1 then `status.peers` increments
     let register_peer = Register::peer(DataModelPeer::new(removed_peer.id.clone()));
     iroha.submit_blocking(register_peer)?;
+
+    // Check that peer is present in topology again
+    assert!(iroha
+        .query(FindPeers)
+        .execute_all()?
+        .into_iter()
+        .any(|peer| peer.id == removed_peer.id));
 
     // Submit transaction by reconnected peer to check if it's functioning
     removed_peer_client
@@ -117,18 +136,31 @@ fn connected_peers_with_f(faults: u64, start_port: Option<u16>) -> Result<()> {
 
     peer_clients.push((removed_peer, removed_peer_client));
 
-    check_status(&peer_clients, 4);
+    check_status(&rt, &peer_clients, 4);
 
     Ok(())
 }
 
-fn check_status(peer_clients: &[(&Peer, Client)], expected_blocks: u64) {
+/// Wait for certain amount of blocks and check number of connected peers
+fn check_status(
+    rt: &tokio::runtime::Runtime,
+    peer_clients: &[(&Peer, Client)],
+    expected_blocks: usize,
+) {
     let n_peers = peer_clients.len() as u64;
+
+    let clients = peer_clients
+        .iter()
+        .map(|(_, client)| client)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    rt.block_on(wait_for_blocks_committed_async(&clients, expected_blocks));
 
     for (_, peer_client) in peer_clients {
         let status = peer_client.get_status().unwrap();
 
         assert_eq!(status.peers, n_peers - 1);
-        assert_eq!(status.blocks, expected_blocks);
+        assert_eq!(status.blocks, expected_blocks as u64);
     }
 }

--- a/client/tests/integration/extra_functional/connected_peers.rs
+++ b/client/tests/integration/extra_functional/connected_peers.rs
@@ -27,8 +27,8 @@ fn connected_peers_with_f_1_0_1() -> Result<()> {
 
 #[test]
 fn register_new_peer() -> Result<()> {
-    let (_rt, network, _) = Network::start_test_with_runtime(4, Some(11_180));
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, _) = Network::start_test_with_runtime(4, Some(11_180));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
     let pipeline_time = Config::pipeline_time();
 
     let mut peer_clients: Vec<_> = Network::peers(&network)
@@ -68,13 +68,13 @@ fn register_new_peer() -> Result<()> {
 fn connected_peers_with_f(faults: u64, start_port: Option<u16>) -> Result<()> {
     let n_peers = 3 * faults + 1;
 
-    let (_rt, network, _) = Network::start_test_with_runtime(
+    let (rt, network, _) = Network::start_test_with_runtime(
         (n_peers)
             .try_into()
             .wrap_err("`faults` argument `u64` value too high, cannot convert to `u32`")?,
         start_port,
     );
-    wait_for_genesis_committed(&network.clients(), 0);
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
     let pipeline_time = Config::pipeline_time();
 
     let mut peer_clients: Vec<_> = Network::peers(&network)

--- a/client/tests/integration/extra_functional/genesis.rs
+++ b/client/tests/integration/extra_functional/genesis.rs
@@ -2,7 +2,7 @@ use iroha::data_model::{
     domain::{Domain, DomainId},
     isi::Register,
 };
-use test_network::{wait_for_genesis_committed, NetworkBuilder};
+use test_network::{wait_for_genesis_committed_async, NetworkBuilder};
 
 #[test]
 fn all_peers_submit_genesis() {
@@ -20,10 +20,10 @@ fn multiple_genesis_4_peers_2_genesis() {
 }
 
 fn multiple_genesis_peers(n_peers: u32, n_genesis_peers: u32, port: u16) {
-    let (_rt, network, client) = NetworkBuilder::new(n_peers, Some(port))
+    let (rt, network, client) = NetworkBuilder::new(n_peers, Some(port))
         .with_genesis_peers(n_genesis_peers)
         .create_with_runtime();
-    wait_for_genesis_committed(&network.clients(), 0);
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
 
     let domain_id: DomainId = "foo".parse().expect("Valid");
     let create_domain = Register::domain(Domain::new(domain_id));

--- a/client/tests/integration/extra_functional/genesis.rs
+++ b/client/tests/integration/extra_functional/genesis.rs
@@ -23,7 +23,7 @@ fn multiple_genesis_peers(n_peers: u32, n_genesis_peers: u32, port: u16) {
     let (rt, network, client) = NetworkBuilder::new(n_peers, Some(port))
         .with_genesis_peers(n_genesis_peers)
         .create_with_runtime();
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
 
     let domain_id: DomainId = "foo".parse().expect("Valid");
     let create_domain = Register::domain(Domain::new(domain_id));

--- a/client/tests/integration/extra_functional/multiple_blocks_created.rs
+++ b/client/tests/integration/extra_functional/multiple_blocks_created.rs
@@ -16,8 +16,8 @@ const N_BLOCKS: usize = 510;
 #[test]
 fn long_multiple_blocks_created() -> Result<()> {
     // Given
-    let (_rt, network, client) = Network::start_test_with_runtime(4, Some(10_965));
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, client) = Network::start_test_with_runtime(4, Some(10_965));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
     let pipeline_time = Config::pipeline_time();
 
     client.submit_blocking(SetParameter::new(Parameter::Block(

--- a/client/tests/integration/extra_functional/multiple_blocks_created.rs
+++ b/client/tests/integration/extra_functional/multiple_blocks_created.rs
@@ -17,7 +17,7 @@ const N_BLOCKS: usize = 510;
 fn long_multiple_blocks_created() -> Result<()> {
     // Given
     let (rt, network, client) = Network::start_test_with_runtime(4, Some(10_965));
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     let pipeline_time = Config::pipeline_time();
 
     client.submit_blocking(SetParameter::new(Parameter::Block(

--- a/client/tests/integration/extra_functional/normal.rs
+++ b/client/tests/integration/extra_functional/normal.rs
@@ -7,8 +7,8 @@ use test_network::*;
 
 #[test]
 fn tranasctions_should_be_applied() {
-    let (_rt, network, iroha) = NetworkBuilder::new(4, Some(11_300)).create_with_runtime();
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, iroha) = NetworkBuilder::new(4, Some(11_300)).create_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
     iroha
         .submit_blocking(SetParameter::new(Parameter::Block(
             BlockParameter::MaxTransactions(nonzero!(1_u64)),

--- a/client/tests/integration/extra_functional/normal.rs
+++ b/client/tests/integration/extra_functional/normal.rs
@@ -8,7 +8,7 @@ use test_network::*;
 #[test]
 fn tranasctions_should_be_applied() {
     let (rt, network, iroha) = NetworkBuilder::new(4, Some(11_300)).create_with_runtime();
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     iroha
         .submit_blocking(SetParameter::new(Parameter::Block(
             BlockParameter::MaxTransactions(nonzero!(1_u64)),

--- a/client/tests/integration/extra_functional/offline_peers.rs
+++ b/client/tests/integration/extra_functional/offline_peers.rs
@@ -15,10 +15,10 @@ use test_samples::ALICE_ID;
 #[test]
 fn genesis_block_is_committed_with_some_offline_peers() -> Result<()> {
     // Given
-    let (_rt, network, client) = NetworkBuilder::new(4, Some(10_560))
+    let (rt, network, client) = NetworkBuilder::new(4, Some(10_560))
         .with_offline_peers(1)
         .create_with_runtime();
-    wait_for_genesis_committed(&network.clients(), 1);
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 1));
 
     //When
     let alice_id = ALICE_ID.clone();
@@ -42,8 +42,8 @@ fn genesis_block_is_committed_with_some_offline_peers() -> Result<()> {
 fn register_offline_peer() -> Result<()> {
     let n_peers = 4;
 
-    let (_rt, network, client) = Network::start_test_with_runtime(n_peers, Some(11_160));
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, client) = Network::start_test_with_runtime(n_peers, Some(11_160));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
     let pipeline_time = Config::pipeline_time();
     let peer_clients = Network::clients(&network);
 

--- a/client/tests/integration/extra_functional/offline_peers.rs
+++ b/client/tests/integration/extra_functional/offline_peers.rs
@@ -18,7 +18,7 @@ fn genesis_block_is_committed_with_some_offline_peers() -> Result<()> {
     let (rt, network, client) = NetworkBuilder::new(4, Some(10_560))
         .with_offline_peers(1)
         .create_with_runtime();
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 1));
+    rt.block_on(wait_for_genesis_committed_async(&network.online_clients()));
 
     //When
     let alice_id = ALICE_ID.clone();
@@ -43,7 +43,7 @@ fn register_offline_peer() -> Result<()> {
     let n_peers = 4;
 
     let (rt, network, client) = Network::start_test_with_runtime(n_peers, Some(11_160));
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     let pipeline_time = Config::pipeline_time();
     let peer_clients = Network::clients(&network);
 

--- a/client/tests/integration/extra_functional/restart_peer.rs
+++ b/client/tests/integration/extra_functional/restart_peer.rs
@@ -21,7 +21,7 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
         let n_peers = 4;
 
         let (rt, network, _) = Network::start_test_with_runtime(n_peers, Some(11_205));
-        rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+        rt.block_on(wait_for_genesis_committed_async(&network.clients()));
         let pipeline_time = Config::pipeline_time();
         let peer_clients = Network::clients(&network);
 
@@ -75,10 +75,9 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
                 .start_with_peer(&mut removed_peer),
         );
         let removed_peer_client = Client::test(&removed_peer.api_address);
-        rt.block_on(wait_for_genesis_committed_async(
-            &vec![removed_peer_client.clone()],
-            0,
-        ));
+        rt.block_on(wait_for_genesis_committed_async(&[
+            removed_peer_client.clone()
+        ]));
 
         removed_peer_client.poll(|client| {
             let assets = client

--- a/client/tests/integration/extra_functional/restart_peer.rs
+++ b/client/tests/integration/extra_functional/restart_peer.rs
@@ -20,8 +20,8 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
     let mut removed_peer = {
         let n_peers = 4;
 
-        let (_rt, network, _) = Network::start_test_with_runtime(n_peers, Some(11_205));
-        wait_for_genesis_committed(&network.clients(), 0);
+        let (rt, network, _) = Network::start_test_with_runtime(n_peers, Some(11_205));
+        rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
         let pipeline_time = Config::pipeline_time();
         let peer_clients = Network::clients(&network);
 
@@ -75,7 +75,10 @@ fn restarted_peer_should_have_the_same_asset_amount() -> Result<()> {
                 .start_with_peer(&mut removed_peer),
         );
         let removed_peer_client = Client::test(&removed_peer.api_address);
-        wait_for_genesis_committed(&vec![removed_peer_client.clone()], 0);
+        rt.block_on(wait_for_genesis_committed_async(
+            &vec![removed_peer_client.clone()],
+            0,
+        ));
 
         removed_peer_client.poll(|client| {
             let assets = client

--- a/client/tests/integration/extra_functional/unregister_peer.rs
+++ b/client/tests/integration/extra_functional/unregister_peer.rs
@@ -16,7 +16,7 @@ use test_samples::gen_account_in;
 fn unstable_network_stable_after_add_and_after_remove_peer() -> Result<()> {
     // Given a network
     let (rt, network, genesis_client, pipeline_time, account_id, asset_definition_id) = init()?;
-    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
 
     // When assets are minted
     mint(

--- a/client/tests/integration/extra_functional/unregister_peer.rs
+++ b/client/tests/integration/extra_functional/unregister_peer.rs
@@ -16,7 +16,7 @@ use test_samples::gen_account_in;
 fn unstable_network_stable_after_add_and_after_remove_peer() -> Result<()> {
     // Given a network
     let (rt, network, genesis_client, pipeline_time, account_id, asset_definition_id) = init()?;
-    wait_for_genesis_committed(&network.clients(), 0);
+    rt.block_on(wait_for_genesis_committed_async(&network.clients(), 0));
 
     // When assets are minted
     mint(

--- a/client/tests/integration/extra_functional/unstable_network.rs
+++ b/client/tests/integration/extra_functional/unstable_network.rs
@@ -63,7 +63,7 @@ fn unstable_network(
         // Note: it is strange that we have `n_offline_peers` but don't set it as offline
         .with_offline_peers(0)
         .create_with_runtime();
-    rt.block_on(wait_for_genesis_committed_events(
+    rt.block_on(wait_for_genesis_committed_async(
         &network.clients(),
         n_offline_peers,
     ));

--- a/client/tests/integration/extra_functional/unstable_network.rs
+++ b/client/tests/integration/extra_functional/unstable_network.rs
@@ -62,10 +62,7 @@ fn unstable_network(
         // Note: it is strange that we have `n_offline_peers` but don't set it as offline
         .with_offline_peers(0)
         .create_with_runtime();
-    rt.block_on(wait_for_genesis_committed_async(
-        &network.clients(),
-        n_offline_peers,
-    ));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
     // Set ttl to max to prevent the case when transaction got expired before end up in the block
     iroha.transaction_ttl = Some(Duration::from_millis(u64::MAX));
     iroha.transaction_status_timeout = Duration::from_millis(u64::MAX);

--- a/client/tests/integration/extra_functional/unstable_network.rs
+++ b/client/tests/integration/extra_functional/unstable_network.rs
@@ -68,6 +68,7 @@ fn unstable_network(
     ));
     // Set ttl to max to prevent the case when transaction got expired before end up in the block
     iroha.transaction_ttl = Some(Duration::from_millis(u64::MAX));
+    iroha.transaction_status_timeout = Duration::from_millis(u64::MAX);
     iroha
         .submit_blocking(SetParameter::new(Parameter::Block(
             BlockParameter::MaxTransactions(nonzero!(5_u64)),

--- a/client/tests/integration/multisig.rs
+++ b/client/tests/integration/multisig.rs
@@ -17,8 +17,8 @@ use test_samples::{gen_account_in, ALICE_ID};
 
 #[test]
 fn mutlisig() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_400).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_400).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     test_client.submit_all_blocking([
         SetParameter::new(Parameter::SmartContract(SmartContractParameter::Fuel(

--- a/client/tests/integration/non_mintable.rs
+++ b/client/tests/integration/non_mintable.rs
@@ -10,8 +10,8 @@ use test_samples::ALICE_ID;
 
 #[test]
 fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_625).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_625).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -64,8 +64,8 @@ fn non_mintable_asset_can_be_minted_once_but_not_twice() -> Result<()> {
 
 #[test]
 fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_610).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_610).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();
@@ -103,8 +103,8 @@ fn non_mintable_asset_cannot_be_minted_if_registered_with_non_zero_value() -> Re
 
 #[test]
 fn non_mintable_asset_can_be_minted_if_registered_with_zero_value() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_630).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_630).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Given
     let account_id = ALICE_ID.clone();

--- a/client/tests/integration/pagination.rs
+++ b/client/tests/integration/pagination.rs
@@ -8,8 +8,8 @@ use test_network::*;
 
 #[test]
 fn limits_should_work() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_690).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_690).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     register_assets(&client)?;
 
@@ -26,8 +26,8 @@ fn limits_should_work() -> Result<()> {
 
 #[test]
 fn reported_length_should_be_accurate() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_170).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_170).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     register_assets(&client)?;
 
@@ -60,8 +60,8 @@ fn fetch_size_should_work() -> Result<()> {
         QueryWithFilter, QueryWithParams,
     };
 
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_120).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_120).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     register_assets(&client)?;
 

--- a/client/tests/integration/permissions.rs
+++ b/client/tests/integration/permissions.rs
@@ -73,8 +73,8 @@ fn get_assets(iroha: &Client, id: &AccountId) -> Vec<Asset> {
 fn permissions_disallow_asset_transfer() {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_730).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_730).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     // Given
     let alice_id = ALICE_ID.clone();
@@ -177,8 +177,8 @@ fn permissions_disallow_asset_burn() {
 #[test]
 #[ignore = "ignore, more in #2851"]
 fn account_can_query_only_its_own_domain() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_740).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_740).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     // Given
     let domain_id: DomainId = "wonderland".parse()?;
@@ -299,8 +299,8 @@ fn permissions_differ_not_only_by_names() {
 fn stored_vs_granted_permission_payload() -> Result<()> {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_730).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(10_730).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     // Given
     let alice_id = ALICE_ID.clone();
@@ -351,8 +351,8 @@ fn stored_vs_granted_permission_payload() -> Result<()> {
 #[test]
 #[allow(deprecated)]
 fn permissions_are_unified() {
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_230).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_230).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     // Given
     let alice_id = ALICE_ID.clone();
@@ -378,8 +378,8 @@ fn permissions_are_unified() {
 
 #[test]
 fn associated_permissions_removed_on_unregister() {
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_240).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_240).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     let bob_id = BOB_ID.clone();
     let kingdom_id: DomainId = "kingdom".parse().expect("Valid");
@@ -430,8 +430,8 @@ fn associated_permissions_removed_on_unregister() {
 
 #[test]
 fn associated_permissions_removed_from_role_on_unregister() {
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_255).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_255).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     let role_id: RoleId = "role".parse().expect("Valid");
     let kingdom_id: DomainId = "kingdom".parse().expect("Valid");

--- a/client/tests/integration/queries/account.rs
+++ b/client/tests/integration/queries/account.rs
@@ -7,8 +7,8 @@ use test_samples::{gen_account_in, ALICE_ID};
 
 #[test]
 fn find_accounts_with_asset() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_760).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_760).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Registering new asset definition
     let definition_id = AssetDefinitionId::from_str("test_coin#wonderland").expect("Valid");

--- a/client/tests/integration/queries/asset.rs
+++ b/client/tests/integration/queries/asset.rs
@@ -10,8 +10,8 @@ use test_samples::{gen_account_in, ALICE_ID};
 #[test]
 #[allow(clippy::too_many_lines)]
 fn find_asset_total_quantity() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_765).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_765).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     // Register new domain
     let domain_id: DomainId = "looking_glass".parse()?;

--- a/client/tests/integration/queries/mod.rs
+++ b/client/tests/integration/queries/mod.rs
@@ -13,8 +13,8 @@ mod smart_contract;
 
 #[test]
 fn too_big_fetch_size_is_not_allowed() {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_130).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_130).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     let err = client
         .query(client::asset::all())

--- a/client/tests/integration/queries/role.rs
+++ b/client/tests/integration/queries/role.rs
@@ -19,8 +19,8 @@ fn create_role_ids() -> [RoleId; 5] {
 
 #[test]
 fn find_roles() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_525).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_525).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let role_ids = create_role_ids();
 
@@ -51,8 +51,8 @@ fn find_roles() -> Result<()> {
 
 #[test]
 fn find_role_ids() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_530).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_530).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let role_ids = create_role_ids();
 
@@ -77,8 +77,8 @@ fn find_role_ids() -> Result<()> {
 
 #[test]
 fn find_role_by_id() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_535).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_535).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let role_id: RoleId = "root".parse().expect("Valid");
     let new_role = Role::new(role_id.clone());
@@ -100,8 +100,8 @@ fn find_role_by_id() -> Result<()> {
 
 #[test]
 fn find_unregistered_role_by_id() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_540).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_540).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let role_id: RoleId = "root".parse().expect("Valid");
 
@@ -120,8 +120,8 @@ fn find_unregistered_role_by_id() {
 
 #[test]
 fn find_roles_by_account_id() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_545).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_545).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let role_ids = create_role_ids();
     let alice_id = ALICE_ID.clone();

--- a/client/tests/integration/queries/smart_contract.rs
+++ b/client/tests/integration/queries/smart_contract.rs
@@ -9,8 +9,8 @@ use test_network::*;
 
 #[test]
 fn live_query_is_dropped_after_smart_contract_end() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_140).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_140).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     let wasm = iroha_wasm_builder::Builder::new("../wasm_samples/query_assets_and_save_cursor")
         .show_output()
@@ -45,8 +45,8 @@ fn live_query_is_dropped_after_smart_contract_end() -> Result<()> {
 
 #[test]
 fn smart_contract_can_filter_queries() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_260).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_260).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     let wasm =
         iroha_wasm_builder::Builder::new("../wasm_samples/smart_contract_can_filter_queries")

--- a/client/tests/integration/roles.rs
+++ b/client/tests/integration/roles.rs
@@ -13,8 +13,8 @@ use test_samples::{gen_account_in, ALICE_ID};
 
 #[test]
 fn register_empty_role() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_695).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_695).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let role_id = "root".parse().expect("Valid");
     let register_role = Register::role(Role::new(role_id));
@@ -37,8 +37,8 @@ fn register_empty_role() -> Result<()> {
 fn register_and_grant_role_for_metadata_access() -> Result<()> {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_700).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_700).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let (mouse_id, mouse_keypair) = gen_account_in("wonderland");
@@ -85,8 +85,8 @@ fn register_and_grant_role_for_metadata_access() -> Result<()> {
 
 #[test]
 fn unregistered_role_removed_from_account() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_705).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_705).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let role_id: RoleId = "root".parse().expect("Valid");
     let alice_id = ALICE_ID.clone();
@@ -127,8 +127,8 @@ fn unregistered_role_removed_from_account() -> Result<()> {
 
 #[test]
 fn role_with_invalid_permissions_is_not_accepted() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_025).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_025).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let role_id = "ACCESS_TO_ACCOUNT_METADATA".parse()?;
     let role = Role::new(role_id).add_permission(CanControlDomainLives);
@@ -155,8 +155,8 @@ fn role_with_invalid_permissions_is_not_accepted() -> Result<()> {
 // so that they don't get deduplicated eagerly but rather in the executor
 // This way, if the executor compares permissions just as JSON strings, the test will fail
 fn role_permissions_are_deduplicated() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_235).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_235).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let allow_alice_to_transfer_rose_1 = Permission::new(
         "CanTransferUserAsset".parse().unwrap(),
@@ -196,8 +196,8 @@ fn role_permissions_are_deduplicated() {
 fn grant_revoke_role_permissions() -> Result<()> {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_245).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_245).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let (mouse_id, mouse_keypair) = gen_account_in("wonderland");

--- a/client/tests/integration/set_parameter.rs
+++ b/client/tests/integration/set_parameter.rs
@@ -12,8 +12,8 @@ use test_network::*;
 
 #[test]
 fn can_change_parameter_value() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_135).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_135).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let old_params: Parameters = test_client.query_single(client::parameter::all())?;
     assert_eq!(

--- a/client/tests/integration/sorting.rs
+++ b/client/tests/integration/sorting.rs
@@ -31,8 +31,8 @@ fn correct_pagination_assets_after_creating_new_one() {
     let sorting = Sorting::by_metadata_key(sort_by_metadata_key.clone());
     let account_id = ALICE_ID.clone();
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_635).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_635).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let mut tester_assets = vec![];
     let mut register_asset_definitions = vec![];
@@ -117,8 +117,8 @@ fn correct_pagination_assets_after_creating_new_one() {
 #[test]
 #[allow(clippy::too_many_lines)]
 fn correct_sorting_of_entities() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_640).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_640).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let sort_by_metadata_key = Name::from_str("test_sort").expect("Valid");
 
@@ -288,8 +288,8 @@ fn correct_sorting_of_entities() {
 fn sort_only_elements_which_have_sorting_key() -> Result<()> {
     const TEST_DOMAIN: &str = "neverland";
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_680).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_680).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let domain_id: DomainId = TEST_DOMAIN.parse().unwrap();
     test_client

--- a/client/tests/integration/status_response.rs
+++ b/client/tests/integration/status_response.rs
@@ -16,8 +16,8 @@ fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
 
 #[test]
 fn json_and_scale_statuses_equality() -> Result<()> {
-    let (_rt, network, client) = Network::start_test_with_runtime(2, Some(11_200));
-    wait_for_genesis_committed(&network.clients(), 0);
+    let (rt, network, client) = Network::start_test_with_runtime(2, Some(11_200));
+    rt.block_on(wait_for_genesis_committed_async(&network.clients()));
 
     let json_status_zero = get_status_json(&client).unwrap();
 

--- a/client/tests/integration/transfer_asset.rs
+++ b/client/tests/integration/transfer_asset.rs
@@ -30,8 +30,8 @@ fn simulate_transfer_numeric() {
 
 #[test]
 fn simulate_transfer_store_asset() {
-    let (_rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_145).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    let (rt, _peer, iroha) = <PeerBuilder>::new().with_port(11_145).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
     let (alice_id, mouse_id) = generate_two_ids();
     let create_mouse = create_mouse(mouse_id.clone());
     let asset_definition_id: AssetDefinitionId = "camomile#wonderland".parse().unwrap();
@@ -85,10 +85,10 @@ fn simulate_transfer<T>(
     Mint<T, Asset>: Instruction,
     Transfer<Asset, T, Account>: Instruction,
 {
-    let (_rt, _peer, iroha) = <PeerBuilder>::new()
+    let (rt, _peer, iroha) = <PeerBuilder>::new()
         .with_port(port_number)
         .start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     let (alice_id, mouse_id) = generate_two_ids();
     let create_mouse = create_mouse(mouse_id.clone());

--- a/client/tests/integration/transfer_domain.rs
+++ b/client/tests/integration/transfer_domain.rs
@@ -22,8 +22,8 @@ use tokio::runtime::Runtime;
 fn domain_owner_domain_permissions() -> Result<()> {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_080).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_080).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let kingdom_id: DomainId = "kingdom".parse()?;
     let (bob_id, bob_keypair) = gen_account_in("kingdom");
@@ -96,8 +96,8 @@ fn domain_owner_domain_permissions() -> Result<()> {
 
 #[test]
 fn domain_owner_account_permissions() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_075).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_075).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let kingdom_id: DomainId = "kingdom".parse()?;
     let (mad_hatter_id, _mad_hatter_keypair) = gen_account_in("kingdom");
@@ -138,8 +138,8 @@ fn domain_owner_account_permissions() -> Result<()> {
 
 #[test]
 fn domain_owner_asset_definition_permissions() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_085).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_085).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
     let kingdom_id: DomainId = "kingdom".parse()?;
@@ -205,8 +205,8 @@ fn domain_owner_asset_definition_permissions() -> Result<()> {
 fn domain_owner_asset_permissions() -> Result<()> {
     let chain_id = ChainId::from("00000000-0000-0000-0000-000000000000");
 
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_090).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_090).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let kingdom_id: DomainId = "kingdom".parse()?;
@@ -269,8 +269,8 @@ fn domain_owner_asset_permissions() -> Result<()> {
 
 #[test]
 fn domain_owner_trigger_permissions() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_095).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_095).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let kingdom_id: DomainId = "kingdom".parse()?;
@@ -325,8 +325,8 @@ fn domain_owner_trigger_permissions() -> Result<()> {
 
 #[test]
 fn domain_owner_transfer() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_100).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_100).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
     let kingdom_id: DomainId = "kingdom".parse()?;
@@ -389,7 +389,7 @@ fn not_allowed_to_transfer_other_user_domain() -> Result<()> {
     let builder = PeerBuilder::new().with_genesis(genesis).with_port(11_110);
     rt.block_on(builder.start_with_peer(&mut peer));
     let client = Client::test(&peer.api_address);
-    wait_for_genesis_committed(&[client.clone()], 0);
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     let domain = client
         .query(client::domain::all())

--- a/client/tests/integration/triggers/by_call_trigger.rs
+++ b/client/tests/integration/triggers/by_call_trigger.rs
@@ -22,8 +22,8 @@ const TRIGGER_NAME: &str = "mint_rose";
 
 #[test]
 fn call_execute_trigger() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_005).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_005).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -46,8 +46,8 @@ fn call_execute_trigger() -> Result<()> {
 
 #[test]
 fn execute_trigger_should_produce_event() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_010).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_010).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -82,8 +82,8 @@ fn execute_trigger_should_produce_event() -> Result<()> {
 
 #[test]
 fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_015).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_015).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -109,8 +109,8 @@ fn infinite_recursion_should_produce_one_call_per_block() -> Result<()> {
 
 #[test]
 fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_020).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_020).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -166,8 +166,8 @@ fn trigger_failure_should_not_cancel_other_triggers_execution() -> Result<()> {
 
 #[test]
 fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_025).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_025).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -226,8 +226,8 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
 
 #[test]
 fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_030).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_030).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -274,8 +274,8 @@ fn trigger_should_be_able_to_modify_its_own_repeats_count() -> Result<()> {
 #[test]
 fn only_account_with_permission_can_register_trigger() -> Result<()> {
     // Building a configuration
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_035).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_035).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let domain_id = ALICE_ID.domain().clone();
     let alice_account_id = ALICE_ID.clone();
@@ -346,8 +346,8 @@ fn only_account_with_permission_can_register_trigger() -> Result<()> {
 
 #[test]
 fn unregister_trigger() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_040).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_040).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let account_id = ALICE_ID.clone();
 
@@ -450,7 +450,7 @@ fn trigger_in_genesis_using_base64() -> Result<()> {
     let builder = PeerBuilder::new().with_genesis(genesis).with_port(10_045);
     rt.block_on(builder.start_with_peer(&mut peer));
     let mut test_client = Client::test(&peer.api_address);
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let asset_id = AssetId::new(asset_definition_id, account_id);
@@ -476,8 +476,8 @@ fn trigger_in_genesis_using_base64() -> Result<()> {
 
 #[test]
 fn trigger_should_be_able_to_modify_other_trigger() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_085).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_085).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -536,8 +536,8 @@ fn trigger_should_be_able_to_modify_other_trigger() -> Result<()> {
 
 #[test]
 fn trigger_burn_repetitions() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_070).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_070).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();
@@ -572,8 +572,8 @@ fn trigger_burn_repetitions() -> Result<()> {
 #[test]
 fn unregistering_one_of_two_triggers_with_identical_wasm_should_not_cause_original_wasm_loss(
 ) -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_105).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_105).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let account_id = ALICE_ID.clone();
     let first_trigger_id = TriggerId::from_str("mint_rose_1")?;
@@ -655,8 +655,8 @@ fn build_register_trigger_isi(
 
 #[test]
 fn call_execute_trigger_with_args() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(11_265).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(11_265).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();

--- a/client/tests/integration/triggers/data_trigger.rs
+++ b/client/tests/integration/triggers/data_trigger.rs
@@ -5,8 +5,8 @@ use test_samples::{gen_account_in, ALICE_ID};
 
 #[test]
 fn must_execute_both_triggers() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_650).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_650).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
 
     let account_id = ALICE_ID.clone();
     let asset_definition_id = "rose#wonderland".parse()?;

--- a/client/tests/integration/triggers/event_trigger.rs
+++ b/client/tests/integration/triggers/event_trigger.rs
@@ -8,8 +8,8 @@ use test_samples::ALICE_ID;
 
 #[test]
 fn test_mint_asset_when_new_asset_definition_created() -> Result<()> {
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_770).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_770).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse()?;
     let account_id = ALICE_ID.clone();

--- a/client/tests/integration/triggers/orphans.rs
+++ b/client/tests/integration/triggers/orphans.rs
@@ -2,7 +2,7 @@ use iroha::{
     client::{trigger, Client},
     data_model::prelude::*,
 };
-use test_network::{wait_for_genesis_committed, Peer, PeerBuilder};
+use test_network::{wait_for_genesis_committed_async, Peer, PeerBuilder};
 use test_samples::gen_account_in;
 use tokio::runtime::Runtime;
 
@@ -17,7 +17,7 @@ fn set_up_trigger(
     port: u16,
 ) -> eyre::Result<(Runtime, Peer, Client, DomainId, AccountId, TriggerId)> {
     let (rt, peer, iroha) = <PeerBuilder>::new().with_port(port).start_with_runtime();
-    wait_for_genesis_committed(&[iroha.clone()], 0);
+    rt.block_on(wait_for_genesis_committed_async(&[iroha.clone()]));
 
     let failand: DomainId = "failand".parse()?;
     let create_failand = Register::domain(Domain::new(failand.clone()));

--- a/client/tests/integration/triggers/time_trigger.rs
+++ b/client/tests/integration/triggers/time_trigger.rs
@@ -59,8 +59,8 @@ fn time_trigger_execution_count_error_should_be_less_than_15_percent() -> Result
     assert!(PERIOD.as_millis() < default_consensus_estimation().as_millis());
     const_assert!(ACCEPTABLE_ERROR_PERCENT <= 100);
 
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_775).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_775).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
     let start_time = curr_time();
 
     // Start listening BEFORE submitting any transaction not to miss any block committed event
@@ -116,8 +116,8 @@ fn time_trigger_execution_count_error_should_be_less_than_15_percent() -> Result
 
 #[test]
 fn mint_asset_after_3_sec() -> Result<()> {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_665).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(10_665).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
     // Sleep to certainly bypass time interval analyzed by genesis
     std::thread::sleep(default_consensus_estimation());
 
@@ -173,8 +173,8 @@ fn mint_asset_after_3_sec() -> Result<()> {
 fn pre_commit_trigger_should_be_executed() -> Result<()> {
     const CHECKS_COUNT: usize = 5;
 
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_600).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_600).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let asset_definition_id = "rose#wonderland".parse().expect("Valid");
     let account_id = ALICE_ID.clone();
@@ -229,8 +229,8 @@ fn mint_nft_for_every_user_every_1_sec() -> Result<()> {
 
     info!("WASM size is {} bytes", wasm.len());
 
-    let (_rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_780).start_with_runtime();
-    wait_for_genesis_committed(&vec![test_client.clone()], 0);
+    let (rt, _peer, mut test_client) = <PeerBuilder>::new().with_port(10_780).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![test_client.clone()]));
 
     let alice_id = ALICE_ID.clone();
 

--- a/client/tests/integration/triggers/trigger_rollback.rs
+++ b/client/tests/integration/triggers/trigger_rollback.rs
@@ -10,8 +10,8 @@ use test_samples::ALICE_ID;
 
 #[test]
 fn failed_trigger_revert() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_150).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_150).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     //When
     let trigger_id = TriggerId::from_str("trigger")?;

--- a/client/tests/integration/tx_chain_id.rs
+++ b/client/tests/integration/tx_chain_id.rs
@@ -5,8 +5,8 @@ use test_samples::gen_account_in;
 
 #[test]
 fn send_tx_with_different_chain_id() {
-    let (_rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_250).start_with_runtime();
-    wait_for_genesis_committed(&[test_client.clone()], 0);
+    let (rt, _peer, test_client) = <PeerBuilder>::new().with_port(11_250).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[test_client.clone()]));
     // Given
     let (sender_id, sender_keypair) = gen_account_in("wonderland");
     let (receiver_id, _receiver_keypair) = gen_account_in("wonderland");

--- a/client/tests/integration/tx_history.rs
+++ b/client/tests/integration/tx_history.rs
@@ -13,8 +13,8 @@ use test_samples::ALICE_ID;
 #[ignore = "ignore, more in #2851"]
 #[test]
 fn client_has_rejected_and_acepted_txs_should_return_tx_history() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_715).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_715).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     let pipeline_time = Config::pipeline_time();
 

--- a/client/tests/integration/tx_rollback.rs
+++ b/client/tests/integration/tx_rollback.rs
@@ -7,8 +7,8 @@ use test_samples::ALICE_ID;
 
 #[test]
 fn client_sends_transaction_with_invalid_instruction_should_not_see_any_changes() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_720).start_with_runtime();
-    wait_for_genesis_committed(&[client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_720).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&[client.clone()]));
 
     //When
     let account_id = ALICE_ID.clone();

--- a/client/tests/integration/upgrade.rs
+++ b/client/tests/integration/upgrade.rs
@@ -31,8 +31,8 @@ fn executor_upgrade_should_work() -> Result<()> {
         .parse::<iroha::crypto::PrivateKey>()
         .unwrap();
 
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_795).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_795).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     // Register `admin` domain and account
     let admin_domain = Domain::new(admin_id.domain().clone());
@@ -71,8 +71,8 @@ fn executor_upgrade_should_work() -> Result<()> {
 
 #[test]
 fn executor_upgrade_should_run_migration() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_990).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_990).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     // Check that `CanUnregisterDomain` exists
     assert!(client
@@ -124,8 +124,8 @@ fn executor_upgrade_should_run_migration() -> Result<()> {
 
 #[test]
 fn executor_upgrade_should_revoke_removed_permissions() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_030).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_030).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     // Permission which will be removed by executor
     let can_unregister_domain = CanUnregisterDomain {
@@ -207,8 +207,8 @@ fn executor_upgrade_should_revoke_removed_permissions() -> Result<()> {
 fn executor_custom_instructions_simple() -> Result<()> {
     use executor_custom_data_model::simple_isi::MintAssetForAllAccounts;
 
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_270).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_270).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     upgrade_executor(
         &client,
@@ -249,8 +249,8 @@ fn executor_custom_instructions_complex() -> Result<()> {
         ConditionalExpr, CoreExpr, EvaluatesTo, Expression, Greater,
     };
 
-    let (_rt, _peer, client) = PeerBuilder::new().with_port(11_275).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = PeerBuilder::new().with_port(11_275).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     let executor_fuel_limit = SetParameter::new(Parameter::Executor(SmartContractParameter::Fuel(
         nonzero!(1_000_000_000_u64),
@@ -308,8 +308,8 @@ fn executor_custom_instructions_complex() -> Result<()> {
 
 #[test]
 fn migration_fail_should_not_cause_any_effects() {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(10_998).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_998).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     let assert_domain_does_not_exist = |client: &Client, domain_id: &DomainId| {
         assert!(
@@ -342,7 +342,7 @@ fn migration_fail_should_not_cause_any_effects() {
 #[test]
 fn migration_should_cause_upgrade_event() {
     let (rt, _peer, client) = <PeerBuilder>::new().with_port(10_996).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     let events_client = client.clone();
     let task = rt.spawn(async move {
@@ -375,8 +375,8 @@ fn migration_should_cause_upgrade_event() {
 fn define_custom_parameter() -> Result<()> {
     use executor_custom_data_model::parameters::DomainLimits;
 
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_325).start_with_runtime();
-    wait_for_genesis_committed(&vec![client.clone()], 0);
+    let (rt, _peer, client) = <PeerBuilder>::new().with_port(11_325).start_with_runtime();
+    rt.block_on(wait_for_genesis_committed_async(&vec![client.clone()]));
 
     let long_domain_name = "0".repeat(2_usize.pow(5)).parse::<DomainId>()?;
     let create_domain = Register::domain(Domain::new(long_domain_name));

--- a/core/test_network/src/lib.rs
+++ b/core/test_network/src/lib.rs
@@ -414,7 +414,7 @@ pub fn wait_for_genesis_committed_with_max_retries(
 
 /// Wait for genesis indefinitely through block stream.
 // TODO: wait is the point of passing offline peers here, instead pass only online peers
-pub async fn wait_for_genesis_committed_events(clients: &[Client], offline_peers: u32) {
+pub async fn wait_for_genesis_committed_async(clients: &[Client], offline_peers: u32) {
     let mut handles = clients
         .iter()
         .cloned()


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

We have `unstable_network` tests which are constantly failing in the CI.

### Solution

Solutions consist of multiple parts:
- @SamHSmith fix to use only genesis peer as client introduced in #4980
- Remove fixed time polling mechanism in favor of event based solution without fixed timeout
    - Idea is that external timeout is anyway exist which would cut off test execution if it takes too long
- Increase transactions ttl to prevent the case when transaction is expired before end up in the committed block

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->