### PR TITLE
fix(p2p): disable sending message when not ready to prevent busy loop

### DIFF
--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -261,6 +261,11 @@ mod run {
                         idle_interval.reset();
                         ping_interval.reset();
                     }
+                    // `message_sender.send()` is safe to be cancelled, it won't advance the queue or write anything if another branch completes first.
+                    // 
+                    // We need to conditionally disable it in case there is no data is to be sent, otherwise `message_sender.send()` will complete immediately
+                    //
+                    // The only source of data to be sent is other branches of this loop, so we do not need any async waiting mechanism for waiting for readiness.
                     result = message_sender.send(), if message_sender.ready() => {
                         if let Err(error) = result {
                             iroha_logger::error!(%error, "Failed to send message to peer.");

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -261,7 +261,7 @@ mod run {
                         idle_interval.reset();
                         ping_interval.reset();
                     }
-                    result = message_sender.send() => {
+                    result = message_sender.send(), if message_sender.ready() => {
                         if let Err(error) = result {
                             iroha_logger::error!(%error, "Failed to send message to peer.");
                             break;
@@ -426,6 +426,11 @@ mod run {
                 self.queue.advance(n);
             }
             Ok(())
+        }
+
+        /// Check if message sender has data ready to be sent.
+        fn ready(&self) -> bool {
+            !self.queue.is_empty()
         }
     }
 


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

It was observed that iroha consume a lot CPU in idle state, turned out it was due to accidental busy loop in p2p code.

Closes: #5033

### Solution

Add conditional disabling sending message in `Peer` even loop when there is no data to be sent to prevent busy loop.

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->