### PR TITLE
fix: address `check-cfg` warnings + chores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ rust.unused_lifetimes = "warn"
 rust.unexpected_cfgs = { level = "warn", check-cfg = [
     # FIXME: https://github.com/hyperledger/iroha/issues/3102
     'cfg(feature, values("ffi_import"))',
-    # FIXME: was never supported https://github.com/hyperledger/iroha/issues/5139
-    #    'cfg(coverage)'
+    # It is set by `cargo-llvm-cov`
+    'cfg(coverage)'
 ] }
 
 # pedantic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ rust.unused_lifetimes = "warn"
 rust.unexpected_cfgs = { level = "warn", check-cfg = [
     # FIXME: https://github.com/hyperledger/iroha/issues/3102
     'cfg(feature, values("ffi_import"))',
-    # FIXME: was never supported
-    'cfg(coverage)'
+    # FIXME: was never supported https://github.com/hyperledger/iroha/issues/5139
+    #    'cfg(coverage)'
 ] }
 
 # pedantic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,9 +128,9 @@ mv = { version = "0.1.0" }
 [workspace.lints]
 rustdoc.private_doc_tests = "deny"
 
-rust.future_incompatible = {level = "deny", priority = -1 }
-rust.nonstandard_style = {level = "deny", priority = -1 }
-rust.rust_2018_idioms = {level = "deny", priority = -1 }
+rust.future_incompatible = { level = "deny", priority = -1 }
+rust.nonstandard_style = { level = "deny", priority = -1 }
+rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rust.unused = { level = "deny", priority = -1 }
 
 rust.anonymous_parameters = "deny"
@@ -149,6 +149,12 @@ rust.single_use_lifetimes = "warn"
 rust.unused_lifetimes = "warn"
 # TODO: reenable
 # rust.unsafe_op_in_unsafe_fn = "deny"
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    # FIXME: https://github.com/hyperledger/iroha/issues/3102
+    'cfg(feature, values("ffi_import"))',
+    # FIXME: was never supported
+    'cfg(coverage)'
+] }
 
 # pedantic
 clippy.pedantic = { level = "warn", priority = -1 }

--- a/crates/iroha_crypto/src/lib.rs
+++ b/crates/iroha_crypto/src/lib.rs
@@ -995,7 +995,6 @@ mod ffi {
     }
 
     // NOTE: Makes sure that only one `dealloc` is exported per generated dynamic library
