### PR TITLE
refactor: make query cursor errors more specific

### DIFF
--- a/crates/iroha/tests/integration/queries/smart_contract.rs
+++ b/crates/iroha/tests/integration/queries/smart_contract.rs
@@ -33,9 +33,7 @@ fn live_query_is_dropped_after_smart_contract_end() -> Result<()> {
 
     assert!(matches!(
         err,
-        QueryError::Validation(ValidationFail::QueryFailed(
-            QueryExecutionFail::UnknownCursor
-        ))
+        QueryError::Validation(ValidationFail::QueryFailed(QueryExecutionFail::Dropped))
     ));
 
     Ok(())

--- a/crates/iroha/tests/integration/queries/smart_contract.rs
+++ b/crates/iroha/tests/integration/queries/smart_contract.rs
@@ -33,7 +33,7 @@ fn live_query_is_dropped_after_smart_contract_end() -> Result<()> {
 
     assert!(matches!(
         err,
-        QueryError::Validation(ValidationFail::QueryFailed(QueryExecutionFail::Dropped))
+        QueryError::Validation(ValidationFail::QueryFailed(QueryExecutionFail::NotFound))
     ));
 
     Ok(())

--- a/crates/iroha_core/src/query/store.rs
+++ b/crates/iroha_core/src/query/store.rs
@@ -284,7 +284,7 @@ impl LiveQueryStoreHandle {
     ///
     /// # Errors
     ///
-    /// - Returns an [`Error`] if the query id is not found, 
+    /// - Returns an [`Error`] if the query id is not found,
     ///   or if cursor position doesn't match or cannot continue.
     pub fn handle_iter_continue(
         &self,

--- a/crates/iroha_core/src/query/store.rs
+++ b/crates/iroha_core/src/query/store.rs
@@ -22,7 +22,7 @@ use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 
-use super::cursor::{QueryBatchedErasedIterator, UnknownCursor};
+use super::cursor::{Error as CursorError, QueryBatchedErasedIterator};
 
 /// Query service error.
 #[derive(
@@ -37,12 +37,14 @@ use super::cursor::{QueryBatchedErasedIterator, UnknownCursor};
     Decode,
 )]
 pub enum Error {
-    /// Unknown cursor error.
+    /// The query has been dropped from the store.
+    Dropped,
+    /// Cursor error.
     #[error(transparent)]
-    UnknownCursor(#[from] UnknownCursor),
+    Cursor(#[from] CursorError),
     /// Fetch size is too big.
     FetchSizeTooBig,
-    /// Reached limit of parallel queries. Either wait for previous queries to complete, or increase the limit in the config.
+    /// Reached the limit of parallel queries. Either wait for previous queries to complete, or increase the limit in the config.
     CapacityLimit,
 }
 
@@ -50,7 +52,11 @@ pub enum Error {
 impl From<Error> for QueryExecutionFail {
     fn from(error: Error) -> Self {
         match error {
-            Error::UnknownCursor(_) => QueryExecutionFail::UnknownCursor,
+            Error::Dropped => QueryExecutionFail::Dropped,
+            Error::Cursor(error) => match error {
+                CursorError::Mismatch => QueryExecutionFail::CursorMismatch,
+                CursorError::Done => QueryExecutionFail::CursorDone,
+            },
             Error::FetchSizeTooBig => QueryExecutionFail::FetchSizeTooBig,
             Error::CapacityLimit => QueryExecutionFail::CapacityLimit,
         }
@@ -204,7 +210,7 @@ impl LiveQueryStore {
             mut live_query,
             authority,
             ..
-        } = self.remove(&query_id).ok_or(UnknownCursor)?;
+        } = self.remove(&query_id).ok_or(Error::Dropped)?;
         let (next_batch, next_cursor) = live_query.next_batch(cursor.get())?;
         let remaining = live_query.remaining();
         if next_cursor.is_some() {
@@ -278,7 +284,8 @@ impl LiveQueryStoreHandle {
     ///
     /// # Errors
     ///
-    /// - Returns [`Error::UnknownCursor`] if query id not found or cursor position doesn't match.
+    /// - Returns an [`Error`] if the query id is not found, 
+    ///   or if cursor position doesn't match or cannot continue.
     pub fn handle_iter_continue(
         &self,
         ForwardCursor { query, cursor }: ForwardCursor,

--- a/crates/iroha_data_model/src/query/mod.rs
+++ b/crates/iroha_data_model/src/query/mod.rs
@@ -1029,10 +1029,10 @@ pub mod error {
                 #[skip_try_from]
                 String,
             ),
+            /// Query not found in the live query store.
+            NotFound,
             /// The server's cursor does not match the provided cursor.
             CursorMismatch,
-            /// The query has been dropped.
-            Dropped,
             /// There aren't enough items for the cursor to proceed.
             CursorDone,
             /// fetch_size could not be greater than {MAX_FETCH_SIZE:?}

--- a/crates/iroha_data_model/src/query/mod.rs
+++ b/crates/iroha_data_model/src/query/mod.rs
@@ -12,7 +12,7 @@ use iroha_macro::FromVariant;
 use iroha_primitives::{json::JsonString, numeric::Numeric};
 use iroha_schema::IntoSchema;
 use iroha_version::prelude::*;
-use parameters::{ForwardCursor, QueryParams, MAX_FETCH_SIZE};
+use parameters::{ForwardCursor, QueryParams};
 use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
@@ -58,7 +58,6 @@ pub trait Query: Sealed {
 
 #[model]
 mod model {
-
     use getset::Getters;
     use iroha_crypto::HashOf;
 
@@ -1001,6 +1000,7 @@ pub mod error {
     #[model]
     mod model {
         use super::*;
+        use crate::query::parameters::MAX_FETCH_SIZE;
 
         /// Query errors.
         #[derive(
@@ -1029,13 +1029,17 @@ pub mod error {
                 #[skip_try_from]
                 String,
             ),
-            /// Unknown query cursor
-            UnknownCursor,
+            /// The server's cursor does not match the provided cursor.
+            CursorMismatch,
+            /// The query has been dropped.
+            Dropped,
+            /// There aren't enough items for the cursor to proceed.
+            CursorDone,
             /// fetch_size could not be greater than {MAX_FETCH_SIZE:?}
             FetchSizeTooBig,
             /// Some of the specified parameters (filter/pagination/fetch_size/sorting) are not applicable to singular queries
             InvalidSingularParameters,
-            /// Reached limit of parallel queries. Either wait for previous queries to complete, or increase the limit in the config.
+            /// Reached the limit of parallel queries. Either wait for previous queries to complete, or increase the limit in the config.
             CapacityLimit,
         }
 

--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -381,9 +381,12 @@ impl Error {
             QueryFailed(query_error)
             | InstructionFailed(InstructionExecutionError::Query(query_error)) => match query_error
             {
-                Conversion(_) | UnknownCursor | FetchSizeTooBig | InvalidSingularParameters => {
-                    StatusCode::BAD_REQUEST
-                }
+                Conversion(_)
+                | CursorMismatch
+                | CursorDone
+                | Dropped
+                | FetchSizeTooBig
+                | InvalidSingularParameters => StatusCode::BAD_REQUEST,
                 Find(_) => StatusCode::NOT_FOUND,
                 CapacityLimit => StatusCode::TOO_MANY_REQUESTS,
             },

--- a/crates/iroha_torii/src/lib.rs
+++ b/crates/iroha_torii/src/lib.rs
@@ -384,7 +384,7 @@ impl Error {
                 Conversion(_)
                 | CursorMismatch
                 | CursorDone
-                | Dropped
+                | NotFound
                 | FetchSizeTooBig
                 | InvalidSingularParameters => StatusCode::BAD_REQUEST,
                 Find(_) => StatusCode::NOT_FOUND,

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -3080,11 +3080,11 @@
         "type": "String"
       },
       {
-        "tag": "CursorMismatch",
+        "tag": "NotFound",
         "discriminant": 2
       },
       {
-        "tag": "Dropped",
+        "tag": "CursorMismatch",
         "discriminant": 3
       },
       {

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -3080,20 +3080,28 @@
         "type": "String"
       },
       {
-        "tag": "UnknownCursor",
+        "tag": "CursorMismatch",
         "discriminant": 2
       },
       {
-        "tag": "FetchSizeTooBig",
+        "tag": "Dropped",
         "discriminant": 3
       },
       {
-        "tag": "InvalidSingularParameters",
+        "tag": "CursorDone",
         "discriminant": 4
       },
       {
-        "tag": "CapacityLimit",
+        "tag": "FetchSizeTooBig",
         "discriminant": 5
+      },
+      {
+        "tag": "InvalidSingularParameters",
+        "discriminant": 6
+      },
+      {
+        "tag": "CapacityLimit",
+        "discriminant": 7
       }
     ]
   },


### PR DESCRIPTION
## Context

- Makes the `UnknownCursor` error more specific. There are several places with different logic where this error is returned (query not found, cursor mismatch, not enough items). Moves the error thrown on a query not being found in the store from `UnknownCursor`.
- Part of investigation of #5085.

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.