### PR TITLE
ci: Switch iroha2 default image to debian-based

### DIFF
--- a/.github/workflows/iroha2-custom-image.yml
+++ b/.github/workflows/iroha2-custom-image.yml
@@ -67,6 +67,8 @@ jobs:
       image: hyperledger/iroha2-ci:nightly-2024-09-09
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.CHECKOUT_REF }}
       - name: Download executor.wasm file
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -157,7 +157,7 @@ jobs:
           tags: docker.soramitsu.co.jp/iroha2/iroha2:dev-${{ github.event.pull_request.head.sha }}
           labels: commit=${{ github.sha }}
           build-args: TAG=dev
-          file: Dockerfile
+          file: Dockerfile.glibc
           # This context specification is required
           context: .
 
@@ -214,7 +214,7 @@ jobs:
         with:
           context: .
           load: true
-          file: Dockerfile
+          file: Dockerfile.glibc
           tags: |
             hyperledger/iroha:local
             hyperledger/iroha:dev

--- a/.github/workflows/iroha2-dev.yml
+++ b/.github/workflows/iroha2-dev.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           name: executor.wasm
           path: ${{ env.DOCKER_COMPOSE_PATH }}/executor.wasm
-          retention-days: 1
 
   registry_save_build_artifacts:
     runs-on: [self-hosted, Linux, iroha2]
@@ -61,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.glibc
           push: true
           tags: |
             hyperledger/iroha:dev

--- a/.github/workflows/iroha2-release.yml
+++ b/.github/workflows/iroha2-release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           load: true
-          file: Dockerfile
+          file: Dockerfile.glibc
           tags: |
             hyperledger/iroha:${{ env.TAG }}
             docker.soramitsu.co.jp/iroha2/iroha:${{ env.TAG }}

--- a/crates/iroha_swarm/src/lib.rs
+++ b/crates/iroha_swarm/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
-                  /bin/sh -c "
+                  /bin/bash -c "
                       EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
                       EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
                       jq \\
@@ -253,7 +253,7 @@ mod tests {
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
-                  /bin/sh -c "
+                  /bin/bash -c "
                       EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
                       EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
                       jq \\
@@ -306,7 +306,7 @@ mod tests {
                 - ./client.toml:/config/client.toml:ro
                 init: true
                 command: |-
-                  /bin/sh -c "
+                  /bin/bash -c "
                       EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
                       EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
                       jq \\
@@ -420,7 +420,7 @@ mod tests {
                   retries: 30
                   start_period: 4s
                 command: |-
-                  /bin/sh -c "
+                  /bin/bash -c "
                       EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
                       EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
                       jq \\
@@ -476,7 +476,7 @@ mod tests {
                   retries: 30
                   start_period: 4s
                 command: |-
-                  /bin/sh -c "
+                  /bin/bash -c "
                       EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
                       EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
                       jq \\

--- a/crates/iroha_swarm/src/schema.rs
+++ b/crates/iroha_swarm/src/schema.rs
@@ -327,7 +327,7 @@ where
 #[derive(Debug)]
 struct SignAndSubmitGenesis;
 
-const SIGN_AND_SUBMIT_GENESIS: &str = r#"/bin/sh -c "
+const SIGN_AND_SUBMIT_GENESIS: &str = r#"/bin/bash -c "
     EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
     EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
     jq \\

--- a/defaults/docker-compose.local.yml
+++ b/defaults/docker-compose.local.yml
@@ -32,7 +32,7 @@ services:
       retries: 30
       start_period: 4s
     command: |-
-      /bin/sh -c "
+      /bin/bash -c "
           EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
           EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
           jq \\

--- a/defaults/docker-compose.single.yml
+++ b/defaults/docker-compose.single.yml
@@ -31,7 +31,7 @@ services:
       retries: 30
       start_period: 4s
     command: |-
-      /bin/sh -c "
+      /bin/bash -c "
           EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
           EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
           jq \\

--- a/defaults/docker-compose.yml
+++ b/defaults/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       retries: 30
       start_period: 4s
     command: |-
-      /bin/sh -c "
+      /bin/bash -c "
           EXECUTOR_RELATIVE_PATH=$(jq -r '.executor' /config/genesis.json) && \\
           EXECUTOR_ABSOLUTE_PATH=$(realpath \"/config/$$EXECUTOR_RELATIVE_PATH\") && \\
           jq \\


### PR DESCRIPTION
### Solution
1. Use Debian based image by default for iroha2 image.
2. Set the default retention policy for `executor.wasm` artifact as we need it to be able to be downloaded.
3. Enable checkout branch/commit option for all custom images build & push job.

Close #5100 

### Note
Building iroha based on glibc and Debian increases compilation time in aboit two times.
iroha based on glibc and Debian increases image size in about three times.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.
