### PR TITLE
fix: Fix `cargo check` and `cargo fmt`

### DIFF
--- a/crates/iroha/tests/extra_functional/multiple_blocks_created.rs
+++ b/crates/iroha/tests/extra_functional/multiple_blocks_created.rs
@@ -2,13 +2,10 @@ use std::{num::NonZero, time::Duration};
 
 use eyre::Result;
 use futures_util::StreamExt;
-use iroha::{
-    client::{self},
-    data_model::{
-        events::pipeline::{BlockEventFilter, TransactionEventFilter},
-        parameter::BlockParameter,
-        prelude::*,
-    },
+use iroha::data_model::{
+    events::pipeline::{BlockEventFilter, TransactionEventFilter},
+    parameter::BlockParameter,
+    prelude::*,
 };
 use iroha_test_network::*;
 use iroha_test_samples::gen_account_in;

--- a/crates/iroha/tests/extra_functional/normal.rs
+++ b/crates/iroha/tests/extra_functional/normal.rs
@@ -1,8 +1,5 @@
 use eyre::Result;
-use iroha::{
-    client,
-    data_model::{asset::AssetDefinitionId, parameter::BlockParameter, prelude::*},
-};
+use iroha::data_model::{asset::AssetDefinitionId, parameter::BlockParameter, prelude::*};
 use iroha_test_network::*;
 use nonzero_ext::nonzero;
 

--- a/crates/iroha/tests/extra_functional/offline_peers.rs
+++ b/crates/iroha/tests/extra_functional/offline_peers.rs
@@ -1,7 +1,6 @@
 use eyre::{OptionExt, Result};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use iroha::{
-    client::{self},
     crypto::KeyPair,
     data_model::{
         peer::{Peer as DataModelPeer, PeerId},

--- a/crates/iroha/tests/extra_functional/restart_peer.rs
+++ b/crates/iroha/tests/extra_functional/restart_peer.rs
@@ -1,8 +1,5 @@
 use eyre::Result;
-use iroha::{
-    client::{self},
-    data_model::prelude::*,
-};
+use iroha::data_model::prelude::*;
 use iroha_test_network::*;
 use iroha_test_samples::ALICE_ID;
 use tokio::{task::spawn_blocking, time::timeout};

--- a/crates/iroha/tests/extra_functional/unregister_peer.rs
+++ b/crates/iroha/tests/extra_functional/unregister_peer.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use assert_matches::assert_matches;
 use eyre::Result;
 use iroha::{
-    client,
     client::Client,
     data_model::{parameter::BlockParameter, prelude::*},
 };

--- a/crates/iroha/tests/queries/account.rs
+++ b/crates/iroha/tests/queries/account.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use eyre::Result;
-use iroha::{client, data_model::prelude::*};
+use iroha::data_model::prelude::*;
 use iroha_test_network::*;
 use iroha_test_samples::{gen_account_in, ALICE_ID};
 

--- a/crates/iroha/tests/queries/mod.rs
+++ b/crates/iroha/tests/queries/mod.rs
@@ -1,5 +1,5 @@
 use iroha::{
-    client::{self, QueryError},
+    client::QueryError,
     data_model::{
         prelude::*,
         query::{error::QueryExecutionFail, parameters::MAX_FETCH_SIZE},

--- a/crates/iroha/tests/queries/query_errors.rs
+++ b/crates/iroha/tests/queries/query_errors.rs
@@ -1,6 +1,6 @@
-use iroha::{
-    client,
-    data_model::{prelude::QueryBuilderExt, query::builder::SingleQueryError},
+use iroha::data_model::{
+    prelude::{FindAccounts, QueryBuilderExt},
+    query::builder::SingleQueryError,
 };
 use iroha_test_network::NetworkBuilder;
 use iroha_test_samples::gen_account_in;

--- a/crates/iroha/tests/queries/role.rs
+++ b/crates/iroha/tests/queries/role.rs
@@ -1,10 +1,7 @@
 use std::collections::HashSet;
 
 use eyre::Result;
-use iroha::{
-    client,
-    data_model::{prelude::*, query::builder::SingleQueryError},
-};
+use iroha::data_model::{prelude::*, query::builder::SingleQueryError};
 use iroha_executor_data_model::permission::account::CanModifyAccountMetadata;
 use iroha_test_network::*;
 use iroha_test_samples::ALICE_ID;

--- a/crates/iroha/tests/triggers/by_call_trigger.rs
+++ b/crates/iroha/tests/triggers/by_call_trigger.rs
@@ -3,7 +3,6 @@ use std::{sync::mpsc, thread, time::Duration};
 use executor_custom_data_model::mint_rose_args::MintRoseArgs;
 use eyre::{eyre, Result, WrapErr};
 use iroha::{
-    client::{self},
     crypto::KeyPair,
     data_model::{
         prelude::*,

--- a/crates/iroha/tests/triggers/mod.rs
+++ b/crates/iroha/tests/triggers/mod.rs
@@ -1,10 +1,9 @@
 use assert_matches::assert_matches;
 use iroha::{
-    client,
     client::Client,
     data_model::{
         asset::{AssetId, AssetValue},
-        prelude::{Numeric, QueryBuilderExt},
+        prelude::{FindAssets, Numeric, QueryBuilderExt},
     },
 };
 

--- a/crates/iroha/tests/triggers/time_trigger.rs
+++ b/crates/iroha/tests/triggers/time_trigger.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use eyre::Result;
 use iroha::{
-    client::{self, Client},
+    client::Client,
     data_model::{
         asset::AssetId,
         events::pipeline::{BlockEventFilter, BlockStatus},

--- a/crates/iroha/tests/triggers/trigger_rollback.rs
+++ b/crates/iroha/tests/triggers/trigger_rollback.rs
@@ -1,8 +1,5 @@
 use eyre::Result;
-use iroha::{
-    client,
-    data_model::{prelude::*, trigger::TriggerId},
-};
+use iroha::data_model::{prelude::*, trigger::TriggerId};
 use iroha_test_network::*;
 use iroha_test_samples::ALICE_ID;
 
@@ -36,9 +33,7 @@ fn failed_trigger_revert() -> Result<()> {
     client.submit_blocking(call_trigger)?;
 
     //Then
-    let query_result = client
-        .query(FindAssetsDefinitions::new())
-        .execute_all()?;
+    let query_result = client.query(FindAssetsDefinitions::new()).execute_all()?;
     assert!(query_result
         .iter()
         .all(|asset_definition| asset_definition.id() != &asset_definition_id));


### PR DESCRIPTION
I think we should mark `I2::Dev::Tests` workflow as required for PR merge, since there are no more flaky tests on CI