### PR TITLE
feat!: introduce block header into every smart contract execution context

### DIFF
--- a/crates/iroha/Cargo.toml
+++ b/crates/iroha/Cargo.toml
@@ -59,7 +59,6 @@ iroha_logger = { workspace = true }
 iroha_telemetry = { workspace = true }
 iroha_torii_const = { workspace = true }
 iroha_version = { workspace = true }
-iroha_test_samples = { workspace = true }
 
 attohttpc = { version = "0.28.0", default-features = false }
 eyre = { workspace = true }
@@ -83,6 +82,7 @@ toml = { workspace = true }
 nonzero_ext = { workspace = true }
 
 [dev-dependencies]
+iroha_test_samples = { workspace = true }
 iroha_genesis = { workspace = true }
 iroha_test_network = { workspace = true }
 executor_custom_data_model = { version = "=2.0.0-rc.1.0", path = "../../wasm_samples/executor_custom_data_model" }

--- a/crates/iroha/examples/tutorial.rs
+++ b/crates/iroha/examples/tutorial.rs
@@ -2,8 +2,7 @@
 //! <https://hyperledger.github.io/iroha-2-docs/guide/rust.html#_2-configuring-iroha-2>
 
 use eyre::{Error, WrapErr};
-use iroha::config::Config;
-use iroha_primitives::numeric::Numeric;
+use iroha::{config::Config, data_model::prelude::Numeric};
 // #region rust_config_crates
 // #endregion rust_config_crates
 

--- a/crates/iroha/src/query.rs
+++ b/crates/iroha/src/query.rs
@@ -4,25 +4,24 @@ use std::{collections::HashMap, fmt::Debug};
 
 use eyre::{eyre, Context, Result};
 use http::StatusCode;
-use iroha_crypto::KeyPair;
-use iroha_data_model::{
-    account::AccountId,
-    query::{
-        builder::{QueryBuilder, QueryExecutor},
-        parameters::ForwardCursor,
-        predicate::HasPredicateBox,
-        QueryOutput, QueryOutputBatchBox, QueryRequest, QueryResponse, QueryWithParams,
-        SingularQuery, SingularQueryBox, SingularQueryOutputBox,
-    },
-    ValidationFail,
-};
 use iroha_torii_const::uri as torii_uri;
 use parity_scale_codec::{DecodeAll, Encode};
 use url::Url;
 
 use crate::{
     client::{join_torii_url, Client, QueryResult, ResponseReport},
-    data_model::query::Query,
+    crypto::KeyPair,
+    data_model::{
+        account::AccountId,
+        query::{
+            builder::{QueryBuilder, QueryExecutor},
+            parameters::ForwardCursor,
+            predicate::HasPredicateBox,
+            Query, QueryOutput, QueryOutputBatchBox, QueryRequest, QueryResponse, QueryWithParams,
+            SingularQuery, SingularQueryBox, SingularQueryOutputBox,
+        },
+        ValidationFail,
+    },
     http::{Method as HttpMethod, RequestBuilder},
     http_default::DefaultRequestBuilder,
 };

