### PR TITLE
feat(queries): Report amount of remaining items in query

### DIFF
--- a/client_cli/src/main.rs
+++ b/client_cli/src/main.rs
@@ -1176,11 +1176,11 @@ mod json {
                             // we can't really do type-erased iterable queries in a nice way right now...
                             use iroha::data_model::query::builder::QueryExecutor;
 
-                            let (mut first_batch, mut continue_cursor) =
+                            let (mut first_batch, _remaining_items, mut continue_cursor) =
                                 client.start_query(query)?;
 
                             while let Some(cursor) = continue_cursor {
-                                let (next_batch, next_continue_cursor) =
+                                let (next_batch, _remaining_items, next_continue_cursor) =
                                     <Client as QueryExecutor>::continue_query(cursor)?;
 
                                 first_batch.extend(next_batch);

--- a/core/src/query/cursor.rs
+++ b/core/src/query/cursor.rs
@@ -12,6 +12,7 @@ trait BatchedTrait {
         &mut self,
         cursor: u64,
     ) -> Result<(QueryOutputBatchBox, Option<NonZeroU64>), UnknownCursor>;
+    fn remaining(&self) -> u64;
 }
 
 struct BatchedInner<I> {
@@ -22,7 +23,7 @@ struct BatchedInner<I> {
 
 impl<I> BatchedTrait for BatchedInner<I>
 where
-    I: Iterator,
+    I: ExactSizeIterator,
     QueryOutputBatchBox: From<Vec<I::Item>>,
 {
     fn next_batch(
@@ -76,6 +77,10 @@ where
                 .map(|cursor| NonZeroU64::new(cursor).expect("Cursor is never 0")),
         ))
     }
+
+    fn remaining(&self) -> u64 {
+        self.iter.len() as u64
+    }
 }
 
 /// Unknown cursor error.
@@ -100,7 +105,7 @@ impl QueryBatchedErasedIterator {
     /// Creates a new batched iterator. Boxes the inner iterator to erase its type.
     pub fn new<I>(iter: I, batch_size: NonZeroU64) -> Self
     where
-        I: Iterator + Send + Sync + 'static,
+        I: ExactSizeIterator + Send + Sync + 'static,
         QueryOutputBatchBox: From<Vec<I::Item>>,
     {
         Self {
@@ -127,5 +132,12 @@ impl QueryBatchedErasedIterator {
         cursor: u64,
     ) -> Result<(QueryOutputBatchBox, Option<NonZeroU64>), UnknownCursor> {
         self.inner.next_batch(cursor)
+    }
+
+    /// Returns the number of remaining elements in the iterator.
+    ///
+    /// NOTE: this is not a safety guarantee, same as it relies on [`ExactSizeIterator::len`].
+    pub fn remaining(&self) -> u64 {
+        self.inner.remaining()
     }
 }

--- a/core/src/query/cursor.rs
+++ b/core/src/query/cursor.rs
@@ -136,7 +136,7 @@ impl QueryBatchedErasedIterator {
 
     /// Returns the number of remaining elements in the iterator.
     ///
-    /// NOTE: this is not a safety guarantee, same as it relies on [`ExactSizeIterator::len`].
+    /// You should not rely on the reported amount being correct for safety, same as [`ExactSizeIterator::len`].
     pub fn remaining(&self) -> u64 {
         self.inner.remaining()
     }

--- a/core/src/query/pagination.rs
+++ b/core/src/query/pagination.rs
@@ -45,6 +45,12 @@ impl<I: Iterator> Iterator for Paginated<I> {
     }
 }
 
+impl<I: ExactSizeIterator> ExactSizeIterator for Paginated<I> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use iroha_data_model::query::parameters::Pagination;

--- a/core/src/query/store.rs
+++ b/core/src/query/store.rs
@@ -347,7 +347,7 @@ mod tests {
             )
             .unwrap();
 
-            let (batch, mut current_cursor) = query_store_handle
+            let (batch, _remaining_items, mut current_cursor) = query_store_handle
                 .handle_iter_start(query_output, &ALICE_ID)
                 .unwrap()
                 .into_parts();
@@ -359,7 +359,7 @@ mod tests {
                 let Ok(batched) = query_store_handle.handle_iter_continue(cursor) else {
                     break;
                 };
-                let (batch, cursor) = batched.into_parts();
+                let (batch, _remaining_items, cursor) = batched.into_parts();
                 counter += batch.len();
 
                 current_cursor = cursor;

--- a/data_model/src/query/mod.rs
+++ b/data_model/src/query/mod.rs
@@ -166,6 +166,8 @@ mod model {
     pub struct QueryOutput {
         /// A single batch of results
         pub batch: QueryOutputBatchBox,
+        /// The number of items in the query remaining to be fetched after this batch
+        pub remaining_items: u64,
         /// If not `None`, contains a cursor that can be used to fetch the next batch of results. Otherwise the current batch is the last one.
         pub continue_cursor: Option<ForwardCursor>,
     }
@@ -308,9 +310,14 @@ impl SingularQuery for SingularQueryBox {
 
 impl QueryOutput {
     /// Create a new [`QueryOutput`] from the iroha response parts.
-    pub fn new(batch: QueryOutputBatchBox, continue_cursor: Option<ForwardCursor>) -> Self {
+    pub fn new(
+        batch: QueryOutputBatchBox,
+        remaining_items: u64,
+        continue_cursor: Option<ForwardCursor>,
+    ) -> Self {
         Self {
             batch,
+            remaining_items,
             continue_cursor,
         }
     }

--- a/data_model/src/query/mod.rs
+++ b/data_model/src/query/mod.rs
@@ -323,8 +323,8 @@ impl QueryOutput {
     }
 
     /// Split this [`QueryOutput`] into its constituent parts.
-    pub fn into_parts(self) -> (QueryOutputBatchBox, Option<ForwardCursor>) {
-        (self.batch, self.continue_cursor)
+    pub fn into_parts(self) -> (QueryOutputBatchBox, u64, Option<ForwardCursor>) {
+        (self.batch, self.remaining_items, self.continue_cursor)
     }
 }
 

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -3079,6 +3079,10 @@
         "type": "QueryOutputBatchBox"
       },
       {
+        "name": "remaining_items",
+        "type": "u64"
+      },
+      {
         "name": "continue_cursor",
         "type": "Option<ForwardCursor>"
       }

--- a/smart_contract/src/lib.rs
+++ b/smart_contract/src/lib.rs
@@ -149,28 +149,36 @@ impl QueryExecutor for SmartContractQueryExecutor {
     fn start_query(
         &self,
         query: QueryWithParams,
-    ) -> Result<(QueryOutputBatchBox, Option<Self::Cursor>), Self::Error> {
+    ) -> Result<(QueryOutputBatchBox, u64, Option<Self::Cursor>), Self::Error> {
         let QueryResponse::Iterable(output) = execute_query(&QueryRequest::Start(query))? else {
             dbg_panic("BUG: iroha returned unexpected type in iterable query");
         };
 
-        let (batch, cursor) = output.into_parts();
+        let (batch, remaining_items, cursor) = output.into_parts();
 
-        Ok((batch, cursor.map(|cursor| QueryCursor { cursor })))
+        Ok((
+            batch,
+            remaining_items,
+            cursor.map(|cursor| QueryCursor { cursor }),
+        ))
     }
 
     fn continue_query(
         cursor: Self::Cursor,
-    ) -> Result<(QueryOutputBatchBox, Option<Self::Cursor>), Self::Error> {
+    ) -> Result<(QueryOutputBatchBox, u64, Option<Self::Cursor>), Self::Error> {
         let QueryResponse::Iterable(output) =
             execute_query(&QueryRequest::Continue(cursor.cursor))?
         else {
             dbg_panic("BUG: iroha returned unexpected type in iterable query");
         };
 
-        let (batch, cursor) = output.into_parts();
+        let (batch, remaining_items, cursor) = output.into_parts();
 
-        Ok((batch, cursor.map(|cursor| QueryCursor { cursor })))
+        Ok((
+            batch,
+            remaining_items,
+            cursor.map(|cursor| QueryCursor { cursor }),
+        ))
     }
 }
 

--- a/wasm_samples/query_assets_and_save_cursor/src/lib.rs
+++ b/wasm_samples/query_assets_and_save_cursor/src/lib.rs
@@ -35,7 +35,7 @@ fn main(owner: AccountId) {
         pub cursor: ForwardCursor,
     }
 
-    let (_batch, cursor) = SmartContractQueryExecutor
+    let (_batch, _remaining_items, cursor) = SmartContractQueryExecutor
         .start_query(QueryWithParams::new(
             QueryWithFilter::new(FindAssets, CompoundPredicate::PASS).into(),
             QueryParams::new(


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

This PR allows the client to inspect the amount of items that is returned by the query without requesting all batches.

Closes #4984

### Solution

- I rely on `ExactSizeIterator` implementation applied to the pagination combinator. Filtering is not a problem, because we currently eagerly collect all items into a vector before returning anything.
- To not introduce additional split between the type of result of initial and continuation queries, each iterable query response returns the remaining number of items in addition to the batch. This allows us to implement `ExactSizeIterator` on `QueryIterator` pretty naturally.

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've written an integration test for the code changes.
- [x] All review comments have been resolved.