### PR TITLE
refactor: Change parameters format in genesis.json

### DIFF
--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -7,7 +7,6 @@ use std::collections::btree_map;
 
 use iroha_data_model_derive::model;
 use iroha_primitives::json::JsonString;
-use nonzero_ext::nonzero;
 
 pub use self::model::*;
 use crate::{name::Name, Identifiable};
@@ -17,6 +16,11 @@ pub(crate) type CustomParameters = btree_map::BTreeMap<CustomParameterId, Custom
 
 #[model]
 mod model {
+    #[cfg(not(feature = "std"))]
+    use alloc::collections::BTreeMap;
+    #[cfg(feature = "std")]
+    use std::collections::BTreeMap;
+
     use derive_more::{Constructor, Display, FromStr};
     use getset::{CopyGetters, Getters};
     use iroha_data_model_derive::IdEqOrdHash;
@@ -70,16 +74,19 @@ mod model {
         ///
         /// A block is created if this limit or [`BlockParameters::max_transactions`] limit is reached,
         /// whichever comes first. Regardless of the limits, an empty block is never created.
+        #[serde(default = "defaults::sumeragi::default_block_time_ms")]
         pub block_time_ms: u64,
         /// Time (in milliseconds) a peer will wait for a block to be committed.
         ///
         /// If this period expires the block will request a view change
+        #[serde(default = "defaults::sumeragi::default_commit_time_ms")]
         pub commit_time_ms: u64,
         /// Maximal allowed random deviation from the nominal rate
         ///
         /// # Warning
         ///
         /// This value should be kept as low as possible to not affect soundness of the consensus
+        #[serde(default = "defaults::sumeragi::default_max_clock_drift_ms")]
         pub max_clock_drift_ms: u64,
     }
 
@@ -129,6 +136,7 @@ mod model {
         ///
         /// A block is created if this limit is reached or [`SumeragiParameters::block_time_ms`] has expired,
         /// whichever comes first. Regardless of the limits, an empty block is never created.
+        #[serde(default = "defaults::block::max_transactions")]
         pub max_transactions: NonZeroU64,
     }
 
@@ -161,8 +169,10 @@ mod model {
     #[getset(get_copy = "pub")]
     pub struct TransactionParameters {
         /// Maximum number of instructions per transaction
+        #[serde(default = "defaults::transaction::max_instructions")]
         pub max_instructions: NonZeroU64,
         /// Maximum size of wasm binary in bytes
+        #[serde(default = "defaults::transaction::smart_contract_size")]
         pub smart_contract_size: NonZeroU64,
     }
 
@@ -196,8 +206,10 @@ mod model {
     #[getset(get_copy = "pub")]
     pub struct SmartContractParameters {
         /// Maximum amount of fuel that a smart contract can consume
+        #[serde(default = "defaults::smart_contract::fuel")]
         pub fuel: NonZeroU64,
         /// Maximum amount of memory that a smart contract can use
+        #[serde(default = "defaults::smart_contract::memory")]
         pub memory: NonZeroU64,
     }
 
@@ -248,21 +260,28 @@ mod model {
     pub struct Parameters {
         /// Sumeragi parameters
         #[getset(get_copy = "pub")]
+        #[serde(default)]
         pub sumeragi: SumeragiParameters,
         /// Block parameters
         #[getset(get_copy = "pub")]
+        #[serde(default)]
         pub block: BlockParameters,
         /// Transaction parameters
         #[getset(get_copy = "pub")]
+        #[serde(default)]
         pub transaction: TransactionParameters,
         /// Executor parameters
         #[getset(get_copy = "pub")]
+        #[serde(default)]
         pub executor: SmartContractParameters,
         /// Smart contract parameters
         #[getset(get_copy = "pub")]
+        #[serde(default)]
         pub smart_contract: SmartContractParameters,
         /// Collection of blockchain specific parameters
         #[getset(get = "pub")]
+        #[serde(default)]
+        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
         pub custom: CustomParameters,
     }
 
@@ -344,45 +363,86 @@ impl SumeragiParameters {
     }
 }
 
+mod defaults {
+    pub mod sumeragi {
+        pub fn default_block_time_ms() -> u64 {
+            2_000
+        }
+        pub fn default_commit_time_ms() -> u64 {
+            4_000
+        }
+        pub fn default_max_clock_drift_ms() -> u64 {
+            1_000
+        }
+    }
+
+    pub mod block {
+        use core::num::NonZeroU64;
+
+        use nonzero_ext::nonzero;
+
+        /// Default value for [`Parameters::MaxTransactionsInBlock`]
+        pub fn default_transactions_in_block() -> NonZeroU64 {
+            nonzero!(2_u64.pow(9))
+        }
+    }
+
+    pub mod transaction {
+        use core::num::NonZeroU64;
+
+        use nonzero_ext::nonzero;
+
+        pub fn default_instruction_number() -> NonZeroU64 {
+            nonzero!(2_u64.pow(12))
+        }
+        pub fn default_smart_contract_size() -> NonZeroU64 {
+            nonzero!(4 * 2_u64.pow(20))
+        }
+    }
+
+    pub mod smart_contract {
+        use core::num::NonZeroU64;
+
+        use nonzero_ext::nonzero;
+
+        pub fn default_fuel() -> NonZeroU64 {
+            nonzero!(55_000_000_u64)
+        }
+        pub fn default_memory() -> NonZeroU64 {
+            nonzero!(55_000_000_u64)
+        }
+    }
+}
+
 impl Default for SumeragiParameters {
     fn default() -> Self {
-        pub const DEFAULT_BLOCK_TIME_MS: u64 = 2_000;
-        pub const DEFAULT_COMMIT_TIME_MS: u64 = 4_000;
-        pub const DEFAULT_MAX_CLOCK_DRIFT_MS: u64 = 1_000;
-
+        use defaults::sumeragi::*;
         Self {
-            block_time_ms: DEFAULT_BLOCK_TIME_MS,
-            commit_time_ms: DEFAULT_COMMIT_TIME_MS,
-            max_clock_drift_ms: DEFAULT_MAX_CLOCK_DRIFT_MS,
+            block_time_ms: default_block_time_ms(),
+            commit_time_ms: default_commit_time_ms(),
+            max_clock_drift_ms: default_max_clock_drift_ms(),
         }
     }
 }
 impl Default for BlockParameters {
     fn default() -> Self {
-        /// Default value for [`Parameters::MaxTransactionsInBlock`]
-        pub const DEFAULT_TRANSACTIONS_IN_BLOCK: NonZeroU64 = nonzero!(2_u64.pow(9));
-
-        Self::new(DEFAULT_TRANSACTIONS_IN_BLOCK)
+        Self::new(defaults::block::default_transactions_in_block())
     }
 }
 
 impl Default for TransactionParameters {
     fn default() -> Self {
-        const DEFAULT_INSTRUCTION_NUMBER: NonZeroU64 = nonzero!(2_u64.pow(12));
-        const DEFAULT_SMART_CONTRACT_SIZE: NonZeroU64 = nonzero!(4 * 2_u64.pow(20));
-
-        Self::new(DEFAULT_INSTRUCTION_NUMBER, DEFAULT_SMART_CONTRACT_SIZE)
+        use defaults::transaction::*;
+        Self::new(default_instruction_number(), default_smart_contract_size())
     }
 }
 
 impl Default for SmartContractParameters {
     fn default() -> Self {
-        const DEFAULT_FUEL: NonZeroU64 = nonzero!(55_000_000_u64);
-        const DEFAULT_MEMORY: NonZeroU64 = nonzero!(55_000_000_u64);
-
+        use defaults::smart_contract::*;
         Self {
-            fuel: DEFAULT_FUEL,
-            memory: DEFAULT_MEMORY,
+            fuel: default_fuel(),
+            memory: default_memory(),
         }
     }
 }

--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -74,19 +74,19 @@ mod model {
         ///
         /// A block is created if this limit or [`BlockParameters::max_transactions`] limit is reached,
         /// whichever comes first. Regardless of the limits, an empty block is never created.
-        #[serde(default = "defaults::sumeragi::default_block_time_ms")]
+        #[serde(default = "defaults::sumeragi::block_time_ms")]
         pub block_time_ms: u64,
         /// Time (in milliseconds) a peer will wait for a block to be committed.
         ///
         /// If this period expires the block will request a view change
-        #[serde(default = "defaults::sumeragi::default_commit_time_ms")]
+        #[serde(default = "defaults::sumeragi::commit_time_ms")]
         pub commit_time_ms: u64,
         /// Maximal allowed random deviation from the nominal rate
         ///
         /// # Warning
         ///
         /// This value should be kept as low as possible to not affect soundness of the consensus
-        #[serde(default = "defaults::sumeragi::default_max_clock_drift_ms")]
+        #[serde(default = "defaults::sumeragi::max_clock_drift_ms")]
         pub max_clock_drift_ms: u64,
     }
 
@@ -136,7 +136,6 @@ mod model {
         ///
         /// A block is created if this limit is reached or [`SumeragiParameters::block_time_ms`] has expired,
         /// whichever comes first. Regardless of the limits, an empty block is never created.
-        #[serde(default = "defaults::block::max_transactions")]
         pub max_transactions: NonZeroU64,
     }
 
@@ -169,10 +168,8 @@ mod model {
     #[getset(get_copy = "pub")]
     pub struct TransactionParameters {
         /// Maximum number of instructions per transaction
-        #[serde(default = "defaults::transaction::max_instructions")]
         pub max_instructions: NonZeroU64,
         /// Maximum size of wasm binary in bytes
-        #[serde(default = "defaults::transaction::smart_contract_size")]
         pub smart_contract_size: NonZeroU64,
     }
 
@@ -206,10 +203,8 @@ mod model {
     #[getset(get_copy = "pub")]
     pub struct SmartContractParameters {
         /// Maximum amount of fuel that a smart contract can consume
-        #[serde(default = "defaults::smart_contract::fuel")]
         pub fuel: NonZeroU64,
         /// Maximum amount of memory that a smart contract can use
-        #[serde(default = "defaults::smart_contract::memory")]
         pub memory: NonZeroU64,
     }
 
@@ -365,13 +360,13 @@ impl SumeragiParameters {
 
 mod defaults {
     pub mod sumeragi {
-        pub const fn default_block_time_ms() -> u64 {
+        pub const fn block_time_ms() -> u64 {
             2_000
         }
-        pub const fn default_commit_time_ms() -> u64 {
+        pub const fn commit_time_ms() -> u64 {
             4_000
         }
-        pub const fn default_max_clock_drift_ms() -> u64 {
+        pub const fn max_clock_drift_ms() -> u64 {
             1_000
         }
     }
@@ -382,7 +377,7 @@ mod defaults {
         use nonzero_ext::nonzero;
 
         /// Default value for [`Parameters::MaxTransactionsInBlock`]
-        pub const fn default_transactions_in_block() -> NonZeroU64 {
+        pub const fn max_transactions() -> NonZeroU64 {
             nonzero!(2_u64.pow(9))
         }
     }
@@ -392,10 +387,10 @@ mod defaults {
 
         use nonzero_ext::nonzero;
 
-        pub const fn default_instruction_number() -> NonZeroU64 {
+        pub const fn max_instructions() -> NonZeroU64 {
             nonzero!(2_u64.pow(12))
         }
-        pub const fn default_smart_contract_size() -> NonZeroU64 {
+        pub const fn smart_contract_size() -> NonZeroU64 {
             nonzero!(4 * 2_u64.pow(20))
         }
     }
@@ -405,10 +400,10 @@ mod defaults {
 
         use nonzero_ext::nonzero;
 
-        pub const fn default_fuel() -> NonZeroU64 {
+        pub const fn fuel() -> NonZeroU64 {
             nonzero!(55_000_000_u64)
         }
-        pub const fn default_memory() -> NonZeroU64 {
+        pub const fn memory() -> NonZeroU64 {
             nonzero!(55_000_000_u64)
         }
     }
@@ -418,22 +413,22 @@ impl Default for SumeragiParameters {
     fn default() -> Self {
         use defaults::sumeragi::*;
         Self {
-            block_time_ms: default_block_time_ms(),
-            commit_time_ms: default_commit_time_ms(),
-            max_clock_drift_ms: default_max_clock_drift_ms(),
+            block_time_ms: block_time_ms(),
+            commit_time_ms: commit_time_ms(),
+            max_clock_drift_ms: max_clock_drift_ms(),
         }
     }
 }
 impl Default for BlockParameters {
     fn default() -> Self {
-        Self::new(defaults::block::default_transactions_in_block())
+        Self::new(defaults::block::max_transactions())
     }
 }
 
 impl Default for TransactionParameters {
     fn default() -> Self {
         use defaults::transaction::*;
-        Self::new(default_instruction_number(), default_smart_contract_size())
+        Self::new(max_instructions(), smart_contract_size())
     }
 }
 
@@ -441,8 +436,8 @@ impl Default for SmartContractParameters {
     fn default() -> Self {
         use defaults::smart_contract::*;
         Self {
-            fuel: default_fuel(),
-            memory: default_memory(),
+            fuel: fuel(),
+            memory: memory(),
         }
     }
 }
@@ -576,7 +571,9 @@ mod candidate {
 
     #[derive(Decode, Deserialize)]
     struct TransactionParametersCandidate {
+        #[serde(default = "defaults::transaction::max_instructions")]
         max_instructions: NonZeroU64,
+        #[serde(default = "defaults::transaction::smart_contract_size")]
         smart_contract_size: NonZeroU64,
     }
 
@@ -587,6 +584,7 @@ mod candidate {
 
     #[derive(Decode, Deserialize)]
     struct BlockParametersCandidate {
+        #[serde(default = "super::defaults::block::max_transactions")]
         max_transactions: NonZeroU64,
     }
 
@@ -598,7 +596,9 @@ mod candidate {
 
     #[derive(Decode, Deserialize)]
     struct SmartContractParametersCandidate {
+        #[serde(default = "super::defaults::smart_contract::fuel")]
         fuel: NonZeroU64,
+        #[serde(default = "super::defaults::smart_contract::memory")]
         memory: NonZeroU64,
     }
 

--- a/data_model/src/parameter.rs
+++ b/data_model/src/parameter.rs
@@ -365,13 +365,13 @@ impl SumeragiParameters {
 
 mod defaults {
     pub mod sumeragi {
-        pub fn default_block_time_ms() -> u64 {
+        pub const fn default_block_time_ms() -> u64 {
             2_000
         }
-        pub fn default_commit_time_ms() -> u64 {
+        pub const fn default_commit_time_ms() -> u64 {
             4_000
         }
-        pub fn default_max_clock_drift_ms() -> u64 {
+        pub const fn default_max_clock_drift_ms() -> u64 {
             1_000
         }
     }
@@ -382,7 +382,7 @@ mod defaults {
         use nonzero_ext::nonzero;
 
         /// Default value for [`Parameters::MaxTransactionsInBlock`]
-        pub fn default_transactions_in_block() -> NonZeroU64 {
+        pub const fn default_transactions_in_block() -> NonZeroU64 {
             nonzero!(2_u64.pow(9))
         }
     }
@@ -392,10 +392,10 @@ mod defaults {
 
         use nonzero_ext::nonzero;
 
-        pub fn default_instruction_number() -> NonZeroU64 {
+        pub const fn default_instruction_number() -> NonZeroU64 {
             nonzero!(2_u64.pow(12))
         }
-        pub fn default_smart_contract_size() -> NonZeroU64 {
+        pub const fn default_smart_contract_size() -> NonZeroU64 {
             nonzero!(4 * 2_u64.pow(20))
         }
     }
@@ -405,10 +405,10 @@ mod defaults {
 
         use nonzero_ext::nonzero;
 
-        pub fn default_fuel() -> NonZeroU64 {
+        pub const fn default_fuel() -> NonZeroU64 {
             nonzero!(55_000_000_u64)
         }
-        pub fn default_memory() -> NonZeroU64 {
+        pub const fn default_memory() -> NonZeroU64 {
             nonzero!(55_000_000_u64)
         }
     }

--- a/defaults/genesis.json
+++ b/defaults/genesis.json
@@ -1,58 +1,28 @@
 {
   "chain": "00000000-0000-0000-0000-000000000000",
   "executor": "./executor.wasm",
-  "parameters": [
-    {
-      "Sumeragi": {
-        "BlockTimeMs": 2000
-      }
+  "parameters": {
+    "sumeragi": {
+      "block_time_ms": 2000,
+      "commit_time_ms": 4000,
+      "max_clock_drift_ms": 1000
     },
-    {
-      "Sumeragi": {
-        "CommitTimeMs": 4000
-      }
+    "block": {
+      "max_transactions": 512
     },
-    {
-      "Sumeragi": {
-        "MaxClockDriftMs": 1000
-      }
+    "transaction": {
+      "max_instructions": 4096,
+      "smart_contract_size": 4194304
     },
-    {
-      "Block": {
-        "MaxTransactions": 512
-      }
+    "executor": {
+      "fuel": 55000000,
+      "memory": 55000000
     },
-    {
-      "Transaction": {
-        "MaxInstructions": 4096
-      }
-    },
-    {
-      "Transaction": {
-        "SmartContractSize": 4194304
-      }
-    },
-    {
-      "Executor": {
-        "Fuel": 55000000
-      }
-    },
-    {
-      "Executor": {
-        "Memory": 55000000
-      }
-    },
-    {
-      "SmartContract": {
-        "Fuel": 55000000
-      }
-    },
-    {
-      "SmartContract": {
-        "Memory": 55000000
-      }
+    "smart_contract": {
+      "fuel": 55000000,
+      "memory": 55000000
     }
-  ],
+  },
   "instructions": [
     {
       "Register": {

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -2727,6 +2727,9 @@
   "Option<Option<NonZero<u64>>>": {
     "Option": "Option<NonZero<u64>>"
   },
+  "Option<Parameters>": {
+    "Option": "Parameters"
+  },
   "Option<PeerId>": {
     "Option": "PeerId"
   },
@@ -3411,7 +3414,7 @@
       },
       {
         "name": "parameters",
-        "type": "Vec<Parameter>"
+        "type": "Option<Parameters>"
       },
       {
         "name": "instructions",

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -532,4 +532,34 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn genesis_parameters_deserialization() {
+        fn test(parameters: &str) {
+            let genesis_json = format!(
+                r#"{{
+              "parameters": {},
+              "chain": "0",
+              "executor": "./executor.wasm",
+              "topology": [],
+              "instructions": []
+            }}"#,
+                parameters
+            );
+            let _genesis: RawGenesisTransaction =
+                serde_json::from_str(&genesis_json).expect("Failed to deserialize");
+        }
+
+        // Empty parameters
+        test("{}");
+        test(
+            r#"{"sumeragi": {}, "block": {}, "transaction": {}, "executor": {}, "smart_contract": {}}"#,
+        );
+
+        // Inner value missing
+        test(r#"{"sumeragi": {"block_time_ms": 2000}}"#);
+        test(r#"{"transaction": {"max_instructions": 4096}}"#);
+        test(r#"{"executor": {"fuel": 55000000}}"#);
+        test(r#"{"smart_contract": {"fuel": 55000000}}"#);
+    }
 }

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -40,8 +40,8 @@ pub struct RawGenesisTransaction {
     /// Path to the [`Executor`] file
     executor: ExecutorPath,
     /// Parameters
-    #[serde(default)]
-    parameters: Vec<Parameter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parameters: Option<Parameters>,
     instructions: Vec<InstructionBox>,
     /// Initial topology
     topology: Vec<PeerId>,
@@ -104,13 +104,16 @@ impl RawGenesisTransaction {
     /// If executor couldn't be read from provided path
     pub fn build_and_sign(self, genesis_key_pair: &KeyPair) -> Result<GenesisBlock> {
         let executor = get_executor(&self.executor.0)?;
+        let parameters = self
+            .parameters
+            .map_or(Vec::new(), |parameters| parameters.parameters().collect());
         let genesis = build_and_sign_genesis(
             self.instructions,
             executor,
             self.chain,
             genesis_key_pair,
             self.topology,
-            self.parameters,
+            parameters,
         );
         Ok(genesis)
     }
@@ -284,7 +287,7 @@ impl GenesisBuilder {
         RawGenesisTransaction {
             instructions: self.instructions,
             executor: ExecutorPath(executor_file),
-            parameters: self.parameters,
+            parameters: convert_parameters(self.parameters),
             chain: chain_id,
             topology,
         }
@@ -322,6 +325,51 @@ impl GenesisDomainBuilder {
             .push(Register::asset_definition(asset_definition).into());
         self
     }
+}
+
+fn convert_parameters(parameters: Vec<Parameter>) -> Option<Parameters> {
+    if parameters.is_empty() {
+        return None;
+    }
+    let mut result = Parameters::default();
+    for parameter in parameters.into_iter() {
+        apply_parameter(&mut result, parameter);
+    }
+    Some(result)
+}
+
+fn apply_parameter(parameters: &mut Parameters, parameter: Parameter) {
+    macro_rules! apply_parameter {
+        ($($container:ident($param:ident.$field:ident) => $single:ident::$variant:ident),* $(,)?) => {
+            match parameter {
+                $(
+                Parameter::$container(iroha_data_model::parameter::$single::$variant(next)) => {
+                    parameters.$param.$field = next;
+                }
+                )*
+                Parameter::Custom(next) => {
+                    parameters.custom.insert(next.id.clone(), next);
+                }
+            }
+        };
+    }
+
+    apply_parameter!(
+        Sumeragi(sumeragi.max_clock_drift_ms) => SumeragiParameter::MaxClockDriftMs,
+        Sumeragi(sumeragi.block_time_ms) => SumeragiParameter::BlockTimeMs,
+        Sumeragi(sumeragi.commit_time_ms) => SumeragiParameter::CommitTimeMs,
+
+        Block(block.max_transactions) => BlockParameter::MaxTransactions,
+
+        Transaction(transaction.max_instructions) => TransactionParameter::MaxInstructions,
+        Transaction(transaction.smart_contract_size) => TransactionParameter::SmartContractSize,
+
+        SmartContract(smart_contract.fuel) => SmartContractParameter::Fuel,
+        SmartContract(smart_contract.memory) => SmartContractParameter::Memory,
+
+        Executor(executor.fuel) => SmartContractParameter::Fuel,
+        Executor(executor.memory) => SmartContractParameter::Memory,
+    );
 }
 
 impl Encode for ExecutorPath {

--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -315,6 +315,7 @@ types!(
     Option<NonZeroU32>,
     Option<NonZeroU64>,
     Option<Option<NonZeroU64>>,
+    Option<Parameters>,
     Option<PeerId>,
     Option<RoleId>,
     Option<TimeInterval>,


### PR DESCRIPTION
## Context

Fixes #4813

### Solution

Changes format of `genesis.json` from:

```json5
{
  ...
  "parameters": [
    {
      "Sumeragi": {
        "BlockTimeMs": 2000
      }
    },
    {
      "Sumeragi": {
        "CommitTimeMs": 4000
      }
    },
    ...
    {
      "Transaction": {
        "MaxInstructions": 4096
      }
    },
    ...
```

to:

```json5
{
  ...
  "parameters": {
    "sumeragi": {
      "block_time_ms": 2000,
      "commit_time_ms": 4000,
      ...
    },
    "transaction": {
      "max_instructions": 4096,
      ...
    },
    ...
```

### Migration Guide (optional)

* `kagami genesis generate` will generate genesis in the new format. Custom genesis generator tools should be changed to new format. 
* Note that schema.json has type entry `RawGenesisTransaction` corresponding to genesis.json file

### Review notes (optional)

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