--- a/crates/iroha/tests/integration/events/pipeline.rs
+++ b/crates/iroha/tests/integration/events/pipeline.rs
@@ -77,5 +77,5 @@ async fn test_with_instruction_and_status(
 #[test]
 #[ignore = "TODO: implement with the help of Kura Inspector, "]
 fn applied_block_must_be_available_in_kura() {
-    unimplemented!();
+    unimplemented!("Take a look at previous implementation and restore this test");
 }

--- a/crates/iroha/tests/integration/extra_functional/multiple_blocks_created.rs
+++ b/crates/iroha/tests/integration/extra_functional/multiple_blocks_created.rs
@@ -4,11 +4,11 @@ use eyre::Result;
 use futures_util::StreamExt;
 use iroha::{
     client::{self},
-    data_model::prelude::*,
-};
-use iroha_data_model::{
-    events::pipeline::{BlockEventFilter, TransactionEventFilter},
-    parameter::BlockParameter,
+    data_model::{
+        events::pipeline::{BlockEventFilter, TransactionEventFilter},
+        parameter::BlockParameter,
+        prelude::*,
+    },
 };
 use iroha_test_network::*;
 use iroha_test_samples::gen_account_in;

--- a/crates/iroha/tests/integration/set_parameter.rs
+++ b/crates/iroha/tests/integration/set_parameter.rs
@@ -2,11 +2,10 @@ use eyre::Result;
 use iroha::{
     client,
     data_model::{
-        parameter::{Parameter, Parameters},
+        parameter::{BlockParameter, Parameter, Parameters},
         prelude::*,
     },
 };
-use iroha_data_model::parameter::BlockParameter;
 use iroha_test_network::*;
 use nonzero_ext::nonzero;
 

--- a/crates/iroha/tests/integration/transfer_domain.rs
+++ b/crates/iroha/tests/integration/transfer_domain.rs
@@ -11,7 +11,6 @@ use iroha_executor_data_model::permission::{
     domain::CanUnregisterDomain,
     trigger::CanUnregisterTrigger,
 };
-use iroha_primitives::json::Json;
 use iroha_test_network::*;
 use iroha_test_samples::{gen_account_in, ALICE_ID, BOB_ID, SAMPLE_GENESIS_ACCOUNT_ID};
 

--- a/crates/iroha/tests/integration/triggers/mod.rs
+++ b/crates/iroha/tests/integration/triggers/mod.rs
@@ -1,8 +1,11 @@
 use assert_matches::assert_matches;
-use iroha::{client, client::Client};
-use iroha_data_model::{
-    asset::{AssetId, AssetValue},
-    prelude::{Numeric, QueryBuilderExt},
+use iroha::{
+    client,
+    client::Client,
+    data_model::{
+        asset::{AssetId, AssetValue},
+        prelude::{Numeric, QueryBuilderExt},
+    },
 };
 
 mod by_call_trigger;

--- a/crates/iroha/tests/integration/triggers/time_trigger.rs
+++ b/crates/iroha/tests/integration/triggers/time_trigger.rs
@@ -25,6 +25,8 @@ fn curr_time() -> Duration {
 
 #[test]
 fn mint_asset_after_3_sec() -> Result<()> {
+    const GAP: Duration = Duration::from_secs(3);
+
     let (network, _rt) = NetworkBuilder::new()
         .with_default_pipeline_time()
         .start_blocking()?;
@@ -43,7 +45,6 @@ fn mint_asset_after_3_sec() -> Result<()> {
     })?;
 
     let start_time = curr_time();
-    const GAP: Duration = Duration::from_secs(3);
     assert!(
         GAP < network.pipeline_time(),
         "Schedule should be in the future but within block estimation"

--- a/crates/iroha_core/benches/blocks/apply_blocks.rs
+++ b/crates/iroha_core/benches/blocks/apply_blocks.rs
@@ -48,9 +48,8 @@ impl StateApplyBlocks {
             instructions
                 .into_iter()
                 .map(|instructions| {
-                    let mut state_block = state.block();
-                    let block = create_block(
-                        &mut state_block,
+                    let (block, mut state_block) = create_block(
+                        &state,
                         instructions,
                         alice_id.clone(),
                         alice_keypair.private_key(),
@@ -88,10 +87,10 @@ impl StateApplyBlocks {
         }: &Self,
     ) -> Result<()> {
         for (block, i) in blocks.iter().zip(1..) {
-            let mut state_block = state.block();
+            let mut state_block = state.block(block.as_ref().header());
             let _events = state_block.apply(block, topology.as_ref().to_owned())?;
-            assert_eq!(state_block.height(), i);
             state_block.commit();
+            assert_eq!(state.view().height(), i);
         }
 
         Ok(())

--- a/crates/iroha_core/benches/blocks/validate_blocks.rs
+++ b/crates/iroha_core/benches/blocks/validate_blocks.rs
@@ -74,9 +74,8 @@ impl StateValidateBlocks {
         }: Self,
     ) {
         for (instructions, i) in instructions.into_iter().zip(1..) {
-            let mut state_block = state.block();
-            let block = create_block(
-                &mut state_block,
+            let (block, mut state_block) = create_block(
+                &state,
                 instructions,
                 account_id.clone(),
                 &account_private_key,

--- a/crates/iroha_core/benches/common/mod.rs
+++ b/crates/iroha_core/benches/common/mod.rs
@@ -1,0 +1,13 @@
+use iroha_crypto::KeyPair;
+use iroha_data_model::account::AccountId;
+
+/// Create new account from a random keypair in the given domain
+pub fn gen_account_in(domain: impl core::fmt::Display) -> (AccountId, KeyPair) {
+    let key_pair = KeyPair::random();
+
+    let account_id = format!("{}@{}", key_pair.public_key(), domain)
+        .parse()
+        .expect("domain name should be valid");
+
+    (account_id, key_pair)
+}

--- a/crates/iroha_core/src/metrics.rs
+++ b/crates/iroha_core/src/metrics.rs
@@ -71,7 +71,7 @@ impl MetricsReporter {
                         .checked_add(1)
                         .expect("INTERNAL BUG: Blockchain height exceeds usize::MAX"),
                 )
-                .and_then(|index| self.kura.get_block_by_height(index)) else {
+                .and_then(|index| self.kura.get_block(index)) else {
                     break;
                 };
                 block_index += 1;

--- a/crates/iroha_core/src/smartcontracts/isi/block.rs
+++ b/crates/iroha_core/src/smartcontracts/isi/block.rs
@@ -38,7 +38,7 @@ impl ValidQuery for FindBlockHeaders {
         Ok(state_ro
             .all_blocks(nonzero!(1_usize))
             .rev()
-            .filter(move |block| filter.applies(block.header()))
-            .map(|block| block.header().clone()))
+            .filter(move |block| filter.applies(&block.header()))
+            .map(|block| block.header()))
     }
 }

--- a/crates/iroha_core/src/sumeragi/mod.rs
+++ b/crates/iroha_core/src/sumeragi/mod.rs
@@ -97,10 +97,6 @@ impl SumeragiHandle {
         // NOTE: topology need to be updated up to block's view_change_index
         topology.nth_rotation(block.header().view_change_index as usize);
 
-        if block.header().is_genesis() {
-            state_block.world.genesis_creation_time_ms = Some(block.header().creation_time_ms);
-        }
-
         let block = ValidBlock::validate(
             block.clone(),
             topology,
@@ -168,7 +164,7 @@ impl SumeragiStartArgs {
             let state_view = state.view();
             let skip_block_count = state_view.height();
             blocks_iter = (skip_block_count + 1..=block_count).map(|block_height| {
-                NonZeroUsize::new(block_height).and_then(|height| kura.get_block_by_height(height)).expect(
+                NonZeroUsize::new(block_height).and_then(|height| kura.get_block(height)).expect(
                     "Sumeragi should be able to load the block that was reported as presented. \
                     If not, the block storage was probably disconnected.",
                 )
@@ -192,7 +188,7 @@ impl SumeragiStartArgs {
         );
 
         for block in blocks_iter {
-            let mut state_block = state.block();
+            let mut state_block = state.block(block.header());
             SumeragiHandle::replay_block(
                 &common_config.chain,
                 &genesis_account,

--- a/crates/iroha_data_model/src/block.rs
+++ b/crates/iroha_data_model/src/block.rs
@@ -30,6 +30,7 @@ mod model {
         Debug,
         Display,
         Clone,
+        Copy,
         PartialEq,
         Eq,
         PartialOrd,
@@ -119,7 +120,6 @@ declare_versioned!(SignedBlock 1..2, Debug, Clone, PartialEq, Eq, PartialOrd, Or
 impl BlockHeader {
     /// Checks if it's a header of a genesis block.
     #[inline]
-    #[cfg(feature = "transparent_api")]
     pub const fn is_genesis(&self) -> bool {
         self.height.get() == 1
     }
@@ -141,8 +141,8 @@ impl SignedBlockV1 {
         self.payload.header.hash()
     }
 
-    fn header(&self) -> &BlockHeader {
-        &self.payload.header
+    fn header(&self) -> BlockHeader {
+        self.payload.header
     }
 }
 
@@ -200,9 +200,9 @@ impl SignedBlock {
 
     /// Block header
     #[inline]
-    pub fn header(&self) -> &BlockHeader {
+    pub fn header(&self) -> BlockHeader {
         let SignedBlock::V1(block) = self;
-        &block.payload.header
+        block.header()
     }
 
     /// Block transactions

--- a/crates/iroha_data_model/src/query/predicate/predicate_atoms/block.rs
+++ b/crates/iroha_data_model/src/query/predicate/predicate_atoms/block.rs
@@ -73,7 +73,7 @@ impl_predicate_box!(SignedBlock: SignedBlockPredicateBox);
 impl EvaluatePredicate<SignedBlock> for SignedBlockPredicateBox {
     fn applies(&self, input: &SignedBlock) -> bool {
         match self {
-            SignedBlockPredicateBox::Header(header) => header.applies(input.header()),
+            SignedBlockPredicateBox::Header(header) => header.applies(&input.header()),
         }
     }
 }

--- a/crates/iroha_data_model/src/smart_contract.rs
+++ b/crates/iroha_data_model/src/smart_contract.rs
@@ -5,13 +5,15 @@ pub mod payloads {
 
     use parity_scale_codec::{Decode, Encode};
 
-    use crate::prelude::*;
+    use crate::{block::BlockHeader, prelude::*};
 
     /// Context for smart contract entrypoint
     #[derive(Debug, Clone, Encode, Decode)]
     pub struct SmartContractContext {
         /// Account that submitted the transaction containing the smart contract
         pub authority: AccountId,
+        /// Block currently being processed
+        pub curr_block: BlockHeader,
     }
 
     /// Context for trigger entrypoint
@@ -21,6 +23,8 @@ pub mod payloads {
         pub id: TriggerId,
         /// Account that registered the trigger
         pub authority: AccountId,
+        /// Block currently being processed
+        pub curr_block: BlockHeader,
         /// Event which triggered the execution
         pub event: EventBox,
     }
@@ -30,8 +34,8 @@ pub mod payloads {
     pub struct ExecutorContext {
         /// Account that is executing the operation
         pub authority: AccountId,
-        /// Height of the latest block in the blockchain
-        pub block_height: u64,
+        /// Block currently being processed (or latest block hash for queries)
+        pub curr_block: BlockHeader,
     }
 
     /// Generic payload for `validate_*()` entrypoints of executor.

--- a/crates/iroha_executor/src/default.rs
+++ b/crates/iroha_executor/src/default.rs
@@ -131,7 +131,7 @@ pub mod peer {
         executor: &mut V,
         isi: &Register<Peer>,
     ) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanManagePeers.is_owned_by(&executor.context().authority, executor.host()) {
@@ -145,7 +145,7 @@ pub mod peer {
         executor: &mut V,
         isi: &Unregister<Peer>,
     ) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanManagePeers.is_owned_by(&executor.context().authority, executor.host()) {
@@ -171,7 +171,7 @@ pub mod domain {
         executor: &mut V,
         isi: &Register<Domain>,
     ) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanRegisterDomain.is_owned_by(&executor.context().authority, executor.host()) {
@@ -187,7 +187,7 @@ pub mod domain {
     ) {
         let domain_id = isi.object();
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || match is_domain_owner(domain_id, &executor.context().authority, executor.host()) {
                 Err(err) => deny!(executor, err),
                 Ok(is_domain_owner) => is_domain_owner,
@@ -236,7 +236,7 @@ pub mod domain {
         let source_id = isi.source();
         let domain_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_account_owner(source_id, &executor.context().authority, executor.host()) {
@@ -259,7 +259,7 @@ pub mod domain {
     ) {
         let domain_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_domain_owner(domain_id, &executor.context().authority, executor.host()) {
@@ -285,7 +285,7 @@ pub mod domain {
     ) {
         let domain_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_domain_owner(domain_id, &executor.context().authority, executor.host()) {
@@ -426,7 +426,7 @@ pub mod account {
     ) {
         let account_id = isi.object();
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || match is_account_owner(account_id, &executor.context().authority, executor.host()) {
                 Err(err) => deny!(executor, err),
                 Ok(is_account_owner) => is_account_owner,
@@ -474,7 +474,7 @@ pub mod account {
     ) {
         let account_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_account_owner(account_id, &executor.context().authority, executor.host()) {
@@ -503,7 +503,7 @@ pub mod account {
     ) {
         let account_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_account_owner(account_id, &executor.context().authority, executor.host()) {
@@ -619,7 +619,7 @@ pub mod asset_definition {
     ) {
         let asset_definition_id = isi.object();
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || match is_asset_definition_owner(
                 asset_definition_id,
                 &executor.context().authority,
@@ -675,7 +675,7 @@ pub mod asset_definition {
         let source_id = isi.source();
         let asset_definition_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_account_owner(source_id, &executor.context().authority, executor.host()) {
@@ -705,7 +705,7 @@ pub mod asset_definition {
     ) {
         let asset_definition_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_definition_owner(
@@ -738,7 +738,7 @@ pub mod asset_definition {
     ) {
         let asset_definition_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_definition_owner(
@@ -850,7 +850,7 @@ pub mod asset {
     ) {
         let asset = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_definition_owner(
@@ -890,7 +890,7 @@ pub mod asset {
     ) {
         let asset_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_owner(asset_id, &executor.context().authority, executor.host()) {
@@ -934,7 +934,7 @@ pub mod asset {
         Mint<Q, Asset>: BuiltInInstruction + Encode,
     {
         let asset_id = isi.destination();
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_definition_owner(
@@ -981,7 +981,7 @@ pub mod asset {
         Burn<Q, Asset>: BuiltInInstruction + Encode,
     {
         let asset_id = isi.destination();
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_owner(asset_id, &executor.context().authority, executor.host()) {
@@ -1030,7 +1030,7 @@ pub mod asset {
         Transfer<Asset, Q, Account>: BuiltInInstruction + Encode,
     {
         let asset_id = isi.source();
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_owner(asset_id, &executor.context().authority, executor.host()) {
@@ -1086,7 +1086,7 @@ pub mod asset {
     ) {
         let asset_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_owner(asset_id, &executor.context().authority, executor.host()) {
@@ -1116,7 +1116,7 @@ pub mod asset {
     ) {
         let asset_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_asset_owner(asset_id, &executor.context().authority, executor.host()) {
@@ -1146,7 +1146,7 @@ pub mod parameter {
     use super::*;
 
     pub fn visit_set_parameter<V: Execute + Visit + ?Sized>(executor: &mut V, isi: &SetParameter) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanSetParameters.is_owned_by(&executor.context().authority, executor.host()) {
@@ -1170,7 +1170,7 @@ pub mod role {
         ($executor:ident, $isi:ident) => {
             let role_id = $isi.object();
 
-            if is_genesis($executor)
+            if $executor.context().curr_block.is_genesis()
                 || find_account_roles($executor.context().authority.clone(), $executor.host())
                     .any(|authority_role_id| authority_role_id == *role_id)
             {
@@ -1187,7 +1187,7 @@ pub mod role {
             let permission = $isi.object();
 
             if let Ok(any_permission) = AnyPermission::try_from(permission) {
-                if !is_genesis($executor) {
+                if !$executor.context().curr_block.is_genesis() {
                     if !find_account_roles($executor.context().authority.clone(), $executor.host())
                         .any(|authority_role_id| authority_role_id == role_id)
                     {
@@ -1235,7 +1235,7 @@ pub mod role {
             iroha_smart_contract::debug!(&format!("Checking `{permission:?}`"));
 
             if let Ok(any_permission) = AnyPermission::try_from(permission) {
-                if !is_genesis(executor) {
+                if !executor.context().curr_block.is_genesis() {
                     if let Err(error) = crate::permission::ValidateGrantRevoke::validate_grant(
                         &any_permission,
                         role.grant_to(),
@@ -1255,7 +1255,7 @@ pub mod role {
             }
         }
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || CanManageRoles.is_owned_by(&executor.context().authority, executor.host())
         {
             let grant_role = &Grant::account_role(role.id().clone(), role.grant_to().clone());
@@ -1275,7 +1275,7 @@ pub mod role {
         executor: &mut V,
         isi: &Unregister<Role>,
     ) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanManageRoles.is_owned_by(&executor.context().authority, executor.host()) {
@@ -1332,7 +1332,7 @@ pub mod trigger {
     ) {
         let trigger = isi.object();
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || {
                 match is_domain_owner(
                     trigger.action().authority().domain(),
@@ -1362,7 +1362,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.object();
 
-        if is_genesis(executor)
+        if executor.context().curr_block.is_genesis()
             || match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
                 Err(err) => deny!(executor, err),
                 Ok(is_trigger_owner) => is_trigger_owner,
@@ -1413,7 +1413,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.destination();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
@@ -1440,7 +1440,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.destination();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
@@ -1467,7 +1467,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.trigger();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
@@ -1491,7 +1491,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
@@ -1520,7 +1520,7 @@ pub mod trigger {
     ) {
         let trigger_id = isi.object();
 
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         match is_trigger_owner(trigger_id, &executor.context().authority, executor.host()) {
@@ -1592,7 +1592,7 @@ pub mod permission {
             let permission = $isi.object();
 
             if let Ok(any_permission) = AnyPermission::try_from(permission) {
-                if !is_genesis($executor) {
+                if !$executor.context().curr_block.is_genesis() {
                     if let Err(error) = crate::permission::ValidateGrantRevoke::$method(
                         &any_permission,
                         &$executor.context().authority,
@@ -1635,7 +1635,7 @@ pub mod executor {
     use super::*;
 
     pub fn visit_upgrade<V: Execute + Visit + ?Sized>(executor: &mut V, isi: &Upgrade) {
-        if is_genesis(executor) {
+        if executor.context().curr_block.is_genesis() {
             execute!(executor, isi);
         }
         if CanUpgradeExecutor.is_owned_by(&executor.context().authority, executor.host()) {
@@ -1663,8 +1663,4 @@ pub mod custom {
             "Custom instructions should be handled in custom executor"
         )
     }
-}
-
-fn is_genesis<V: Execute + Visit + ?Sized>(executor: &V) -> bool {
-    executor.context().block_height == 0
 }

--- a/crates/iroha_executor/src/permission.rs
+++ b/crates/iroha_executor/src/permission.rs
@@ -1038,7 +1038,7 @@ pub(crate) struct OnlyGenesis;
 
 impl PassCondition for OnlyGenesis {
     fn validate(&self, _authority: &AccountId, _host: &Iroha, context: &Context) -> Result {
-        if context.block_height == 0 {
+        if context.curr_block.is_genesis() {
             Ok(())
         } else {
             Err(ValidationFail::NotPermitted(

--- a/crates/iroha_torii/src/block.rs
+++ b/crates/iroha_torii/src/block.rs
@@ -55,7 +55,7 @@ impl<'ws> Consumer<'ws> {
     /// Can fail due to timeout. Also receiving might fail
     #[iroha_futures::telemetry_future]
     pub async fn consume(&mut self) -> Result<()> {
-        if let Some(block) = self.kura.get_block_by_height(
+        if let Some(block) = self.kura.get_block(
             self.height
                 .try_into()
                 .expect("INTERNAL BUG: Number of blocks exceeds usize::MAX"),

--- a/wasm_samples/default_executor/src/lib.rs
+++ b/wasm_samples/default_executor/src/lib.rs
@@ -6,7 +6,9 @@
 extern crate panic_halt;
 
 use dlmalloc::GlobalDlmalloc;
-use iroha_executor::{debug::dbg_panic, prelude::*, DataModelBuilder};
+use iroha_executor::{
+    data_model::block::BlockHeader, debug::dbg_panic, prelude::*, DataModelBuilder,
+};
 
 #[global_allocator]
 static ALLOC: GlobalDlmalloc = GlobalDlmalloc;
@@ -26,8 +28,8 @@ struct Executor {
 }
 
 impl Executor {
-    fn ensure_genesis(block_height: u64) {
-        if block_height != 0 {
+    fn ensure_genesis(curr_block: BlockHeader) {
+        if !curr_block.is_genesis() {
             dbg_panic(
                 "Default Executor is intended to be used only in genesis. \
                  Write your own executor if you need to upgrade executor on existing chain.",
@@ -47,6 +49,6 @@ impl Executor {
 /// will be denied and previous executor will stay unchanged.
 #[entrypoint]
 fn migrate(host: Iroha, context: Context) {
-    Executor::ensure_genesis(context.block_height);
+    Executor::ensure_genesis(context.curr_block);
     DataModelBuilder::with_default_permissions().build_and_set(&host);
 }

--- a/wasm_samples/executor_with_custom_permission/src/lib.rs
+++ b/wasm_samples/executor_with_custom_permission/src/lib.rs
@@ -1,5 +1,4 @@
-//! Runtime Executor which allows domain (un-)registration only for users who own
-//! [`CanControlDomainLives`] permission token.
+//! Runtime Executor which allows domain (un-)registration only for users who own [`CanControlDomainLives`] permission token.
 //!
 //! This executor should be applied on top of the blockchain with default validation.
 //!
@@ -85,7 +84,7 @@ impl Executor {
 }
 
 fn visit_register_domain(executor: &mut Executor, isi: &Register<Domain>) {
-    if executor.context().block_height == 0 {
+    if executor.context().curr_block.is_genesis() {
         execute!(executor, isi);
     }
     if CanControlDomainLives.is_owned_by(&executor.context().authority, executor.host()) {
@@ -99,7 +98,7 @@ fn visit_register_domain(executor: &mut Executor, isi: &Register<Domain>) {
 }
 
 fn visit_unregister_domain(executor: &mut Executor, isi: &Unregister<Domain>) {
-    if executor.context().block_height == 0 {
+    if executor.context().curr_block.is_genesis() {
         execute!(executor, isi);
     }
     if CanControlDomainLives.is_owned_by(&executor.context().authority, executor.host()) {


### PR DESCRIPTION
closes #4958

Block header is provided as context of execution for:
1. migrate payload (as current block header)
2. execute_instruction (as current block header)
3. execute_transaction (as current block header)
4. validate_query (as latest committed block header)
5. smart contract and trigger execution (as latest current block header)

As a consequence of this change block header variable was added to `StateBlock` and `StateTransaction`. While doing this I get the feeling that `StateBlock` could take ownership of the whole block that it is validating