### PR TITLE
refactor(permissions): define default permission set

### DIFF
--- a/crates/iroha/tests/integration/asset.rs
+++ b/crates/iroha/tests/integration/asset.rs
@@ -12,7 +12,7 @@ use iroha::{
     },
 };
 use iroha_config::parameters::actual::Root as Config;
-use iroha_executor_data_model::permission::asset::CanTransferUserAsset;
+use iroha_executor_data_model::permission::asset::CanTransferAsset;
 use iroha_test_network::*;
 use iroha_test_samples::{gen_account_in, ALICE_ID, BOB_ID};
 
@@ -328,7 +328,7 @@ fn find_rate_and_make_exchange_isi_should_succeed() {
 
     let alice_id = ALICE_ID.clone();
     let alice_can_transfer_asset = |asset_id: AssetId, owner_key_pair: KeyPair| {
-        let permission = CanTransferUserAsset {
+        let permission = CanTransferAsset {
             asset: asset_id.clone(),
         };
         let instruction = Grant::account_permission(permission, alice_id.clone());

--- a/crates/iroha/tests/integration/transfer_domain.rs
+++ b/crates/iroha/tests/integration/transfer_domain.rs
@@ -7,10 +7,10 @@ use iroha::{
 };
 use iroha_executor_data_model::permission::{
     account::CanUnregisterAccount,
-    asset::CanUnregisterUserAsset,
-    asset_definition::CanUnregisterAssetDefinition,
-    domain::{CanRegisterAssetDefinitionInDomain, CanUnregisterDomain},
-    trigger::CanUnregisterUserTrigger,
+    asset::CanUnregisterAsset,
+    asset_definition::{CanRegisterAssetDefinition, CanUnregisterAssetDefinition},
+    domain::CanUnregisterDomain,
+    trigger::CanUnregisterTrigger,
 };
 use iroha_genesis::GenesisBlock;
 use iroha_primitives::json::JsonString;
@@ -59,7 +59,7 @@ fn domain_owner_domain_permissions() -> Result<()> {
     test_client.submit_blocking(Unregister::asset_definition(coin_id))?;
 
     // Granting a respective permission also allows "bob@kingdom" to do so
-    let permission = CanRegisterAssetDefinitionInDomain {
+    let permission = CanRegisterAssetDefinition {
         domain: kingdom_id.clone(),
     };
     test_client.submit_blocking(Grant::account_permission(
@@ -158,7 +158,7 @@ fn domain_owner_asset_definition_permissions() -> Result<()> {
     test_client.submit_blocking(Register::account(rabbit))?;
 
     // Grant permission to register asset definitions to "bob@kingdom"
-    let permission = CanRegisterAssetDefinitionInDomain { domain: kingdom_id };
+    let permission = CanRegisterAssetDefinition { domain: kingdom_id };
     test_client.submit_blocking(Grant::account_permission(permission, bob_id.clone()))?;
 
     // register asset definitions by "bob@kingdom" so he is owner of it
@@ -222,7 +222,7 @@ fn domain_owner_asset_permissions() -> Result<()> {
     test_client.submit_blocking(Register::account(bob))?;
 
     // Grant permission to register asset definitions to "bob@kingdom"
-    let permission = CanRegisterAssetDefinitionInDomain { domain: kingdom_id };
+    let permission = CanRegisterAssetDefinition { domain: kingdom_id };
     test_client.submit_blocking(Grant::account_permission(permission, bob_id.clone()))?;
 
     // register asset definitions by "bob@kingdom" so he is owner of it
@@ -255,7 +255,7 @@ fn domain_owner_asset_permissions() -> Result<()> {
     test_client.submit_blocking(RemoveKeyValue::asset(bob_store_id.clone(), key))?;
 
     // check that "alice@wonderland" as owner of domain can grant and revoke asset related permissions in her domain
-    let permission = CanUnregisterUserAsset {
+    let permission = CanUnregisterAsset {
         asset: bob_store_id,
     };
     test_client.submit_blocking(Grant::account_permission(
@@ -308,8 +308,8 @@ fn domain_owner_trigger_permissions() -> Result<()> {
     let _result = test_client.submit_blocking(execute_trigger)?;
 
     // check that "alice@wonderland" as owner of domain can grant and revoke trigger related permissions in her domain
-    let permission = CanUnregisterUserTrigger {
-        account: bob_id.clone(),
+    let permission = CanUnregisterTrigger {
+        trigger: trigger_id.clone(),
     };
     test_client.submit_blocking(Grant::account_permission(
         permission.clone(),

--- a/crates/iroha/tests/integration/triggers/by_call_trigger.rs
+++ b/crates/iroha/tests/integration/triggers/by_call_trigger.rs
@@ -12,7 +12,7 @@ use iroha::{
     },
 };
 use iroha_data_model::query::{builder::SingleQueryError, trigger::FindTriggers};
-use iroha_executor_data_model::permission::trigger::CanRegisterUserTrigger;
+use iroha_executor_data_model::permission::trigger::CanRegisterTrigger;
 use iroha_genesis::GenesisBlock;
 use iroha_logger::info;
 use iroha_test_network::{Peer as TestPeer, *};
@@ -217,8 +217,7 @@ fn trigger_should_not_be_executed_with_zero_repeats_count() -> Result<()> {
             downcasted_error,
             Some(FindError::Trigger(id)) if *id == trigger_id
         ),
-        "Unexpected error received: {:?}",
-        error
+        "Unexpected error received: {error:?}",
     );
 
     // Checking results
@@ -295,8 +294,8 @@ fn only_account_with_permission_can_register_trigger() -> Result<()> {
     rabbit_client.key_pair = rabbit_keys;
 
     // Permission for the trigger registration on behalf of alice
-    let permission_on_registration = CanRegisterUserTrigger {
-        account: ALICE_ID.clone(),
+    let permission_on_registration = CanRegisterTrigger {
+        authority: ALICE_ID.clone(),
     };
 
     // Trigger with 'alice' as authority

--- a/crates/iroha/tests/integration/upgrade.rs
+++ b/crates/iroha/tests/integration/upgrade.rs
@@ -137,7 +137,8 @@ fn executor_upgrade_should_revoke_removed_permissions() -> Result<()> {
 
     // Register `TEST_ROLE` with permission
     let test_role_id: RoleId = "TEST_ROLE".parse()?;
-    let test_role = Role::new(test_role_id.clone()).add_permission(can_unregister_domain.clone());
+    let test_role = Role::new(test_role_id.clone(), ALICE_ID.clone())
+        .add_permission(can_unregister_domain.clone());
     client.submit_blocking(Register::role(test_role))?;
 
     // Check that permission exists

--- a/crates/iroha_core/src/kura.rs
+++ b/crates/iroha_core/src/kura.rs
@@ -1063,6 +1063,7 @@ mod tests {
 
     #[allow(clippy::too_many_lines)]
     fn create_blocks(rt: &tokio::runtime::Runtime, temp_dir: &TempDir) -> Vec<CommittedBlock> {
+        const BLOCK_FLUSH_TIMEOUT: Duration = Duration::from_secs(1);
         let mut blocks = Vec::new();
 
         let (leader_public_key, leader_private_key) = KeyPair::random().into_parts();
@@ -1170,7 +1171,6 @@ mod tests {
             blocks.push(block.clone());
             kura.store_block(block);
         }
-        const BLOCK_FLUSH_TIMEOUT: Duration = Duration::from_secs(1);
         thread::sleep(BLOCK_FLUSH_TIMEOUT);
 
         {

--- a/crates/iroha_core/src/smartcontracts/isi/account.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/account.rs
@@ -308,14 +308,6 @@ pub mod isi {
             let account_id = self.destination;
             let role_id = self.object;
 
-            let permissions = state_transaction
-                .world
-                .roles
-                .get(&role_id)
-                .ok_or_else(|| FindError::Role(role_id.clone()))?
-                .permissions
-                .clone();
-
             state_transaction.world.account(&account_id)?;
 
             if state_transaction
@@ -334,23 +326,12 @@ pub mod isi {
                 .into());
             }
 
-            state_transaction.world.emit_events({
-                let account_id_clone = account_id.clone();
-                permissions
-                    .into_iter()
-                    .zip(core::iter::repeat_with(move || account_id.clone()))
-                    .map(|(permission, account_id)| AccountPermissionChanged {
-                        account: account_id,
-                        permission,
-                    })
-                    .map(AccountEvent::PermissionAdded)
-                    .chain(std::iter::once(AccountEvent::RoleGranted(
-                        AccountRoleChanged {
-                            account: account_id_clone,
-                            role: role_id,
-                        },
-                    )))
-            });
+            state_transaction
+                .world
+                .emit_events(Some(AccountEvent::RoleGranted(AccountRoleChanged {
+                    account: account_id.clone(),
+                    role: role_id,
+                })));
 
             Ok(())
         }
@@ -366,14 +347,6 @@ pub mod isi {
             let account_id = self.destination;
             let role_id = self.object;
 
-            let permissions = state_transaction
-                .world
-                .roles
-                .get(&role_id)
-                .ok_or_else(|| FindError::Role(role_id.clone()))?
-                .permissions
-                .clone();
-
             if state_transaction
                 .world
                 .account_roles
@@ -386,23 +359,12 @@ pub mod isi {
                 return Err(FindError::Role(role_id).into());
             }
 
-            state_transaction.world.emit_events({
-                let account_id_clone = account_id.clone();
-                permissions
-                    .into_iter()
-                    .zip(core::iter::repeat_with(move || account_id.clone()))
-                    .map(|(permission, account_id)| AccountPermissionChanged {
-                        account: account_id,
-                        permission,
-                    })
-                    .map(AccountEvent::PermissionRemoved)
-                    .chain(std::iter::once(AccountEvent::RoleRevoked(
-                        AccountRoleChanged {
-                            account: account_id_clone,
-                            role: role_id,
-                        },
-                    )))
-            });
+            state_transaction
+                .world
+                .emit_events(Some(AccountEvent::RoleRevoked(AccountRoleChanged {
+                    account: account_id.clone(),
+                    role: role_id,
+                })));
 
             Ok(())
         }

--- a/crates/iroha_core/src/smartcontracts/isi/world.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/world.rs
@@ -417,7 +417,7 @@ pub mod isi {
 
             state_transaction
                 .world
-                .emit_events(std::iter::once(ExecutorEvent::Upgraded(ExecutorUpgrade {
+                .emit_events(Some(ExecutorEvent::Upgraded(ExecutorUpgrade {
                     new_data_model: state_transaction.world.executor_data_model.clone(),
                 })));
 

--- a/crates/iroha_core/src/state.rs
+++ b/crates/iroha_core/src/state.rs
@@ -576,20 +576,10 @@ pub trait WorldReadOnly {
     fn account_permissions_iter<'slf>(
         &'slf self,
         account_id: &AccountId,
-    ) -> Result<std::collections::btree_set::IntoIter<&'slf Permission>, FindError> {
+    ) -> Result<std::collections::btree_set::Iter<'slf, Permission>, FindError> {
         self.account(account_id)?;
 
-        let mut tokens = self
-            .account_inherent_permissions(account_id)
-            .collect::<BTreeSet<_>>();
-
-        for role_id in self.account_roles_iter(account_id) {
-            if let Some(role) = self.roles().get(role_id) {
-                tokens.extend(role.permissions.iter());
-            }
-        }
-
-        Ok(tokens.into_iter())
+        Ok(self.account_inherent_permissions(account_id))
     }
 
     /// Return a set of permission tokens granted to this account not as part of any role.

--- a/crates/iroha_data_model/src/isi.rs
+++ b/crates/iroha_data_model/src/isi.rs
@@ -823,7 +823,7 @@ mod transparent {
 
     impl Grant<RoleId, Account> {
         /// Constructs a new [`Grant`] for a [`Role`].
-        pub fn role(role_id: RoleId, to: AccountId) -> Self {
+        pub fn account_role(role_id: RoleId, to: AccountId) -> Self {
             Self {
                 object: role_id,
                 destination: to,

--- a/crates/iroha_data_model/src/role.rs
+++ b/crates/iroha_data_model/src/role.rs
@@ -7,6 +7,7 @@ use iroha_data_model_derive::model;
 
 pub use self::model::*;
 use crate::{
+    account::AccountId,
     permission::{Permission, Permissions},
     Identifiable, Name, Registered,
 };
@@ -76,23 +77,23 @@ mod model {
         Serialize,
         IntoSchema,
     )]
-    #[serde(transparent, rename = "Role")]
-    #[ffi_type(unsafe {robust})]
+    #[ffi_type]
     #[getset(get = "pub")]
-    #[schema(transparent)]
-    #[repr(transparent)]
+    #[display(fmt = "{grant_to}: {inner}")]
     pub struct NewRole {
         #[allow(missing_docs)]
         #[id(transparent)]
         pub inner: Role,
+        /// First owner
+        pub grant_to: AccountId,
     }
 }
 
 impl Role {
     /// Constructor.
     #[inline]
-    pub fn new(id: RoleId) -> <Self as Registered>::With {
-        NewRole::new(id)
+    pub fn new(id: RoleId, grant_to: AccountId) -> <Self as Registered>::With {
+        NewRole::new(id, grant_to)
     }
 
     /// Get an iterator over [`permissions`](Permission) of the `Role`
@@ -106,8 +107,9 @@ impl NewRole {
     /// Constructor
     #[must_use]
     #[inline]
-    fn new(id: RoleId) -> Self {
+    fn new(id: RoleId, grant_to: AccountId) -> Self {
         Self {
+            grant_to,
             inner: Role {
                 id,
                 permissions: Permissions::new(),

--- a/crates/iroha_executor/src/lib.rs
+++ b/crates/iroha_executor/src/lib.rs
@@ -137,7 +137,12 @@ mod host {
 #[macro_export]
 macro_rules! execute {
     ($executor:ident, $isi:ident) => {{
-        if $executor.verdict().is_ok() {
+        #[cfg(debug_assertions)]
+        if !$executor.verdict().is_ok() {
+            unreachable!("Executor already denied");
+        }
+
+        {
             use $crate::smart_contract::ExecuteOnHost as _;
 
             if let Err(err) = $isi.execute() {
@@ -156,7 +161,7 @@ macro_rules! execute {
 macro_rules! deny {
     ($executor:ident, $l:literal $(,)?) => {{
         #[cfg(debug_assertions)]
-        if let Err(_error) = $executor.verdict() {
+        if $executor.verdict().is_err() {
             unreachable!("Executor already denied");
         }
         $executor.deny($crate::data_model::ValidationFail::NotPermitted(
@@ -166,7 +171,7 @@ macro_rules! deny {
     }};
     ($executor:ident, $e:expr $(,)?) => {{
         #[cfg(debug_assertions)]
-        if let Err(_error) = $executor.verdict() {
+        if $executor.verdict().is_err() {
             unreachable!("Executor already denied");
         }
         $executor.deny($e);

--- a/crates/iroha_executor_data_model/src/permission.rs
+++ b/crates/iroha_executor_data_model/src/permission.rs
@@ -37,12 +37,17 @@ pub mod peer {
 
     permission! {
         #[derive(Copy)]
-        pub struct CanUnregisterAnyPeer;
+        pub struct CanManagePeers;
     }
 }
 
 pub mod domain {
     use super::*;
+
+    permission! {
+        #[derive(Copy)]
+        pub struct CanRegisterDomain;
+    }
 
     permission! {
         pub struct CanUnregisterDomain {
@@ -51,25 +56,7 @@ pub mod domain {
     }
 
     permission! {
-        pub struct CanSetKeyValueInDomain {
-            pub domain: DomainId,
-        }
-    }
-
-    permission! {
-        pub struct CanRemoveKeyValueInDomain {
-            pub domain: DomainId,
-        }
-    }
-
-    permission! {
-        pub struct CanRegisterAccountInDomain {
-            pub domain: DomainId,
-        }
-    }
-
-    permission! {
-        pub struct CanRegisterAssetDefinitionInDomain {
+        pub struct CanModifyDomainMetadata {
             pub domain: DomainId,
         }
     }
@@ -79,19 +66,19 @@ pub mod asset_definition {
     use super::*;
 
     permission! {
+        pub struct CanRegisterAssetDefinition {
+            pub domain: DomainId,
+        }
+    }
+
+    permission! {
         pub struct CanUnregisterAssetDefinition {
             pub asset_definition: AssetDefinitionId,
         }
     }
 
     permission! {
-        pub struct CanSetKeyValueInAssetDefinition {
-            pub asset_definition: AssetDefinitionId,
-        }
-    }
-
-    permission! {
-        pub struct CanRemoveKeyValueInAssetDefinition {
+        pub struct CanModifyAssetDefinitionMetadata {
             pub asset_definition: AssetDefinitionId,
         }
     }
@@ -101,17 +88,18 @@ pub mod account {
     use super::*;
 
     permission! {
+        pub struct CanRegisterAccount {
+            pub domain: DomainId,
+        }
+    }
+
+    permission! {
         pub struct CanUnregisterAccount {
             pub account: AccountId,
         }
     }
     permission! {
-        pub struct CanSetKeyValueInAccount {
-            pub account: AccountId,
-        }
-    }
-    permission! {
-        pub struct CanRemoveKeyValueInAccount {
+        pub struct CanModifyAccountMetadata {
             pub account: AccountId,
         }
     }
@@ -133,56 +121,90 @@ pub mod asset {
     }
 
     permission! {
-        pub struct CanUnregisterUserAsset {
-            pub asset: AssetId,
-        }
-    }
-
-    permission! {
-        pub struct CanBurnAssetWithDefinition {
+        pub struct CanMintAssetsWithDefinition {
             pub asset_definition: AssetDefinitionId,
         }
     }
 
     permission! {
-        pub struct CanBurnUserAsset {
-            pub asset: AssetId,
-        }
-    }
-
-    permission! {
-        pub struct CanMintAssetWithDefinition {
+        pub struct CanBurnAssetsWithDefinition {
             pub asset_definition: AssetDefinitionId,
         }
     }
 
     permission! {
-        pub struct CanMintUserAsset {
-            pub asset: AssetId,
-        }
-    }
-
-    permission! {
-        pub struct CanTransferAssetWithDefinition {
+        pub struct CanTransferAssetsWithDefinition {
             pub asset_definition: AssetDefinitionId,
         }
     }
 
     permission! {
-        pub struct CanTransferUserAsset {
+        pub struct CanRegisterAsset {
+            pub owner: AccountId,
+        }
+    }
+
+    permission! {
+        pub struct CanUnregisterAsset {
             pub asset: AssetId,
         }
     }
 
     permission! {
-        pub struct CanSetKeyValueInUserAsset {
+        pub struct CanMintAsset {
             pub asset: AssetId,
         }
     }
 
     permission! {
-        pub struct CanRemoveKeyValueInUserAsset {
+        pub struct CanBurnAsset {
             pub asset: AssetId,
+        }
+    }
+
+    permission! {
+        pub struct CanTransferAsset {
+            pub asset: AssetId,
+        }
+    }
+
+    permission! {
+        pub struct CanModifyAssetMetadata {
+            pub asset: AssetId,
+        }
+    }
+}
+
+pub mod trigger {
+    use super::*;
+
+    permission! {
+        pub struct CanRegisterTrigger {
+            pub authority: AccountId,
+        }
+    }
+
+    permission! {
+        pub struct CanUnregisterTrigger {
+            pub trigger: TriggerId,
+        }
+    }
+
+    permission! {
+        pub struct CanModifyTrigger {
+            pub trigger: TriggerId,
+        }
+    }
+
+    permission! {
+        pub struct CanExecuteTrigger {
+            pub trigger: TriggerId,
+        }
+    }
+
+    permission! {
+        pub struct CanModifyTriggerMetadata {
+            pub trigger: TriggerId,
         }
     }
 }
@@ -201,53 +223,7 @@ pub mod role {
 
     permission! {
         #[derive(Copy)]
-        pub struct CanUnregisterAnyRole;
-    }
-}
-
-pub mod trigger {
-    use super::*;
-
-    permission! {
-        pub struct CanRegisterUserTrigger {
-            pub account: AccountId,
-        }
-    }
-
-    permission! {
-        pub struct CanExecuteUserTrigger {
-            pub trigger: TriggerId,
-        }
-    }
-
-    permission! {
-        pub struct CanUnregisterUserTrigger {
-            pub account: AccountId,
-        }
-    }
-
-    permission! {
-        pub struct CanMintUserTrigger {
-            pub trigger: TriggerId,
-        }
-    }
-
-    permission! {
-        pub struct CanBurnUserTrigger {
-            pub trigger: TriggerId,
-        }
-    }
-
-    permission! {
-        pub struct CanSetKeyValueInTrigger {
-            pub trigger: TriggerId,
-        }
-    }
-
-    permission! {
-        pub struct CanRemoveKeyValueInTrigger {
-            pub trigger: TriggerId,
-        }
+        pub struct CanManageRoles;
     }
 }
 

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -64,38 +64,31 @@ pub fn build_schemas() -> MetaMap {
         MerkleTree<SignedTransaction>,
 
         // Default permissions
-        permission::peer::CanUnregisterAnyPeer,
+        permission::peer::CanManagePeers,
         permission::domain::CanUnregisterDomain,
-        permission::domain::CanSetKeyValueInDomain,
-        permission::domain::CanRemoveKeyValueInDomain,
-        permission::domain::CanRegisterAccountInDomain,
-        permission::domain::CanRegisterAssetDefinitionInDomain,
+        permission::domain::CanModifyDomainMetadata,
+        permission::account::CanRegisterAccount,
         permission::account::CanUnregisterAccount,
-        permission::account::CanSetKeyValueInAccount,
-        permission::account::CanRemoveKeyValueInAccount,
+        permission::account::CanModifyAccountMetadata,
+        permission::asset_definition::CanRegisterAssetDefinition,
         permission::asset_definition::CanUnregisterAssetDefinition,
-        permission::asset_definition::CanSetKeyValueInAssetDefinition,
-        permission::asset_definition::CanRemoveKeyValueInAssetDefinition,
+        permission::asset_definition::CanModifyAssetDefinitionMetadata,
         permission::asset::CanRegisterAssetWithDefinition,
         permission::asset::CanUnregisterAssetWithDefinition,
-        permission::asset::CanUnregisterUserAsset,
-        permission::asset::CanBurnAssetWithDefinition,
-        permission::asset::CanMintAssetWithDefinition,
-        permission::asset::CanMintUserAsset,
-        permission::asset::CanBurnUserAsset,
-        permission::asset::CanTransferAssetWithDefinition,
-        permission::asset::CanTransferUserAsset,
-        permission::asset::CanSetKeyValueInUserAsset,
-        permission::asset::CanRemoveKeyValueInUserAsset,
+        permission::asset::CanTransferAssetsWithDefinition,
+        permission::asset::CanRegisterAsset,
+        permission::asset::CanUnregisterAsset,
+        permission::asset::CanMintAsset,
+        permission::asset::CanBurnAsset,
+        permission::asset::CanTransferAsset,
+        permission::asset::CanModifyAssetMetadata,
         permission::parameter::CanSetParameters,
-        permission::role::CanUnregisterAnyRole,
-        permission::trigger::CanRegisterUserTrigger,
-        permission::trigger::CanExecuteUserTrigger,
-        permission::trigger::CanUnregisterUserTrigger,
-        permission::trigger::CanMintUserTrigger,
-        permission::trigger::CanBurnUserTrigger,
-        permission::trigger::CanSetKeyValueInTrigger,
-        permission::trigger::CanRemoveKeyValueInTrigger,
+        permission::role::CanManageRoles,
+        permission::trigger::CanRegisterTrigger,
+        permission::trigger::CanExecuteTrigger,
+        permission::trigger::CanUnregisterTrigger,
+        permission::trigger::CanModifyTrigger,
+        permission::trigger::CanModifyTriggerMetadata,
         permission::executor::CanUpgradeExecutor,
 
         // Genesis file - used by SDKs to generate the genesis block
@@ -597,75 +590,46 @@ mod tests {
         insert_into_test_map!(Compact<u128>);
         insert_into_test_map!(Compact<u32>);
 
-        insert_into_test_map!(iroha_executor_data_model::permission::peer::CanUnregisterAnyPeer);
+        insert_into_test_map!(iroha_executor_data_model::permission::peer::CanManagePeers);
         insert_into_test_map!(iroha_executor_data_model::permission::domain::CanUnregisterDomain);
         insert_into_test_map!(
-            iroha_executor_data_model::permission::domain::CanSetKeyValueInDomain
+            iroha_executor_data_model::permission::domain::CanModifyDomainMetadata
         );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::domain::CanRemoveKeyValueInDomain
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::domain::CanRegisterAccountInDomain
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::domain::CanRegisterAssetDefinitionInDomain
-        );
+        insert_into_test_map!(iroha_executor_data_model::permission::account::CanRegisterAccount);
         insert_into_test_map!(iroha_executor_data_model::permission::account::CanUnregisterAccount);
         insert_into_test_map!(
-            iroha_executor_data_model::permission::account::CanSetKeyValueInAccount
+            iroha_executor_data_model::permission::account::CanModifyAccountMetadata
         );
         insert_into_test_map!(
-            iroha_executor_data_model::permission::account::CanRemoveKeyValueInAccount
+            iroha_executor_data_model::permission::asset_definition::CanRegisterAssetDefinition
         );
         insert_into_test_map!(
             iroha_executor_data_model::permission::asset_definition::CanUnregisterAssetDefinition
         );
-        insert_into_test_map!(iroha_executor_data_model::permission::asset_definition::CanSetKeyValueInAssetDefinition);
-        insert_into_test_map!(iroha_executor_data_model::permission::asset_definition::CanRemoveKeyValueInAssetDefinition);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset_definition::CanModifyAssetDefinitionMetadata);
         insert_into_test_map!(
             iroha_executor_data_model::permission::asset::CanRegisterAssetWithDefinition
         );
         insert_into_test_map!(
             iroha_executor_data_model::permission::asset::CanUnregisterAssetWithDefinition
         );
-        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanUnregisterUserAsset);
         insert_into_test_map!(
-            iroha_executor_data_model::permission::asset::CanBurnAssetWithDefinition
+            iroha_executor_data_model::permission::asset::CanTransferAssetsWithDefinition
         );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::asset::CanMintAssetWithDefinition
-        );
-        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanMintUserAsset);
-        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanBurnUserAsset);
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::asset::CanTransferAssetWithDefinition
-        );
-        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanTransferUserAsset);
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::asset::CanSetKeyValueInUserAsset
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::asset::CanRemoveKeyValueInUserAsset
-        );
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanRegisterAsset);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanUnregisterAsset);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanMintAsset);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanBurnAsset);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanTransferAsset);
+        insert_into_test_map!(iroha_executor_data_model::permission::asset::CanModifyAssetMetadata);
         insert_into_test_map!(iroha_executor_data_model::permission::parameter::CanSetParameters);
-        insert_into_test_map!(iroha_executor_data_model::permission::role::CanUnregisterAnyRole);
+        insert_into_test_map!(iroha_executor_data_model::permission::role::CanManageRoles);
+        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanRegisterTrigger);
+        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanExecuteTrigger);
+        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanUnregisterTrigger);
+        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanModifyTrigger);
         insert_into_test_map!(
-            iroha_executor_data_model::permission::trigger::CanRegisterUserTrigger
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::trigger::CanExecuteUserTrigger
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::trigger::CanUnregisterUserTrigger
-        );
-        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanMintUserTrigger);
-        insert_into_test_map!(iroha_executor_data_model::permission::trigger::CanBurnUserTrigger);
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::trigger::CanSetKeyValueInTrigger
-        );
-        insert_into_test_map!(
-            iroha_executor_data_model::permission::trigger::CanRemoveKeyValueInTrigger
+            iroha_executor_data_model::permission::trigger::CanModifyTriggerMetadata
         );
         insert_into_test_map!(iroha_executor_data_model::permission::executor::CanUpgradeExecutor);
 

--- a/crates/iroha_test_network/src/lib.rs
+++ b/crates/iroha_test_network/src/lib.rs
@@ -14,11 +14,8 @@ pub use iroha_core::state::StateReadOnly;
 use iroha_crypto::{ExposedPrivateKey, KeyPair};
 use iroha_data_model::{asset::AssetDefinitionId, isi::InstructionBox, ChainId};
 use iroha_executor_data_model::permission::{
-    asset::{CanBurnAssetWithDefinition, CanMintAssetWithDefinition},
-    domain::CanUnregisterDomain,
-    executor::CanUpgradeExecutor,
-    peer::CanUnregisterAnyPeer,
-    role::CanUnregisterAnyRole,
+    asset::CanMintAssetsWithDefinition, domain::CanUnregisterDomain, executor::CanUpgradeExecutor,
+    peer::CanManagePeers, role::CanManageRoles,
 };
 use iroha_futures::supervisor::ShutdownSignal;
 use iroha_genesis::{GenesisBlock, RawGenesisTransaction};
@@ -99,22 +96,16 @@ impl TestGenesis for GenesisBlock {
 
         let rose_definition_id = "rose#wonderland".parse::<AssetDefinitionId>().unwrap();
 
-        let grant_mint_rose_permission = Grant::account_permission(
-            CanMintAssetWithDefinition {
+        let grant_modify_rose_permission = Grant::account_permission(
+            CanMintAssetsWithDefinition {
                 asset_definition: rose_definition_id.clone(),
             },
             ALICE_ID.clone(),
         );
-        let grant_burn_rose_permission = Grant::account_permission(
-            CanBurnAssetWithDefinition {
-                asset_definition: rose_definition_id,
-            },
-            ALICE_ID.clone(),
-        );
-        let grant_unregister_any_peer_permission =
-            Grant::account_permission(CanUnregisterAnyPeer, ALICE_ID.clone());
-        let grant_unregister_any_role_permission =
-            Grant::account_permission(CanUnregisterAnyRole, ALICE_ID.clone());
+        let grant_manage_peers_permission =
+            Grant::account_permission(CanManagePeers, ALICE_ID.clone());
+        let grant_manage_roles_permission =
+            Grant::account_permission(CanManageRoles, ALICE_ID.clone());
         let grant_unregister_wonderland_domain = Grant::account_permission(
             CanUnregisterDomain {
                 domain: "wonderland".parse().unwrap(),
@@ -124,10 +115,9 @@ impl TestGenesis for GenesisBlock {
         let grant_upgrade_executor_permission =
             Grant::account_permission(CanUpgradeExecutor, ALICE_ID.clone());
         for isi in [
-            grant_mint_rose_permission,
-            grant_burn_rose_permission,
-            grant_unregister_any_peer_permission,
-            grant_unregister_any_role_permission,
+            grant_modify_rose_permission,
+            grant_manage_peers_permission,
+            grant_manage_roles_permission,
             grant_unregister_wonderland_domain,
             grant_upgrade_executor_permission,
         ] {

--- a/defaults/genesis.json
+++ b/defaults/genesis.json
@@ -140,23 +140,13 @@
       }
     },
     {
-      "Register": {
-        "Role": {
-          "id": "ALICE_METADATA_ACCESS",
-          "permissions": [
-            {
-              "name": "CanRemoveKeyValueInAccount",
-              "payload": {
-                "account": "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
-              }
-            },
-            {
-              "name": "CanSetKeyValueInAccount",
-              "payload": {
-                "account": "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
-              }
-            }
-          ]
+      "Grant": {
+        "Permission": {
+          "object": {
+            "name": "CanRegisterDomain",
+            "payload": null
+          },
+          "destination": "ed0120CE7FA46C9DCE7EA4B125E2E36BDB63EA33073E7590AC92816AE1E861B7048B03@wonderland"
         }
       }
     }

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -802,15 +802,7 @@
       }
     ]
   },
-  "CanBurnAssetWithDefinition": {
-    "Struct": [
-      {
-        "name": "asset_definition",
-        "type": "AssetDefinitionId"
-      }
-    ]
-  },
-  "CanBurnUserAsset": {
+  "CanBurnAsset": {
     "Struct": [
       {
         "name": "asset",
@@ -818,7 +810,7 @@
       }
     ]
   },
-  "CanBurnUserTrigger": {
+  "CanExecuteTrigger": {
     "Struct": [
       {
         "name": "trigger",
@@ -826,23 +818,9 @@
       }
     ]
   },
-  "CanExecuteUserTrigger": {
-    "Struct": [
-      {
-        "name": "trigger",
-        "type": "TriggerId"
-      }
-    ]
-  },
-  "CanMintAssetWithDefinition": {
-    "Struct": [
-      {
-        "name": "asset_definition",
-        "type": "AssetDefinitionId"
-      }
-    ]
-  },
-  "CanMintUserAsset": {
+  "CanManagePeers": null,
+  "CanManageRoles": null,
+  "CanMintAsset": {
     "Struct": [
       {
         "name": "asset",
@@ -850,15 +828,31 @@
       }
     ]
   },
-  "CanMintUserTrigger": {
+  "CanModifyAccountMetadata": {
     "Struct": [
       {
-        "name": "trigger",
-        "type": "TriggerId"
+        "name": "account",
+        "type": "AccountId"
       }
     ]
   },
-  "CanRegisterAccountInDomain": {
+  "CanModifyAssetDefinitionMetadata": {
+    "Struct": [
+      {
+        "name": "asset_definition",
+        "type": "AssetDefinitionId"
+      }
+    ]
+  },
+  "CanModifyAssetMetadata": {
+    "Struct": [
+      {
+        "name": "asset",
+        "type": "AssetId"
+      }
+    ]
+  },
+  "CanModifyDomainMetadata": {
     "Struct": [
       {
         "name": "domain",
@@ -866,7 +860,39 @@
       }
     ]
   },
-  "CanRegisterAssetDefinitionInDomain": {
+  "CanModifyTrigger": {
+    "Struct": [
+      {
+        "name": "trigger",
+        "type": "TriggerId"
+      }
+    ]
+  },
+  "CanModifyTriggerMetadata": {
+    "Struct": [
+      {
+        "name": "trigger",
+        "type": "TriggerId"
+      }
+    ]
+  },
+  "CanRegisterAccount": {
+    "Struct": [
+      {
+        "name": "domain",
+        "type": "DomainId"
+      }
+    ]
+  },
+  "CanRegisterAsset": {
+    "Struct": [
+      {
+        "name": "owner",
+        "type": "AccountId"
+      }
+    ]
+  },
+  "CanRegisterAssetDefinition": {
     "Struct": [
       {
         "name": "domain",
@@ -882,108 +908,28 @@
       }
     ]
   },
-  "CanRegisterUserTrigger": {
+  "CanRegisterTrigger": {
     "Struct": [
       {
-        "name": "account",
+        "name": "authority",
         "type": "AccountId"
-      }
-    ]
-  },
-  "CanRemoveKeyValueInAccount": {
-    "Struct": [
-      {
-        "name": "account",
-        "type": "AccountId"
-      }
-    ]
-  },
-  "CanRemoveKeyValueInAssetDefinition": {
-    "Struct": [
-      {
-        "name": "asset_definition",
-        "type": "AssetDefinitionId"
-      }
-    ]
-  },
-  "CanRemoveKeyValueInDomain": {
-    "Struct": [
-      {
-        "name": "domain",
-        "type": "DomainId"
-      }
-    ]
-  },
-  "CanRemoveKeyValueInTrigger": {
-    "Struct": [
-      {
-        "name": "trigger",
-        "type": "TriggerId"
-      }
-    ]
-  },
-  "CanRemoveKeyValueInUserAsset": {
-    "Struct": [
-      {
-        "name": "asset",
-        "type": "AssetId"
-      }
-    ]
-  },
-  "CanSetKeyValueInAccount": {
-    "Struct": [
-      {
-        "name": "account",
-        "type": "AccountId"
-      }
-    ]
-  },
-  "CanSetKeyValueInAssetDefinition": {
-    "Struct": [
-      {
-        "name": "asset_definition",
-        "type": "AssetDefinitionId"
-      }
-    ]
-  },
-  "CanSetKeyValueInDomain": {
-    "Struct": [
-      {
-        "name": "domain",
-        "type": "DomainId"
-      }
-    ]
-  },
-  "CanSetKeyValueInTrigger": {
-    "Struct": [
-      {
-        "name": "trigger",
-        "type": "TriggerId"
-      }
-    ]
-  },
-  "CanSetKeyValueInUserAsset": {
-    "Struct": [
-      {
-        "name": "asset",
-        "type": "AssetId"
       }
     ]
   },
   "CanSetParameters": null,
-  "CanTransferAssetWithDefinition": {
-    "Struct": [
-      {
-        "name": "asset_definition",
-        "type": "AssetDefinitionId"
-      }
-    ]
-  },
-  "CanTransferUserAsset": {
+  "CanTransferAsset": {
     "Struct": [
       {
         "name": "asset",
         "type": "AssetId"
+      }
+    ]
+  },
+  "CanTransferAssetsWithDefinition": {
+    "Struct": [
+      {
+        "name": "asset_definition",
+        "type": "AssetDefinitionId"
       }
     ]
   },
@@ -995,8 +941,14 @@
       }
     ]
   },
-  "CanUnregisterAnyPeer": null,
-  "CanUnregisterAnyRole": null,
+  "CanUnregisterAsset": {
+    "Struct": [
+      {
+        "name": "asset",
+        "type": "AssetId"
+      }
+    ]
+  },
   "CanUnregisterAssetDefinition": {
     "Struct": [
       {
@@ -1021,19 +973,11 @@
       }
     ]
   },
-  "CanUnregisterUserAsset": {
+  "CanUnregisterTrigger": {
     "Struct": [
       {
-        "name": "asset",
-        "type": "AssetId"
-      }
-    ]
-  },
-  "CanUnregisterUserTrigger": {
-    "Struct": [
-      {
-        "name": "account",
-        "type": "AccountId"
+        "name": "trigger",
+        "type": "TriggerId"
       }
     ]
   },
@@ -2680,6 +2624,18 @@
       }
     ]
   },
+  "NewRole": {
+    "Struct": [
+      {
+        "name": "inner",
+        "type": "Role"
+      },
+      {
+        "name": "grant_to",
+        "type": "AccountId"
+      }
+    ]
+  },
   "NonZero<u32>": "u32",
   "NonZero<u64>": "u64",
   "Numeric": {
@@ -3517,7 +3473,7 @@
     "Struct": [
       {
         "name": "object",
-        "type": "Role"
+        "type": "NewRole"
       }
     ]
   },

--- a/wasm_samples/executor_with_custom_permission/src/lib.rs
+++ b/wasm_samples/executor_with_custom_permission/src/lib.rs
@@ -19,7 +19,7 @@ extern crate panic_halt;
 use dlmalloc::GlobalDlmalloc;
 use executor_custom_data_model::permissions::CanControlDomainLives;
 use iroha_executor::{
-    data_model::prelude::*, permission::ExecutorPermision as _, prelude::*, smart_contract::query,
+    data_model::prelude::*, permission::ExecutorPermission as _, prelude::*, smart_contract::query,
     DataModelBuilder,
 };
 use iroha_executor_data_model::permission::domain::CanUnregisterDomain;


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

- added `CanManagePeers`, `CanRegisterDomain` and `CanManageRoles` permissions
- unified `CanSetKeyValueXXX` + `CanRemoveKeyValueXXX` = `CanModifyXXXMetadata`
- unified `CanMintAsset` + `CanBurnAsset` + `CanTransferAsset` = `CanModifyAsset`
- changed `FindPermissions` so it returns only inherent permissions, not from roles 
- fixed validation of grant/revoke for roles

closes #4206

### Solution

- Describe the approach taken to achieve the objective / resolve the issue.

### Review notes (optional)

- For complex PRs, try to provide some information on how to approach the review more effectively.
- For example, is there a natural order in which the affected files should be reviewed?

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->