### PR TITLE
perf: Reduce memory usage of `CommittedTransaction`

### DIFF
--- a/crates/iroha_core/src/block.rs
+++ b/crates/iroha_core/src/block.rs
@@ -232,7 +232,7 @@ mod pending {
                         );
                         CommittedTransaction {
                             value: tx,
-                            error: Some(error),
+                            error: Some(Box::new(error)),
                         }
                     }
                 })

--- a/crates/iroha_data_model/src/query/predicate/predicate_atoms/block.rs
+++ b/crates/iroha_data_model/src/query/predicate/predicate_atoms/block.rs
@@ -1,7 +1,7 @@
 //! This module contains predicates for block-related objects, mirroring [`crate::block`].
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, string::String, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec::Vec};
 
 use iroha_crypto::HashOf;
 use iroha_schema::IntoSchema;
@@ -128,10 +128,10 @@ pub enum TransactionErrorPredicateBox {
     IsSome,
 }
 
-impl_predicate_box!(Option<TransactionRejectionReason>: TransactionErrorPredicateBox);
+impl_predicate_box!(Option<Box<TransactionRejectionReason>>: TransactionErrorPredicateBox);
 
-impl EvaluatePredicate<Option<TransactionRejectionReason>> for TransactionErrorPredicateBox {
-    fn applies(&self, input: &Option<TransactionRejectionReason>) -> bool {
+impl EvaluatePredicate<Option<Box<TransactionRejectionReason>>> for TransactionErrorPredicateBox {
+    fn applies(&self, input: &Option<Box<TransactionRejectionReason>>) -> bool {
         match self {
             TransactionErrorPredicateBox::IsSome => input.is_some(),
         }

--- a/crates/iroha_data_model/src/transaction.rs
+++ b/crates/iroha_data_model/src/transaction.rs
@@ -175,6 +175,7 @@ mod model {
         #[getset(skip)]
         pub value: SignedTransaction,
         /// Reason of rejection
+        // NOTE: Using `Box` reduces memory use by 10%
         pub error: Option<Box<error::TransactionRejectionReason>>,
     }
 }

--- a/crates/iroha_data_model/src/transaction.rs
+++ b/crates/iroha_data_model/src/transaction.rs
@@ -175,7 +175,7 @@ mod model {
         #[getset(skip)]
         pub value: SignedTransaction,
         /// Reason of rejection
-        pub error: Option<error::TransactionRejectionReason>,
+        pub error: Option<Box<error::TransactionRejectionReason>>,
     }
 }
 

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -330,7 +330,7 @@ types!(
     Option<PeerId>,
     Option<RoleId>,
     Option<TimeInterval>,
-    Option<TransactionRejectionReason>,
+    Option<Box<TransactionRejectionReason>>,
     Option<TransactionStatus>,
     Option<TriggerCompletedOutcomeType>,
     Option<TriggerId>,


### PR DESCRIPTION
## Context

Related: #5083

### Solution

`CommittedTransaction::error` takes 200 bytes and is `None` in case of a successful transaction. Using `Option<Box<...>` reduces memory usage of iroha approximately by 10% (considering that all transactions are successful and with testing configuration as in #5083)

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.