### PR TITLE
fix: put `CommittedTransaction::error` in block hash

### DIFF
--- a/crates/iroha_core/src/block.rs
+++ b/crates/iroha_core/src/block.rs
@@ -195,7 +195,7 @@ mod pending {
                 prev_block_hash: prev_block.map(SignedBlock::hash),
                 transactions_hash: transactions
                     .iter()
-                    .map(|value| value.as_ref().hash())
+                    .map(CommittedTransaction::hash)
                     .collect::<MerkleTree<_>>()
                     .hash()
                     .expect("INTERNAL BUG: Empty block created"),

--- a/crates/iroha_data_model/src/transaction.rs
+++ b/crates/iroha_data_model/src/transaction.rs
@@ -295,6 +295,14 @@ impl SignedTransaction {
     }
 }
 
+impl CommittedTransaction {
+    /// Calculate transaction [`Hash`](`iroha_crypto::HashOf`).
+    #[inline]
+    pub fn hash(&self) -> iroha_crypto::HashOf<Self> {
+        iroha_crypto::HashOf::new(self)
+    }
+}
+
 #[cfg(feature = "transparent_api")]
 impl From<SignedTransaction> for (AccountId, Executable) {
     fn from(source: SignedTransaction) -> Self {

--- a/crates/iroha_schema_gen/src/lib.rs
+++ b/crates/iroha_schema_gen/src/lib.rs
@@ -252,7 +252,7 @@ types!(
     Grant<Permission, Role>,
     Grant<RoleId, Account>,
     Hash,
-    HashOf<MerkleTree<SignedTransaction>>,
+    HashOf<MerkleTree<CommittedTransaction>>,
     HashOf<BlockHeader>,
     HashOf<SignedTransaction>,
     IdBox,

--- a/docs/source/references/schema.json
+++ b/docs/source/references/schema.json
@@ -673,7 +673,7 @@
       },
       {
         "name": "transactions_hash",
-        "type": "HashOf<MerkleTree<SignedTransaction>>"
+        "type": "HashOf<MerkleTree<CommittedTransaction>>"
       },
       {
         "name": "creation_time_ms",
@@ -2111,7 +2111,7 @@
   },
   "Hash": "Array<u8, 32>",
   "HashOf<BlockHeader>": "Hash",
-  "HashOf<MerkleTree<SignedTransaction>>": "Hash",
+  "HashOf<MerkleTree<CommittedTransaction>>": "Hash",
   "HashOf<SignedTransaction>": "Hash",
   "IdBox": {
     "Enum": [


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

Error in `CommittedTransaction` was not reflected in the block hash which allowed for this value to be tempered result in block false rejection.

Closes #5001.

### Solution

Include error in block hash calculation.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->