### PR TITLE
refactor(iroha_torii): spawn a single server task with only one `TcpListener`

### DIFF
--- a/crates/iroha_torii/Cargo.toml
+++ b/crates/iroha_torii/Cargo.toml
@@ -28,7 +28,7 @@ schema = ["iroha_schema", "iroha_schema_gen"]
 [dependencies]
 iroha_core = { workspace = true }
 iroha_config = { workspace = true }
-iroha_primitives = { workspace = true }
+iroha_primitives = { workspace = true, features = ["std"] }
 iroha_logger = { workspace = true }
 iroha_data_model = { workspace = true, features = ["http"] }
 iroha_version = { workspace = true }


### PR DESCRIPTION


## Context

Split from #5087 

Chore refactor: there was extra code complexity in Torii due to `iroha_primities::SocketAddr` not implementing `tokio::ToSocketAddrs`.

### Solution

Workarounded with a match construction.

### Migration Guide (optional)

None

---

### Review notes (optional)

None

### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->