### PR TITLE
fix(supervisor): failing tests, chores

### DIFF
--- a/crates/iroha_core/src/gossiper.rs
+++ b/crates/iroha_core/src/gossiper.rs
@@ -92,7 +92,7 @@ impl TransactionGossiper {
                     self.handle_transaction_gossip(transaction_gossip);
                 }
                 () = shutdown_signal.receive() => {
-                    iroha_logger::info!("Shutting down transactions gossiper");
+                    iroha_logger::debug!("Shutting down transactions gossiper");
                     break;
                 },
             }

--- a/crates/iroha_core/src/kura.rs
+++ b/crates/iroha_core/src/kura.rs
@@ -983,8 +983,8 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test]
-    async fn kura_not_miss_replace_block() {
+    #[test]
+    fn kura_not_miss_replace_block() {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_time()
             .build()

--- a/crates/iroha_core/src/query/store.rs
+++ b/crates/iroha_core/src/query/store.rs
@@ -141,7 +141,7 @@ impl LiveQueryStore {
                         });
                     }
                     () = self.shutdown_signal.receive() => {
-                        iroha_logger::info!("LiveQueryStore is being shut down.");
+                        iroha_logger::debug!("LiveQueryStore is being shut down.");
                         break;
                     }
                     else => break,

--- a/crates/iroha_futures/src/supervisor.rs
+++ b/crates/iroha_futures/src/supervisor.rs
@@ -693,7 +693,8 @@ mod tests {
             .recv_timeout(OS_THREAD_SPAWN_TICK)
             .expect("thread should start by now");
         signal2.send();
-        timeout(TICK_TIMEOUT, sup_fut)
+        // It is too slow in CI sometimes
+        timeout(TICK_TIMEOUT * 10, sup_fut)
             .await
             .expect("should shutdown within timeout")
             .expect("should not panic")
@@ -715,6 +716,5 @@ mod tests {
         else {
             panic!("no other error expected");
         };
-        println!("hey");
     }
 }


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

#4716 broke some tests.

### Solution

This PR fixes `kura_not_miss_replace_block`, increases timeout for `can_monitor_os_thread_spawn` (broken in #4996), and does some other chores.

It doesn't fix `restarted_peer_should_have_the_same_asset_amount` as it requires deeper refactoring (WiP).

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->