### PR TITLE
fix(topology): dont depend on signatures for update

### DIFF
--- a/core/src/sumeragi/main_loop.rs
+++ b/core/src/sumeragi/main_loop.rs
@@ -338,7 +338,7 @@ impl Sumeragi {
         let prev_role = self.role();
 
         self.topology
-            .block_committed(block.as_ref(), state_block.world.peers().cloned());
+            .block_committed(state_block.world.peers().cloned());
 
         let state_events =
             state_block.apply_without_execution(&block, self.topology.as_ref().to_owned());

--- a/core/src/sumeragi/mod.rs
+++ b/core/src/sumeragi/mod.rs
@@ -106,7 +106,7 @@ impl SumeragiHandle {
             *topology = Topology::new(state_block.world.trusted_peers_ids.clone());
         }
 
-        topology.block_committed(block.as_ref(), state_block.world.peers().cloned());
+        topology.block_committed(state_block.world.peers().cloned());
 
         state_block
             .apply_without_execution(&block, topology.as_ref().to_owned())


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

Closes #4883.

### Solution

Don't use block signatures for topology update.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->