-    #[cfg(any(crate_type = "dylib", crate_type = "cdylib"))]
     #[cfg(all(feature = "ffi_export", not(feature = "ffi_import")))]
     mod dylib {
         #[cfg(not(feature = "std"))]

--- a/crates/iroha_data_model/src/lib.rs
+++ b/crates/iroha_data_model/src/lib.rs
@@ -468,7 +468,6 @@ mod ffi {
     }
 
     // NOTE: Makes sure that only one `dealloc` is exported per generated dynamic library
-    #[cfg(any(crate_type = "dylib", crate_type = "cdylib"))]
     #[cfg(all(feature = "ffi_export", not(feature = "ffi_import")))]
     mod dylib {
         #[cfg(not(feature = "std"))]

--- a/crates/iroha_derive/tests/ui.rs
+++ b/crates/iroha_derive/tests/ui.rs
@@ -1,3 +1,4 @@
+#![cfg(not(coverage))]
 use trybuild::TestCases;
 
 #[test]

--- a/crates/iroha_derive/tests/ui.rs
+++ b/crates/iroha_derive/tests/ui.rs
@@ -1,4 +1,3 @@
-#![cfg(not(coverage))]
 use trybuild::TestCases;
 
 #[test]

--- a/crates/iroha_telemetry/Cargo.toml
+++ b/crates/iroha_telemetry/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # Should not be enabled on production builds.
 dev-telemetry = []
 # Export Prometheus metrics. See https://prometheus.io/.
-metric-instrumentation = []
+metric-instrumentation = ["iroha_telemetry_derive/metric-instrumentation"]
 
 [dependencies]
 iroha_telemetry_derive = { path = "../iroha_telemetry_derive" }

--- a/crates/iroha_telemetry_derive/Cargo.toml
+++ b/crates/iroha_telemetry_derive/Cargo.toml
@@ -18,6 +18,10 @@ is-it-maintained-issue-resolution = { repository = "https://github.com/hyperledg
 is-it-maintained-open-issues = { repository = "https://github.com/hyperledger/iroha" }
 maintenance = { status = "actively-developed" }
 
+[features]
+# FIXME: it doesn't work https://github.com/hyperledger/iroha/issues/5134
+metric-instrumentation = []
+
 [dependencies]
 syn = { workspace = true }
 quote = { workspace = true }

--- a/crates/iroha_telemetry_derive/src/lib.rs
+++ b/crates/iroha_telemetry_derive/src/lib.rs
@@ -244,26 +244,26 @@ fn impl_metrics(
         }
     };
 
-    #[cfg(feature = "metric-instrumentation")]
-    {
-        let (totals, successes, times) = write_metrics(metric_arg_ident, specs);
-        return quote!(
-            #(#attrs)* #vis #sig {
-                let _closure = || #block;
-                let started_at = std::time::Instant::now();
+    // #[cfg(feature = "metric-instrumentation")]
+    // {
+    //     let (totals, successes, times) = write_metrics(metric_arg_ident, specs);
+    //     quote!(
+    //         #(#attrs)* #vis #sig {
+    //             let closure = || #block;
+    //             let started_at = std::time::Instant::now();
+    //
+    //             #totals
+    //             let res = closure();
+    //
+    //             #times
+    //             if let Ok(_) = res {
+    //                 #successes
+    //             };
+    //             res
+    //     })
+    // }
 
-                #totals
-                let res = _closure();
-
-                #times
-                if let Ok(_) = res {
-                    #successes
-                };
-                res
-        });
-    };
-
-    #[cfg(not(feature = "metric-instrumentation"))]
+    // #[cfg(not(feature = "metric-instrumentation"))]
     quote!(
         #(#attrs)* #vis #sig {
             #block
@@ -279,19 +279,19 @@ fn write_metrics(
 ) -> (TokenStream, TokenStream, TokenStream) {
     let inc_metric = |spec: &MetricSpec, kind: &str| {
         quote!(
-            // #metric_arg_ident
-            //     .metrics
-            //     .isi
-            //     .with_label_values( &[#spec, #kind ]).inc();
+            #metric_arg_ident
+                .metrics
+                .isi
+                .with_label_values( &[#spec, #kind ]).inc();
         )
     };
     let track_time = |spec: &MetricSpec| {
         quote!(
-            // #metric_arg_ident
-            //     .metrics
-            //     .isi_times
-            //     .with_label_values( &[#spec])
-            //     .observe(started_at.elapsed().as_millis() as f64);
+            #metric_arg_ident
+                .metrics
+                .isi_times
+                .with_label_values( &[#spec])
+                .observe(started_at.elapsed().as_millis() as f64);
         )
     };
     let totals: TokenStream = specs

--- a/wasm_samples/default_executor/src/lib.rs
+++ b/wasm_samples/default_executor/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 
-extern crate alloc;
 #[cfg(not(test))]
 extern crate panic_halt;
 

--- a/wasm_samples/executor_with_migration_fail/src/lib.rs
+++ b/wasm_samples/executor_with_migration_fail/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 
-extern crate alloc;
 #[cfg(not(test))]
 extern crate panic_halt;
 

--- a/wasm_samples/query_assets_and_save_cursor/src/lib.rs
+++ b/wasm_samples/query_assets_and_save_cursor/src/lib.rs
@@ -5,8 +5,6 @@
 #[cfg(not(test))]
 extern crate panic_halt;
 
-extern crate alloc;
-
 use dlmalloc::GlobalDlmalloc;
 use iroha_smart_contract::{
     data_model::query::{


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

Close #4993 (see context there)

I found yet another time that metrics & telemetry is broken in Iroha. This PR doesn't fix it, but disables more parts of it to remove noisy warnings. Main issue is #5134 

### Migration Guide (optional)


---

### Review notes (optional)


### Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->