### PR TITLE
feat(schema): use the type names passed to schema's `types!` macro in type position

### DIFF
--- a/schema/gen/src/lib.rs
+++ b/schema/gen/src/lib.rs
@@ -10,6 +10,14 @@ use iroha_schema::prelude::*;
 
 macro_rules! types {
     ($($t:ty),+ $(,)?) => {
+        // use all the types in a type position, so that IDE can resolve them
+        const _: () = {
+            use complete_data_model::*;
+            $(
+                let _resolve_my_type_pls: $t;
+            )+
+        };
+
         /// Apply `callback` to all types in the schema.
         #[macro_export]
         macro_rules! map_all_schema_types {


### PR DESCRIPTION
This gives the IDE a hint that it's a type name and allows one to navigate to the type definition and see name resolution errors

---

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.