### PR TITLE
ci: Add llvm-cov parameter for sonar

### DIFF
--- a/.github/workflows/iroha2-dev-pr.yml
+++ b/.github/workflows/iroha2-dev-pr.yml
@@ -116,12 +116,12 @@ jobs:
           --branch
           --no-report
       - name: Generate lcov report
-        run: cargo llvm-cov report --lcov --output-path lcov.info
+        run: cargo llvm-cov report --text --output-path coverage.txt
       - name: Upload lcov report
         uses: actions/upload-artifact@v4
         with:
           name: report-coverage
-          path: lcov.info
+          path: coverage.txt
 
   # include: iroha/tests/integration/
   # exclude: iroha/tests/integration/extra_functional

--- a/.github/workflows/iroha2-dev-sonar-dojo.yml
+++ b/.github/workflows/iroha2-dev-sonar-dojo.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           args: >
             -Dcommunity.rust.clippy.reportPaths=lints/clippy.json
-            -Dcommunity.rust.lcov.reportPaths=lints/lcov.info
+            -Dsonar.cfamily.llvm-cov.reportPath=lints/coverage.txt
             -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}


### PR DESCRIPTION
## Context
Possible fix for `llvm-cov` (instead of `grcov`) coverage report compatibility within the Sonarqube analysis.

### Solution

Based on https://community.sonarsource.com/t/cant-get-llvm-cov-reports-to-show-up-in-sonarqube-project/20833/4 topic.
We might revert back to `lcov.info` coverage format instead of `coverage.txt`. The last one is a kinda of tested and recommended.

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.