### PR TITLE
chore: add an item on CI checks to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,7 @@
 - [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - [ ] (optional) I've written unit tests for the code changes.
 - [ ] All review comments have been resolved.
+- [ ] All CI checks pass.
 
 <!-- Add more items if needed -->
 


### PR DESCRIPTION
## Context

We had to disable required status checks because GitHub doesn't provide a clean way to ignore them conditionally. This PR returns the item on CI checks passing back into the PR template

---

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] All review comments have been resolved.