### PR TITLE
refactor: use `mv` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,8 +910,9 @@ dependencies = [
 
 [[package]]
 name = "concread"
-version = "0.5.2"
-source = "git+https://github.com/Erigara/concread.git?rev=bd80db2e85ed179f41aeabc6629e4eb3ec987ed9#bd80db2e85ed179f41aeabc6629e4eb3ec987ed9"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba00cef522c2597dfbb0a8d1b0ac8ac2b99714f50cc354cda71da63164da0be"
 dependencies = [
  "ahash 0.8.11",
  "arc-swap",
@@ -3024,6 +3025,7 @@ dependencies = [
  "iroha_telemetry",
  "iroha_version",
  "iroha_wasm_codec",
+ "mv",
  "nonzero_ext",
  "once_cell",
  "parity-scale-codec",
@@ -3031,7 +3033,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "storage",
  "tempfile",
  "test_samples",
  "thiserror",
@@ -4102,6 +4103,16 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "mv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043dac58686a287d11266132477331e8afdc83bd5880dbfeeba8adef565f9303"
+dependencies = [
+ "concread",
+ "serde",
 ]
 
 [[package]]
@@ -5583,15 +5594,6 @@ dependencies = [
  "log",
  "termcolor",
  "thread_local",
-]
-
-[[package]]
-name = "storage"
-version = "0.1.0"
-source = "git+https://github.com/Erigara/storage.git?rev=cf82588d20494a1c1613ea2f4faa1e66bd827b5c#cf82588d20494a1c1613ea2f4faa1e66bd827b5c"
-dependencies = [
- "concread",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ parity-scale-codec = { version = "3.6.12", default-features = false }
 json5 = "0.4.1"
 toml = "0.8.16"
 
-storage = { git = "https://github.com/Erigara/storage.git", rev = "cf82588d20494a1c1613ea2f4faa1e66bd827b5c" }
+mv = { version = "0.1.0" }
 
 [workspace.lints]
 rustdoc.private_doc_tests = "deny"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,7 +45,7 @@ iroha_telemetry = { workspace = true }
 iroha_primitives = { workspace = true }
 iroha_genesis = { workspace = true }
 iroha_wasm_codec = { workspace = true }
-storage = { workspace = true, features = ["serde"] }
+mv = { workspace = true, features = ["serde"] }
 
 async-trait = { workspace = true }
 dashmap = { workspace = true }

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -283,7 +283,7 @@ mod valid {
     use commit::CommittedBlock;
     use indexmap::IndexMap;
     use iroha_data_model::{account::AccountId, events::pipeline::PipelineEventBox, ChainId};
-    use storage::storage::StorageReadOnly;
+    use mv::storage::StorageReadOnly;
 
     use super::*;
     use crate::{state::StateBlock, sumeragi::network_topology::Role};

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -4,8 +4,8 @@ use std::{num::NonZeroUsize, sync::Arc, time::SystemTime};
 
 use eyre::{Result, WrapErr as _};
 use iroha_telemetry::metrics::Metrics;
+use mv::storage::StorageReadOnly;
 use parking_lot::Mutex;
-use storage::storage::StorageReadOnly;
 
 use crate::{
     kura::Kura,

--- a/core/src/smartcontracts/isi/mod.rs
+++ b/core/src/smartcontracts/isi/mod.rs
@@ -16,7 +16,7 @@ use iroha_data_model::{
     prelude::*,
 };
 use iroha_logger::prelude::*;
-use storage::storage::StorageReadOnly;
+use mv::storage::StorageReadOnly;
 
 use super::Execute;
 use crate::{

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -24,19 +24,19 @@ use iroha_data_model::{
 };
 use iroha_logger::prelude::*;
 use iroha_primitives::{must_use::MustUse, numeric::Numeric, small::SmallVec};
+use mv::{
+    cell::{Block as CellBlock, Cell, Transaction as CellTransaction, View as CellView},
+    storage::{
+        Block as StorageBlock, RangeIter, Storage, StorageReadOnly,
+        Transaction as StorageTransaction, View as StorageView,
+    },
+};
 use nonzero_ext::nonzero;
 use parking_lot::Mutex;
 use range_bounds::*;
 use serde::{
     de::{DeserializeSeed, MapAccess, Visitor},
     Deserializer, Serialize,
-};
-use storage::{
-    cell::{Block as CellBlock, Cell, Transaction as CellTransaction, View as CellView},
-    storage::{
-        Block as StorageBlock, RangeIter, Storage, StorageReadOnly,
-        Transaction as StorageTransaction, View as StorageView,
-    },
 };
 
 use crate::{
@@ -1871,7 +1871,7 @@ mod range_bounds {
 }
 
 pub(crate) mod deserialize {
-    use storage::serde::CellSeeded;
+    use mv::serde::CellSeeded;
 
     use super::*;
 

--- a/core/src/tx.rs
+++ b/core/src/tx.rs
@@ -20,7 +20,7 @@ use iroha_data_model::{
 };
 use iroha_logger::{debug, error};
 use iroha_macro::FromVariant;
-use storage::storage::StorageReadOnly;
+use mv::storage::StorageReadOnly;
 
 use crate::{
     smartcontracts::wasm,


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

Use published on `crates.io` version of `mv` crate (previous name `storage`) to be able to publish iroha itself.
Partially unblock #2933.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->