### PR TITLE
fix: Fix `iroha_genesis` compilation without `transparent_api` feature

### DIFF
--- a/crates/iroha/tests/integration/pagination.rs
+++ b/crates/iroha/tests/integration/pagination.rs
@@ -26,7 +26,7 @@ fn limits_should_work() -> Result<()> {
 
 #[test]
 fn reported_length_should_be_accurate() -> Result<()> {
-    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_170).start_with_runtime();
+    let (_rt, _peer, client) = <PeerBuilder>::new().with_port(11_200).start_with_runtime();
     wait_for_genesis_committed(&vec![client.clone()], 0);
 
     register_assets(&client)?;

--- a/crates/iroha/tests/integration/status_response.rs
+++ b/crates/iroha/tests/integration/status_response.rs
@@ -14,7 +14,7 @@ fn status_eq_excluding_uptime_and_queue(lhs: &Status, rhs: &Status) -> bool {
 
 #[test]
 fn json_and_scale_statuses_equality() -> Result<()> {
-    let (_rt, network, client) = Network::start_test_with_runtime(2, Some(11_200));
+    let (_rt, network, client) = Network::start_test_with_runtime(2, Some(11_280));
     wait_for_genesis_committed(&network.clients(), 0);
 
     let json_status_zero = get_status_json(&client).unwrap();

--- a/crates/iroha_data_model/src/parameter.rs
+++ b/crates/iroha_data_model/src/parameter.rs
@@ -458,6 +458,41 @@ impl Parameters {
             )
             .chain(self.custom.values().cloned().map(Parameter::Custom))
     }
+
+    /// Set `parameter` value to corresponding parameter in `self`
+    pub fn apply_parameter(&mut self, parameter: Parameter) {
+        macro_rules! apply_parameter {
+            ($($container:ident($param:ident.$field:ident) => $single:ident::$variant:ident),* $(,)?) => {
+                match parameter {
+                    $(
+                    Parameter::$container($single::$variant(next)) => {
+                        self.$param.$field = next;
+                    }
+                    )*
+                    Parameter::Custom(next) => {
+                        self.custom.insert(next.id.clone(), next);
+                    }
+                }
+            };
+        }
+
+        apply_parameter!(
+            Sumeragi(sumeragi.max_clock_drift_ms) => SumeragiParameter::MaxClockDriftMs,
+            Sumeragi(sumeragi.block_time_ms) => SumeragiParameter::BlockTimeMs,
+            Sumeragi(sumeragi.commit_time_ms) => SumeragiParameter::CommitTimeMs,
+
+            Block(block.max_transactions) => BlockParameter::MaxTransactions,
+
+            Transaction(transaction.max_instructions) => TransactionParameter::MaxInstructions,
+            Transaction(transaction.smart_contract_size) => TransactionParameter::SmartContractSize,
+
+            SmartContract(smart_contract.fuel) => SmartContractParameter::Fuel,
+            SmartContract(smart_contract.memory) => SmartContractParameter::Memory,
+
+            Executor(executor.fuel) => SmartContractParameter::Fuel,
+            Executor(executor.memory) => SmartContractParameter::Memory,
+        );
+    }
 }
 
 impl SumeragiParameters {

--- a/crates/iroha_data_model/src/parameter.rs
+++ b/crates/iroha_data_model/src/parameter.rs
@@ -460,7 +460,7 @@ impl Parameters {
     }
 
     /// Set `parameter` value to corresponding parameter in `self`
-    pub fn apply_parameter(&mut self, parameter: Parameter) {
+    pub fn set_parameter(&mut self, parameter: Parameter) {
         macro_rules! apply_parameter {
             ($($container:ident($param:ident.$field:ident) => $single:ident::$variant:ident),* $(,)?) => {
                 match parameter {

--- a/crates/iroha_genesis/src/lib.rs
+++ b/crates/iroha_genesis/src/lib.rs
@@ -334,43 +334,9 @@ fn convert_parameters(parameters: Vec<Parameter>) -> Option<Parameters> {
     }
     let mut result = Parameters::default();
     for parameter in parameters {
-        apply_parameter(&mut result, parameter);
+        result.apply_parameter(parameter);
     }
     Some(result)
-}
-
-fn apply_parameter(parameters: &mut Parameters, parameter: Parameter) {
-    macro_rules! apply_parameter {
-        ($($container:ident($param:ident.$field:ident) => $single:ident::$variant:ident),* $(,)?) => {
-            match parameter {
-                $(
-                Parameter::$container(iroha_data_model::parameter::$single::$variant(next)) => {
-                    parameters.$param.$field = next;
-                }
-                )*
-                Parameter::Custom(next) => {
-                    parameters.custom.insert(next.id.clone(), next);
-                }
-            }
-        };
-    }
-
-    apply_parameter!(
-        Sumeragi(sumeragi.max_clock_drift_ms) => SumeragiParameter::MaxClockDriftMs,
-        Sumeragi(sumeragi.block_time_ms) => SumeragiParameter::BlockTimeMs,
-        Sumeragi(sumeragi.commit_time_ms) => SumeragiParameter::CommitTimeMs,
-
-        Block(block.max_transactions) => BlockParameter::MaxTransactions,
-
-        Transaction(transaction.max_instructions) => TransactionParameter::MaxInstructions,
-        Transaction(transaction.smart_contract_size) => TransactionParameter::SmartContractSize,
-
-        SmartContract(smart_contract.fuel) => SmartContractParameter::Fuel,
-        SmartContract(smart_contract.memory) => SmartContractParameter::Memory,
-
-        Executor(executor.fuel) => SmartContractParameter::Fuel,
-        Executor(executor.memory) => SmartContractParameter::Memory,
-    );
 }
 
 impl Encode for ExecutorPath {

--- a/crates/iroha_genesis/src/lib.rs
+++ b/crates/iroha_genesis/src/lib.rs
@@ -334,7 +334,7 @@ fn convert_parameters(parameters: Vec<Parameter>) -> Option<Parameters> {
     }
     let mut result = Parameters::default();
     for parameter in parameters {
-        result.apply_parameter(parameter);
+        result.set_parameter(parameter);
     }
     Some(result)
 }


### PR DESCRIPTION
## Context

Fixes #5049

### Solution

* Moved `apply_parameter` function to the `data_model`
* Also fixed port for some tests:
  * `reported_length_should_be_accurate` used port 11_170 which conflicts with `register_offline_peer`
  * `json_and_scale_statuses_equality` used port 11_200 which conflicts with `restarted_peer_should_have_the_same_asset_amount`

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
