### PR TITLE
fix: make sure that chacha20poly1305::tests::decrypt_should_fail is not flaky

### DIFF
--- a/crypto/src/encryption/chacha20poly1305.rs
+++ b/crypto/src/encryption/chacha20poly1305.rs
@@ -104,10 +104,12 @@ mod tests {
         let mut ciphertext = res.unwrap();
 
         let aad = b"decrypt should succeed".to_vec();
+        // decrypt should fail because if mismatched aad
         cipher.decrypt_easy(&aad, &ciphertext).unwrap_err();
 
         let aad = b"decrypt should fail".to_vec();
-        ciphertext[0] ^= ciphertext[1];
+        ciphertext[0] ^= 0x01;
+        // decrypt should fail because of tampered ciphertext
         cipher.decrypt_easy(&aad, &ciphertext).unwrap_err();
     }
 


### PR DESCRIPTION
## Context

Closes #4994

### Solution

- instead of XORing with `ciphertext[1]` which can happen to be `0`, XOR with a constant `0x01`, always flipping one bit

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] All review comments have been resolved.