### PR TITLE
fix: Add range check to signature index

### DIFF
--- a/crates/iroha_core/src/sumeragi/main_loop.rs
+++ b/crates/iroha_core/src/sumeragi/main_loop.rs
@@ -622,7 +622,19 @@ impl Sumeragi {
                 );
 
                 if let Ok(signatory_idx) = usize::try_from(signature.0) {
-                    let signatory = &self.topology.as_ref()[signatory_idx];
+                    let signatory = if let Some(s) = self.topology.as_ref().get(signatory_idx) {
+                        s
+                    } else {
+                        error!(
+                            peer_id=%self.peer_id,
+                            role=%self.role(),
+                            ?signatory_idx,
+                            topology_size=%self.topology.as_ref().len(),
+                            "Unknown signatory"
+                        );
+
+                        return;
+                    };
 
                     match self.topology.role(signatory) {
                         Role::Leader => error!(

--- a/crates/iroha_p2p/src/network.rs
+++ b/crates/iroha_p2p/src/network.rs
@@ -223,7 +223,7 @@ impl<T: Pload, K: Kex, E: Enc> NetworkBase<T, K, E> {
     #[log(skip(self, shutdown_signal), fields(listen_addr=%self.listen_addr, public_key=%self.key_pair.public_key()))]
     async fn run(mut self, shutdown_signal: ShutdownSignal) {
         // TODO: probably should be configuration parameter
-        let mut update_topology_interval = tokio::time::interval(Duration::from_millis(100));
+        let mut update_topology_interval = tokio::time::interval(Duration::from_millis(1000));
         loop {
             tokio::select! {
                 // Select is biased because we want to service messages to take priority over data messages.


### PR DESCRIPTION
<!-- Note: replace the instructions with your text -->

## Context

The bug is triggered if a a peer is unregistered from the topology while Sumeragi Messages are still in flight. This
is the only place where we use and array index operation that can panic. It is very hard to write a test for this case
that is guaranteed to show the issue each time.

Closes #5104 
### Solution

- Describe the approach taken to achieve the objective / resolve the issue.

### Migration Guide (optional)

- If this PR contains a breaking change relative to the `main` branch, provide an instruction on how affected parties might need to adapt to the change.

---

### Review notes (optional)

- For complex PRs, try to provide some information on how to approach the review more effectively.
- For example, is there a natural order in which the affected files should be reviewed?

### Checklist

- [ ] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] (optional) I've written unit tests for the code changes.
- [ ] All review comments have been resolved.
- [ ] All CI checks pass.

<!-- Add more items if needed -->

<!-- USEFUL LINKS 
 - Commit sign-off: https://www.secondstate.io/articles/dco
 - Telegram: https://t.me/hyperledgeriroha
 - Discord: https://discord.com/channels/905194001349627914/905205848547155968
-->