### PR TITLE
fix(iroha_config): broken trusted peers check

### DIFF
--- a/crates/iroha_config/Cargo.toml
+++ b/crates/iroha_config/Cargo.toml
@@ -40,3 +40,4 @@ stderrlog = "0.6.0"
 [dev-dependencies]
 expect-test = { workspace = true }
 assertables = { workspace = true }
+iroha_crypto = { workspace = true, features = ["rand"] }

--- a/crates/irohad/src/lib.rs
+++ b/crates/irohad/src/lib.rs
@@ -535,7 +535,13 @@ fn validate_config(config: &Config) -> Result<(), ConfigError> {
     // maybe validate only if snapshot mode is enabled
     validate_directory_path(&mut emitter, &config.snapshot.store_dir);
 
-    if config.genesis.file.is_none() && !config.sumeragi.contains_other_trusted_peers() {
+    if config.genesis.file.is_none()
+        && !config
+            .sumeragi
+            .trusted_peers
+            .value()
+            .contains_other_trusted_peers()
+    {
         emitter.emit(Report::new(ConfigError::LonePeer).attach_printable("\
             Reason: the network consists from this one peer only (no `sumeragi.trusted_peers` provided).\n\
             Since `genesis.file` is not set, there is no way to receive the genesis block.\n\


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

_Split from #5087_

When there was one trusted peer, it decided that there are no.

### Solution

Fix the check

### Migration Guide (optional)

None

---

### Review notes (optional)

None

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->