### PR TITLE
perf: Make `PublicKey` decoding lazy inside WASM

### DIFF
--- a/.github/workflows/iroha2-dev-pr-wasm.yaml
+++ b/.github/workflows/iroha2-dev-pr-wasm.yaml
@@ -9,6 +9,11 @@ on:
       - 'crates/iroha_data_model/**.json'
       - 'crates/iroha_data_model/**.toml'
 
+      - 'crates/iroha_crypto/**.rs'
+      - 'crates/iroha_crypto/**.yml'
+      - 'crates/iroha_crypto/**.json'
+      - 'crates/iroha_crypto/**.toml'
+
       - 'crates/iroha_smart_contract/**.rs'
       - 'crates/iroha_smart_contract/**.yml'
       - 'crates/iroha_smart_contract/**.json'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,7 +3473,6 @@ dependencies = [
  "iroha_macro",
  "iroha_smart_contract_derive",
  "iroha_smart_contract_utils",
- "iroha_test_samples",
  "parity-scale-codec",
  "trybuild",
  "webassembly-test",

--- a/crates/iroha_smart_contract/Cargo.toml
+++ b/crates/iroha_smart_contract/Cargo.toml
@@ -29,8 +29,6 @@ displaydoc.workspace = true
 getrandom = "0.2"
 
 [dev-dependencies]
-iroha_test_samples = { workspace = true }
-
 webassembly-test = "0.1.0"
 # Not used directly but required for compilation
 getrandom = { version = "0.2", features = ["custom"] }


### PR DESCRIPTION
## Context

Fixes #5038

### Solution

Make `PublicKey` decoding lazy inside WASM, since `PublicKey` in WASM is used mostly for comparison operations (`==`), and comparison can be performed without decoding (see #5038 for details). This givess approximatelly 400tps increase for single peer (from ~2450 to ~2850).

### Review notes (optional)

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
